### PR TITLE
Keep the read's schema across an inspect round trip (#1138)

### DIFF
--- a/internal/atlashclrender/inspected_object_schema_test.go
+++ b/internal/atlashclrender/inspected_object_schema_test.go
@@ -1,0 +1,234 @@
+package atlashclrender_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// TestRenderInspectedAttributesEverySchemaScopedBlock pins that an inspected
+// render names the read's schema on EVERY block type that can carry one, not
+// just on the two that reached the fallback first.
+//
+// A PostgreSQL catalog blanks the schema on exactly the objects the read's own
+// search_path made implicit, so an inspected IR arrives with an empty Schema on
+// its own schema's objects. A block written without the attribute is created
+// wherever the connection that replays it happens to point. Measured on
+// PostgreSQL 17.10, one schema `wf1138s` holding one object of each kind below,
+// inspected and then planned back into a fresh database with
+// `psql -v ON_ERROR_STOP=1`:
+//
+//	CREATE OR REPLACE FUNCTION "f"(a integer) ...       -> public.f
+//	CREATE SEQUENCE "seq1" ...                          -> public.seq1
+//	CREATE DOMAIN "positive_int" ...                    -> public.positive_int
+//	CREATE TYPE "numrng" AS RANGE ...                   -> public.numrng
+//	CREATE TYPE "addr" AS (...)                         -> public.addr
+//	CREATE VIEW "v" ...                                 -> public.v
+//	CREATE MATERIALIZED VIEW "mv" ...                   -> public.mv
+//	CREATE TYPE "wf1138s"."mood" AS ENUM (...)          -> wf1138s.mood, correct
+//	CREATE TABLE "wf1138s"."t" (...)                    -> wf1138s.t, correct
+//
+// Seven of the nine landed in the wrong schema (stokaro/ptah#1138); the two
+// that did not are the pair the fallback already served (stokaro/ptah#1276).
+//
+// The rows are the whole enumeration on purpose. A per-block fix keeps being
+// applied to the block an issue happened to name, and the two correct rows are
+// here so the table states the rule rather than the exceptions.
+func TestRenderInspectedAttributesEverySchemaScopedBlock(t *testing.T) {
+	tests := []struct {
+		name    string
+		declare func(*goschema.Database)
+		want    string
+	}{
+		{
+			name: "a sequence",
+			declare: func(db *goschema.Database) {
+				db.Sequences = []goschema.Sequence{{Name: "seq1"}}
+			},
+			want: "sequence \"seq1\" {\n  schema = schema.public\n",
+		},
+		{
+			name: "a domain",
+			declare: func(db *goschema.Database) {
+				db.Domains = []goschema.Domain{{Name: "positive_int", BaseType: "integer"}}
+			},
+			want: "domain \"positive_int\" {\n  schema = schema.public\n",
+		},
+		{
+			name: "a composite type",
+			declare: func(db *goschema.Database) {
+				db.CompositeTypes = []goschema.CompositeType{{
+					Name:   "addr",
+					Fields: []goschema.CompositeTypeField{{Name: "street", Type: "text"}},
+				}}
+			},
+			want: "composite \"addr\" {\n  schema = schema.public\n",
+		},
+		{
+			name: "a range type",
+			declare: func(db *goschema.Database) {
+				db.Ranges = []goschema.Range{{Name: "numrng", Subtype: "numeric"}}
+			},
+			want: "range \"numrng\" {\n  schema = schema.public\n",
+		},
+		{
+			name: "a function",
+			declare: func(db *goschema.Database) {
+				db.Functions = []goschema.Function{{
+					Name: "f", Returns: "integer", Language: "sql", Body: "SELECT 1",
+				}}
+			},
+			want: "function \"f\" {\n  schema = schema.public\n",
+		},
+		{
+			name: "a view",
+			declare: func(db *goschema.Database) {
+				db.Views = []goschema.View{{Name: "v", Body: "SELECT id FROM t"}}
+			},
+			want: "view \"v\" {\n  schema = schema.public\n",
+		},
+		{
+			name: "a materialized view",
+			declare: func(db *goschema.Database) {
+				db.MaterializedViews = []goschema.MaterializedView{{
+					Name: "mv", Body: "SELECT id FROM t",
+				}}
+			},
+			want: "materialized \"mv\" {\n  schema = schema.public\n",
+		},
+		{
+			// Already correct before stokaro/ptah#1138, and here so the table
+			// says so rather than leaving it to be rediscovered.
+			name: "an enum",
+			declare: func(db *goschema.Database) {
+				db.Enums = []goschema.Enum{{Name: "mood", Values: []string{"sad", "ok"}}}
+			},
+			want: "enum \"mood\" {\n  schema = schema.public\n",
+		},
+		{
+			name:    "a table",
+			declare: func(_ *goschema.Database) {},
+			want:    "table \"t\" {\n  schema = schema.public\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := inspectedTable("")
+			test.declare(db)
+
+			result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, test.want)
+		})
+	}
+}
+
+// TestRenderInspectedKeepsASchemaTheReaderReported is the negative half: the
+// fallback is a fallback, so a reader that did report a schema is believed for
+// every one of the same block types.
+//
+// Without this row set, "write the read's schema everywhere" and "write the
+// read's schema where the object has none" are indistinguishable, and the first
+// one moves objects the reader placed correctly.
+func TestRenderInspectedKeepsASchemaTheReaderReported(t *testing.T) {
+	tests := []struct {
+		name    string
+		declare func(*goschema.Database)
+		want    string
+	}{
+		{
+			name: "a sequence",
+			declare: func(db *goschema.Database) {
+				db.Sequences = []goschema.Sequence{{Name: "seq1", Schema: "reporting"}}
+			},
+			want: "sequence \"seq1\" {\n  schema = schema.reporting\n",
+		},
+		{
+			name: "a domain",
+			declare: func(db *goschema.Database) {
+				db.Domains = []goschema.Domain{{
+					Name: "positive_int", Schema: "reporting", BaseType: "integer",
+				}}
+			},
+			want: "domain \"positive_int\" {\n  schema = schema.reporting\n",
+		},
+		{
+			name: "a composite type",
+			declare: func(db *goschema.Database) {
+				db.CompositeTypes = []goschema.CompositeType{{
+					Name:   "addr",
+					Schema: "reporting",
+					Fields: []goschema.CompositeTypeField{{Name: "street", Type: "text"}},
+				}}
+			},
+			want: "composite \"addr\" {\n  schema = schema.reporting\n",
+		},
+		{
+			name: "a range type",
+			declare: func(db *goschema.Database) {
+				db.Ranges = []goschema.Range{{
+					Name: "numrng", Schema: "reporting", Subtype: "numeric",
+				}}
+			},
+			want: "range \"numrng\" {\n  schema = schema.reporting\n",
+		},
+		{
+			name: "a function",
+			declare: func(db *goschema.Database) {
+				db.Functions = []goschema.Function{{
+					Name: "reporting.f", Returns: "integer", Language: "sql", Body: "SELECT 1",
+				}}
+			},
+			want: "function \"f\" {\n  schema = schema.reporting\n",
+		},
+		{
+			name: "a view",
+			declare: func(db *goschema.Database) {
+				db.Views = []goschema.View{{Name: "reporting.v", Body: "SELECT id FROM t"}}
+			},
+			want: "view \"v\" {\n  schema = schema.reporting\n",
+		},
+		{
+			name: "a materialized view",
+			declare: func(db *goschema.Database) {
+				db.MaterializedViews = []goschema.MaterializedView{{
+					Name: "reporting.mv", Body: "SELECT id FROM t",
+				}}
+			},
+			want: "materialized \"mv\" {\n  schema = schema.reporting\n",
+		},
+		{
+			name: "an enum",
+			declare: func(db *goschema.Database) {
+				db.Enums = []goschema.Enum{{
+					Name: "mood", Schema: "reporting", Values: []string{"sad", "ok"},
+				}}
+			},
+			want: "enum \"mood\" {\n  schema = schema.reporting\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := inspectedTable("")
+			test.declare(db)
+
+			result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, test.want)
+		})
+	}
+}

--- a/internal/atlashclrender/inspected_schema_test.go
+++ b/internal/atlashclrender/inspected_schema_test.go
@@ -580,10 +580,13 @@ func TestRenderedRelationTargetRoundTrips(t *testing.T) {
 		target string
 	}{
 		{
-			// The table target comes back qualified: goschema.Finalize reads a
-			// grant's schema off the table block it names, which is what it has
-			// always done and what the schema restore for the other two block
-			// types is modeled on.
+			// All three targets come back qualified, and that uniformity is
+			// the point. goschema.Finalize reads a grant's schema off the block
+			// it names, and an inspected render now attributes a view and a
+			// materialized view to the read's schema exactly as it has always
+			// attributed a table. Before stokaro/ptah#1138 only this row was
+			// qualified; the other two came back bare, which was the asymmetry
+			// rather than the rule.
 			name: "a table",
 			db: func() *goschema.Database {
 				return relationTargetDocument(goschema.Grant{
@@ -601,7 +604,7 @@ func TestRenderedRelationTargetRoundTrips(t *testing.T) {
 				db.Views = []goschema.View{{Name: "v", Body: "SELECT id FROM t"}}
 				return db
 			},
-			target: "v",
+			target: "public.v",
 		},
 		{
 			name: "a materialized view",
@@ -612,7 +615,7 @@ func TestRenderedRelationTargetRoundTrips(t *testing.T) {
 				db.MaterializedViews = []goschema.MaterializedView{{Name: "mv", Body: "SELECT id FROM t"}}
 				return db
 			},
-			target: "mv",
+			target: "public.mv",
 		},
 	}
 
@@ -657,7 +660,12 @@ func TestRenderedTriggerOnAViewRoundTrips(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(parsed.Triggers, qt.HasLen, 1)
-	c.Assert(parsed.Triggers[0].Table, qt.Equals, "v")
+	// Qualified, because an inspected render attributes the view block to the
+	// read's schema the way it has always attributed a table block. A trigger
+	// on an inspected TABLE has always come back `public.t`; the bare `v` this
+	// line used to expect was the view being the odd one out
+	// (stokaro/ptah#1138).
+	c.Assert(parsed.Triggers[0].Table, qt.Equals, "public.v")
 }
 
 // TestRenderedRelationTargetKeepsItsSchema pins that shortening the reference
@@ -673,23 +681,30 @@ func TestRenderedTriggerOnAViewRoundTrips(t *testing.T) {
 // restore for these lives in the HCL reader beside the other two positions the
 // same note leaves out.
 //
-// The single-schema row is the control: a bare name there was never carrying a
-// schema, and inventing one would change a document the author controls.
+// The second row is the one an inspected read produces for its own schema. The
+// grant goes in bare, because a catalog reports the read's own schema as
+// implicit, and comes back naming that schema -- exactly as the same document's
+// TABLE target always has (stokaro/ptah#1138). Separating the written target
+// from the expected one is what makes the row an assertion about the restore
+// rather than an echo.
 func TestRenderedRelationTargetKeepsItsSchema(t *testing.T) {
 	tests := []struct {
-		name       string
-		viewName   string
-		wantTarget string
+		name        string
+		viewName    string
+		grantTarget string
+		wantTarget  string
 	}{
 		{
-			name:       "a view outside the default schema",
-			viewName:   "other.v",
-			wantTarget: "other.v",
+			name:        "a view outside the default schema",
+			viewName:    "other.v",
+			grantTarget: "other.v",
+			wantTarget:  "other.v",
 		},
 		{
-			name:       "a view the document declares no schema for",
-			viewName:   "v",
-			wantTarget: "v",
+			name:        "a view the catalog reported without a schema",
+			viewName:    "v",
+			grantTarget: "v",
+			wantTarget:  "public.v",
 		},
 	}
 
@@ -699,7 +714,7 @@ func TestRenderedRelationTargetKeepsItsSchema(t *testing.T) {
 			c := qt.New(t)
 
 			db := relationTargetDocument(goschema.Grant{
-				Role: "app", OnTable: test.wantTarget, Privileges: []string{"SELECT"},
+				Role: "app", OnTable: test.grantTarget, Privileges: []string{"SELECT"},
 			})
 			db.Views = []goschema.View{{Name: test.viewName, Body: "SELECT id FROM t"}}
 
@@ -779,16 +794,23 @@ func TestRenderedSequenceTargetKeepsItsSchema(t *testing.T) {
 	tests := []struct {
 		name           string
 		sequenceSchema string
+		grantTarget    string
 		wantTarget     string
 	}{
 		{
 			name:           "a sequence outside the default schema",
 			sequenceSchema: "app",
+			grantTarget:    "app.order_seq",
 			wantTarget:     "app.order_seq",
 		},
 		{
-			name:       "a sequence the document declares no schema for",
-			wantTarget: "order_seq",
+			// Bare in, because a catalog reports the read's own schema as
+			// implicit; qualified out, because the sequence block now names
+			// that schema the way the table block always has
+			// (stokaro/ptah#1138).
+			name:        "a sequence the catalog reported without a schema",
+			grantTarget: "order_seq",
+			wantTarget:  "public.order_seq",
 		},
 	}
 
@@ -798,7 +820,7 @@ func TestRenderedSequenceTargetKeepsItsSchema(t *testing.T) {
 			c := qt.New(t)
 
 			db := relationTargetDocument(goschema.Grant{
-				Role: "app", OnSequence: test.wantTarget, Privileges: []string{"USAGE"},
+				Role: "app", OnSequence: test.grantTarget, Privileges: []string{"USAGE"},
 			})
 			db.Sequences = []goschema.Sequence{{Name: "order_seq", Schema: test.sequenceSchema}}
 

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -41,8 +41,8 @@ func (r *renderer) renderSequences() {
 		}
 		sequence.Canonicalize()
 		r.linef(`sequence %s {`, quote(sequence.Name))
-		if sequence.Schema != "" {
-			r.rawAttr(1, "schema", r.schemaRef(sequence.Schema))
+		if schema := r.schemaFor(sequence.Schema); schema != "" {
+			r.rawAttr(1, "schema", r.schemaRef(schema))
 		}
 		// A quoted string, not the bare word `bigint`. Bare, it is an HCL
 		// variable reference with nothing behind it and the pinned Atlas
@@ -105,8 +105,8 @@ func (r *renderer) renderUserTypes() {
 func (r *renderer) renderDomain(domain goschema.Domain) {
 	domain.Canonicalize()
 	r.linef(`domain %s {`, quote(domain.Name))
-	if domain.Schema != "" {
-		r.rawAttr(1, "schema", r.schemaRef(domain.Schema))
+	if schema := r.schemaFor(domain.Schema); schema != "" {
+		r.rawAttr(1, "schema", r.schemaRef(schema))
 	}
 	r.rawAttr(1, "type", userTypeExpr(domain.BaseType))
 	if domain.NotNull {
@@ -128,8 +128,8 @@ func (r *renderer) renderDomain(domain goschema.Domain) {
 func (r *renderer) renderComposite(composite goschema.CompositeType) {
 	composite.Canonicalize()
 	r.linef(`composite %s {`, quote(composite.Name))
-	if composite.Schema != "" {
-		r.rawAttr(1, "schema", r.schemaRef(composite.Schema))
+	if schema := r.schemaFor(composite.Schema); schema != "" {
+		r.rawAttr(1, "schema", r.schemaRef(schema))
 	}
 	r.stringAttr(1, "comment", composite.Comment)
 	for _, field := range composite.Fields {
@@ -144,8 +144,8 @@ func (r *renderer) renderComposite(composite goschema.CompositeType) {
 func (r *renderer) renderRange(rangeType goschema.Range) {
 	rangeType.Canonicalize()
 	r.linef(`range %s {`, quote(rangeType.Name))
-	if rangeType.Schema != "" {
-		r.rawAttr(1, "schema", r.schemaRef(rangeType.Schema))
+	if schema := r.schemaFor(rangeType.Schema); schema != "" {
+		r.rawAttr(1, "schema", r.schemaRef(schema))
 	}
 	r.rawAttr(1, "subtype", userTypeExpr(rangeType.Subtype))
 	r.stringAttr(1, "subtype_opclass", rangeType.SubtypeOpClass)
@@ -248,7 +248,7 @@ func (r *renderer) renderFunction(function goschema.Function) {
 	}
 	name := objectNameFromQualified(function.Name)
 	r.linef(`function %s {`, quote(name))
-	if schema := schemaNameFromQualified(function.Name); schema != "" {
+	if schema := r.schemaFor(schemaNameFromQualified(function.Name)); schema != "" {
 		r.rawAttr(1, "schema", r.schemaRef(schema))
 	}
 	// Every one of these four is a quoted string rather than a bare word.
@@ -310,7 +310,7 @@ func (r *renderer) renderViews() {
 		}
 		name := objectNameFromQualified(view.Name)
 		r.linef(`view %s {`, quote(name))
-		if schema := schemaNameFromQualified(view.Name); schema != "" {
+		if schema := r.schemaFor(schemaNameFromQualified(view.Name)); schema != "" {
 			r.rawAttr(1, "schema", r.schemaRef(schema))
 		}
 		r.stringAttr(1, "as", view.Body)
@@ -341,7 +341,7 @@ func (r *renderer) renderMaterializedView(view goschema.MaterializedView) {
 	}
 	name := objectNameFromQualified(view.Name)
 	r.linef(`materialized %s {`, quote(name))
-	if schema := schemaNameFromQualified(view.Name); schema != "" {
+	if schema := r.schemaFor(schemaNameFromQualified(view.Name)); schema != "" {
 		r.rawAttr(1, "schema", r.schemaRef(schema))
 	}
 	r.stringAttr(1, "as", view.Body)

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -339,6 +339,25 @@ func (r *renderer) documentResolvesTableRef(schema, name string) bool {
 
 // schemaFor returns the schema name to write for an object, which is the one it
 // carries or, failing that, the schema the whole read belongs to.
+//
+// Every schema-scoped block an inspected render writes goes through it, and the
+// reason is that the alternative to the attribute is not "no schema", it is
+// "whichever schema replays it". A PostgreSQL catalog blanks the schema on
+// exactly the objects the read's own search_path made implicit, so an object of
+// the schema being inspected arrives with an empty Schema; a block written
+// without the attribute is then created wherever the replaying connection's
+// search_path points.
+//
+// This renderer writes nine schema-scoped block types -- sequence, domain,
+// composite, range, enum, table, function, view, materialized. Measured on
+// PostgreSQL 17.10 with one schema `wf1138s` holding one object of each,
+// inspected and planned back into a fresh database, seven of the nine landed in
+// `public`; only `enum` and `table` were already reaching this helper. See
+// stokaro/ptah#1138, and stokaro/ptah#1276 for the two that were not.
+//
+// An empty default is the parse-and-re-render contract and is deliberately
+// preserved: those callers got their IR from HCL, where an absent schema is
+// what the author wrote, and synthesizing one would invent a declaration.
 func (r *renderer) schemaFor(schema string) string {
 	if strings.TrimSpace(schema) != "" {
 		return schema

--- a/internal/convert/fromschema/builtintypes.go
+++ b/internal/convert/fromschema/builtintypes.go
@@ -61,8 +61,8 @@ import (
 // TestFromDatabaseKeepsTheScalarEnumHalfWithIssue1276 pins both halves so this
 // split is a decision rather than an accident.
 func namesABuiltInType(dialect, typeName string) bool {
-	names, known := builtInTypeNames[platform.NormalizeDialect(dialect)]
-	if !known {
+	names := builtInTypeNamesFor(dialect)
+	if names == nil {
 		return false
 	}
 	trimmed := strings.TrimSpace(typeName)
@@ -73,17 +73,74 @@ func namesABuiltInType(dialect, typeName string) bool {
 	return found
 }
 
-// builtInTypeNames maps a dialect to the type names its own catalog answers to.
+// builtInTypeNamesFor returns the type names the target's own catalog answers
+// to, or nil for a target whose catalog this package has no vocabulary for.
 //
-// A dialect absent from this map treats no name as built in, which is exactly
-// the behavior it had before stokaro/ptah#1138 -- the same convention
-// internal/atlashclrender/modeled_types.go uses for the same reason. Only
-// PostgreSQL is listed because only PostgreSQL was measured; CockroachDB,
-// YugabyteDB and Spanner reuse much of the PostgreSQL type namespace, and
-// listing them here on that resemblance would be a claim nobody ran.
-var builtInTypeNames = map[string]map[string]struct{}{
-	platform.Postgres: builtInNameSet(postgresCatalogTypeNames, postgresGrammarTypeNames),
+// The selector is [platform.IsPostgresFamily] rather than a list of dialect
+// names, because that is the same predicate that decides what the guarded pass
+// emits. Keying the guard on the literal "postgres" while
+// [QualifyDeclaredUserTypes] runs for four dialects is how stokaro/ptah#1138's
+// collision stayed live on three of them: the PASS was never absent for
+// cockroachdb, yugabytedb or spanner, only the GUARD was. Measured with a
+// ptah binary built from the commit before this fix, one document declaring
+// `CREATE DOMAIN advm.money` beside a `money` column and a `money[]` column:
+//
+//	ptah schema render --dialect postgres     ->  "c" money       "arr" money[]
+//	ptah schema render --dialect cockroachdb  ->  "c" advm.money  "arr" advm.money[]
+//	ptah schema render --dialect yugabytedb   ->  "c" advm.money  "arr" advm.money[]
+//	ptah schema render --dialect spanner      ->  "c" advm.money  "arr" advm.money[]
+//
+// and the yugabytedb plan replayed into a live YugabyteDB at exit 0 turned
+// `money | pg_catalog | b` into `advm.money | advm | d`, the same base-type-
+// became-a-domain the PostgreSQL measurement found.
+//
+// The four family members share one vocabulary because they emit one document:
+// the four renders above differ only in a comment line. How well that one
+// vocabulary fits each member was measured rather than assumed, with the same
+// catalog query [postgresCatalogTypeNames] carries:
+//
+//   - YugabyteDB 2026.1.0.0-b118 (PostgreSQL 15.12-YB) returns the SAME 107
+//     names, no additions and no omissions, and `money` there is
+//     `money | b | pg_catalog`. For YugabyteDB this list is exact.
+//   - CockroachDB v26.2.5 returns 52 names. Sixty-one of the 107 are absent,
+//     `money` among them, and six names it does have are absent here (box2d,
+//     citext, geography, geometry, ltree, vector). It also refuses
+//     `CREATE DOMAIN advm.money AS DECIMAL(12,2)` outright -- "unimplemented:
+//     this syntax" -- so the domain half of the collision cannot arise there at
+//     all.
+//   - Spanner's PostgreSQL dialect was not run.
+//
+// So the list is exact for one member and an over-approximation for another,
+// and that is tolerable only because the two directions are not symmetric. A
+// name listed here that the target does not have costs the shadowed user type
+// its qualifier, which is how that column planned before stokaro/ptah#1138 and
+// which fails LOUDLY at replay: measured on the same CockroachDB,
+// `CREATE TABLE advm.t2 (c money[])` is refused at exit 1 while
+// `CREATE TABLE advm.t (c advm.money[])` against a declared enum succeeds. A
+// name MISSING from here retypes a live column and reports success, which is
+// the YugabyteDB catalog above. Only the second direction is a defect, so
+// inside the family over-inclusion is the side to err on, and the six
+// CockroachDB names this list lacks leave stokaro/ptah#1138's collision open
+// there for those six exactly the way it is open for any name not listed --
+// name by name, never wholesale.
+// [TestQualifyDeclaredUserTypesGuardsEveryPostgresFamilySpelling] pins that the
+// set the guard covers is the set the pass runs for.
+//
+// A dialect outside the family gets no vocabulary and treats no name as built
+// in, which is the behavior it had before stokaro/ptah#1138 -- the same
+// convention internal/atlashclrender/modeled_types.go uses. That table stays
+// PostgreSQL-only for a reason that does not apply here: its rows are measured
+// against the pinned community binary, and a wrong row there produces a
+// document that binary cannot read, so its failure directions are symmetric.
+func builtInTypeNamesFor(dialect string) map[string]struct{} {
+	if !platform.IsPostgresFamily(dialect) {
+		return nil
+	}
+	return postgresBuiltInTypeNames
 }
+
+// postgresBuiltInTypeNames is the folded lookup the PostgreSQL family shares.
+var postgresBuiltInTypeNames = builtInNameSet(postgresCatalogTypeNames, postgresGrammarTypeNames)
 
 func builtInNameSet(lists ...[]string) map[string]struct{} {
 	set := make(map[string]struct{})

--- a/internal/convert/fromschema/builtintypes.go
+++ b/internal/convert/fromschema/builtintypes.go
@@ -1,0 +1,179 @@
+package fromschema
+
+import (
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// namesABuiltInType reports whether typeName is a name the target dialect
+// resolves through its own catalog rather than through a declaration in the
+// document.
+//
+// It is the difference between "this column's type IS the declared user type"
+// and "this column's type name COLLIDES with one", and nothing else in the IR
+// can tell them apart. A column carries a type name, not a type identity; the
+// declaration carries the schema. Matching the two by bare name alone retypes
+// a built-in column the moment somebody declares a user type that answers to
+// the same word, and PostgreSQL has plenty of one-word type names people reuse
+// -- money, point, line, box, path, text, name, date, interval, json, xml.
+//
+// Measured on PostgreSQL 17.10, source seeded by hand:
+//
+//	CREATE SCHEMA advm; CREATE DOMAIN advm.money AS numeric(12,2);
+//	CREATE TABLE advm.prices (id integer, domain_col advm.money, builtin_col money);
+//
+// The read is unambiguous -- inspect writes `type = money` for the built-in
+// column and `type = sql("advm.money")` for the domain column -- and without
+// this predicate the plan was not: `builtin_col` came back as `advm.money`,
+// replayed at exit 0, and the catalog of the replayed database reported
+// `advm.money | advm | d` where the source had `money | pg_catalog | b`. A base
+// type became a domain silently. The same happened for `money[]`, for a
+// composite named `point` in both spellings, and -- through [handleEnumTypes],
+// which is stokaro/ptah#1276 rather than stokaro/ptah#1138 -- for an enum named
+// `money`.
+//
+// The direction this predicate refuses in is deliberate. A name that could mean
+// either thing is left exactly as the source spelled it, which is what the rest
+// of [declaredUserTypeQualifiers] already does for a name two schemas both
+// declare. Leaving a built-in alone costs a user type whose name shadows a
+// catalog type its qualifier, and that column plans the way it planned before
+// stokaro/ptah#1138. Rewriting it the other way changes a column's type in a
+// live database and reports success.
+//
+// # Where this predicate is NOT applied, and why
+//
+// [handleEnumTypes] re-points a bare enum name and is left unguarded, so the
+// SCALAR spelling of an enum whose name shadows a catalog type still resolves to
+// the enum. That line is stokaro/ptah#1276's, it predates stokaro/ptah#1138, and
+// guarding it would not help: measured on PostgreSQL 17.10 with
+// `CREATE TYPE adve.money AS ENUM ('lo','hi')` beside an ordinary `money`
+// column, an inspected document writes `type = enum.money` for BOTH columns,
+// because the renderer resolves a column type against the declared enum blocks.
+// By the time a name reaches that line the two columns are one string, so a
+// guard would only move which of them is wrong -- and on the annotation path it
+// would be a plain regression, because `type="money"` beside a declared enum
+// `money` is an author naming their own type.
+//
+// The array spelling of the same enum IS guarded, because there the catalog
+// keeps the two apart: the same read wrote `sql("money[]")` for the built-in
+// array and `sql("adve.money[]")` for the enum array.
+// TestFromDatabaseKeepsTheScalarEnumHalfWithIssue1276 pins both halves so this
+// split is a decision rather than an accident.
+func namesABuiltInType(dialect, typeName string) bool {
+	names, known := builtInTypeNames[platform.NormalizeDialect(dialect)]
+	if !known {
+		return false
+	}
+	trimmed := strings.TrimSpace(typeName)
+	if open := strings.IndexByte(trimmed, '('); open >= 0 {
+		trimmed = strings.TrimSpace(trimmed[:open])
+	}
+	_, found := names[strings.ToLower(trimmed)]
+	return found
+}
+
+// builtInTypeNames maps a dialect to the type names its own catalog answers to.
+//
+// A dialect absent from this map treats no name as built in, which is exactly
+// the behavior it had before stokaro/ptah#1138 -- the same convention
+// internal/atlashclrender/modeled_types.go uses for the same reason. Only
+// PostgreSQL is listed because only PostgreSQL was measured; CockroachDB,
+// YugabyteDB and Spanner reuse much of the PostgreSQL type namespace, and
+// listing them here on that resemblance would be a claim nobody ran.
+var builtInTypeNames = map[string]map[string]struct{}{
+	platform.Postgres: builtInNameSet(postgresCatalogTypeNames, postgresGrammarTypeNames),
+}
+
+func builtInNameSet(lists ...[]string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, names := range lists {
+		for _, name := range names {
+			set[strings.ToLower(name)] = struct{}{}
+		}
+	}
+	return set
+}
+
+// postgresCatalogTypeNames is every non-array type name pg_catalog holds,
+// read out of a live server rather than remembered:
+//
+//	SELECT typname FROM pg_type
+//	WHERE typnamespace = 'pg_catalog'::regnamespace
+//	  AND typtype IN ('b', 'r', 'm', 'p')
+//	  AND typname NOT LIKE '\_%'
+//	ORDER BY typname;
+//
+// run against PostgreSQL 17.10, which returned these 107 rows. Array names are
+// excluded because [splitArraySuffix] has already removed the brackets by the
+// time this list is consulted, and pg_catalog spells an array type `_money`
+// rather than `money[]`.
+//
+// Internal and pseudo names -- cstring, internal, record, trigger, void and the
+// anycompatible family -- are kept rather than filtered. They cost nothing: the
+// only effect of a name being here is that a user type declared under it is not
+// re-pointed, and a schema that declares a composite called `record` is a schema
+// where refusing to guess is right.
+//
+// Unlike internal/atlashclrender/modeledColumnTypes, this list has no
+// conformance run behind it, and it does not need one, because its two failure
+// directions are not symmetric and neither is worse than not having the list:
+//
+//   - a name here that is NOT built in costs that user type its qualifier, which
+//     is how the column planned before stokaro/ptah#1138
+//   - a name MISSING from here re-exposes stokaro/ptah#1138's collision for that
+//     one name, and only when a schema declares a user type answering to it
+//
+// So a list that is too long is safe and a list that is too short degrades to
+// the previous behavior, name by name. No entry can produce a spelling the
+// source did not already carry. That is the opposite of the modeled-types table,
+// where a wrong row makes a document the pinned binary cannot read.
+var postgresCatalogTypeNames = []string{
+	"aclitem", "any", "anyarray", "anycompatible", "anycompatiblearray",
+	"anycompatiblemultirange", "anycompatiblenonarray", "anycompatiblerange",
+	"anyelement", "anyenum", "anymultirange", "anynonarray", "anyrange", "bit",
+	"bool", "box", "bpchar", "bytea", "char", "cid", "cidr", "circle", "cstring",
+	"date", "datemultirange", "daterange", "event_trigger", "fdw_handler",
+	"float4", "float8", "gtsvector", "index_am_handler", "inet", "int2",
+	"int2vector", "int4", "int4multirange", "int4range", "int8", "int8multirange",
+	"int8range", "internal", "interval", "json", "jsonb", "jsonpath",
+	"language_handler", "line", "lseg", "macaddr", "macaddr8", "money", "name",
+	"numeric", "nummultirange", "numrange", "oid", "oidvector", "path",
+	"pg_brin_bloom_summary", "pg_brin_minmax_multi_summary", "pg_ddl_command",
+	"pg_dependencies", "pg_lsn", "pg_mcv_list", "pg_ndistinct", "pg_node_tree",
+	"pg_snapshot", "point", "polygon", "record", "refcursor", "regclass",
+	"regcollation", "regconfig", "regdictionary", "regnamespace", "regoper",
+	"regoperator", "regproc", "regprocedure", "regrole", "regtype",
+	"table_am_handler", "text", "tid", "time", "timestamp", "timestamptz",
+	"timetz", "trigger", "tsm_handler", "tsmultirange", "tsquery", "tsrange",
+	"tstzmultirange", "tstzrange", "tsvector", "txid_snapshot", "unknown", "uuid",
+	"varbit", "varchar", "void", "xid", "xid8", "xml",
+}
+
+// postgresGrammarTypeNames are the spellings PostgreSQL's parser accepts that
+// pg_catalog does not store under that name: the SQL standard aliases and the
+// SERIAL shorthands.
+//
+// They are a separate list because the query above cannot produce them:
+// `integer` is int4 in the catalog and `bigserial` is not a type at all. Each
+// was measured on the same PostgreSQL 17.10 server instead. The seventeen
+// aliases through to_regtype, every one resolving into pg_catalog:
+//
+//	SELECT n.name, tn.nspname FROM (VALUES ('bigint'), ...) AS n(name)
+//	LEFT JOIN pg_type t ON t.oid = to_regtype(n.name)
+//	LEFT JOIN pg_namespace tn ON tn.oid = t.typnamespace;
+//
+// and the six SERIAL spellings through a CREATE TABLE, because to_regtype does
+// not know them:
+//
+//	CREATE TABLE p (a serial, b serial2, c serial4,
+//	                d serial8, e bigserial, f smallserial);
+//	  -> integer, smallint, integer, bigint, bigint, smallint, all pg_catalog
+var postgresGrammarTypeNames = []string{
+	"bigint", "bigserial", "bit varying", "boolean", "character",
+	"character varying", "decimal", "double precision", "int", "integer",
+	"national character", "national character varying", "real", "serial",
+	"serial2", "serial4", "serial8", "smallint", "smallserial",
+	"time with time zone", "time without time zone",
+	"timestamp with time zone", "timestamp without time zone",
+}

--- a/internal/convert/fromschema/builtintypes_test.go
+++ b/internal/convert/fromschema/builtintypes_test.go
@@ -1,0 +1,322 @@
+package fromschema_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/convert/fromschema"
+)
+
+// shadowingDocument is the IR a PostgreSQL read produces for a schema whose
+// user type answers to a name pg_catalog already answers to, next to a column
+// of the built-in type of that name.
+//
+// Seeded and read on PostgreSQL 17.10:
+//
+//	CREATE SCHEMA advm; CREATE DOMAIN advm.money AS numeric(12,2);
+//	CREATE TABLE advm.prices (id integer, domain_col advm.money, builtin_col money);
+//
+// inspect wrote `column "builtin_col" { type = money }` and
+// `column "domain_col" { type = sql("advm.money") }`, so the read had already
+// said which column is which. `declare` is what varies per row: it puts the
+// shadowing declaration into the document, and the column type is the bare name
+// both of them answer to.
+func shadowingDocument(columnType string, declare func(*goschema.Database)) *goschema.Database {
+	database := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t", Schema: "advm"}},
+		Fields: []goschema.Field{{StructName: "T", Name: "c", Type: columnType}},
+	}
+	declare(database)
+	return database
+}
+
+func declareShadowingDomain(database *goschema.Database) {
+	database.Domains = []goschema.Domain{{
+		Name: "money", Schema: "advm", BaseType: "numeric(12,2)",
+	}}
+}
+
+func declareShadowingComposite(database *goschema.Database) {
+	database.CompositeTypes = []goschema.CompositeType{{
+		Name:   "point",
+		Schema: "advp",
+		Fields: []goschema.CompositeTypeField{{Name: "x", Type: "numeric"}},
+	}}
+}
+
+func declareShadowingRange(database *goschema.Database) {
+	database.Ranges = []goschema.Range{{
+		Name: "numrange", Schema: "advr", Subtype: "numeric",
+	}}
+}
+
+func declareShadowingEnum(database *goschema.Database) {
+	database.Enums = []goschema.Enum{{
+		Name: "money", Schema: "adve", Values: []string{"lo", "hi"},
+	}}
+}
+
+// TestQualifyDeclaredUserTypesLeavesABuiltInTypeAlone pins the direction the
+// name-keyed rewrite gets wrong: a column whose type is a BUILT-IN keeps it,
+// even when a declaration in the same document answers to the same bare name.
+//
+// Every row is a column that was catalog-correct before stokaro/ptah#1138 and
+// silently retyped by it. Measured on PostgreSQL 17.10 for the first row, both
+// plans replayed into fresh databases at exit 0 and the catalog read with
+// format_type and pg_type.typtype:
+//
+//	source            builtin_col | money      | pg_catalog | b
+//	without the guard builtin_col | advm.money | advm       | d
+//	with it           builtin_col | money      | pg_catalog | b
+//
+// The kinds are enumerated rather than sampled because the map that does the
+// rewriting is built from Domains, CompositeTypes, Ranges and Enums in one
+// loop each, and a guard added to one loop looks exactly like a guard added to
+// all four until a row says otherwise. Both spellings are enumerated for the
+// same reason: the scalar and the array spelling read two different maps.
+func TestQualifyDeclaredUserTypesLeavesABuiltInTypeAlone(t *testing.T) {
+	tests := []struct {
+		name       string
+		columnType string
+		declare    func(*goschema.Database)
+	}{
+		{
+			name:       "a domain shadowing money, scalar",
+			columnType: "money",
+			declare:    declareShadowingDomain,
+		},
+		{
+			name:       "a domain shadowing money, array",
+			columnType: "money[]",
+			declare:    declareShadowingDomain,
+		},
+		{
+			name:       "a composite shadowing point, scalar",
+			columnType: "point",
+			declare:    declareShadowingComposite,
+		},
+		{
+			name:       "a composite shadowing point, array",
+			columnType: "point[]",
+			declare:    declareShadowingComposite,
+		},
+		{
+			name:       "a range shadowing numrange, scalar",
+			columnType: "numrange",
+			declare:    declareShadowingRange,
+		},
+		{
+			name:       "a range shadowing numrange, array",
+			columnType: "numrange[]",
+			declare:    declareShadowingRange,
+		},
+		{
+			// The scalar spelling of an enum belongs to handleEnumTypes and
+			// stays with stokaro/ptah#1276; see
+			// TestFromDatabaseKeepsTheScalarEnumHalfWithIssue1276. This is the
+			// spelling stokaro/ptah#1138 added.
+			name:       "an enum shadowing money, array",
+			columnType: "money[]",
+			declare:    declareShadowingEnum,
+		},
+		{
+			// PostgreSQL type names are case insensitive, so a lookup that
+			// compares them verbatim protects `money` and retypes `MONEY`.
+			name:       "a built-in name the column spells in upper case",
+			columnType: "MONEY",
+			declare: func(database *goschema.Database) {
+				database.Domains = []goschema.Domain{{
+					Name: "MONEY", Schema: "advm", BaseType: "numeric(12,2)",
+				}}
+			},
+		},
+		{
+			// A SERIAL column reaches this pass as the shorthand, not as int4,
+			// and `serial` is not a pg_catalog type name -- it is grammar.
+			name:       "a grammar spelling pg_catalog does not store",
+			columnType: "serial",
+			declare: func(database *goschema.Database) {
+				database.Domains = []goschema.Domain{{
+					Name: "serial", Schema: "advm", BaseType: "integer",
+				}}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			qualified := fromschema.QualifyDeclaredUserTypes(
+				shadowingDocument(test.columnType, test.declare), platform.Postgres,
+			)
+
+			c.Assert(qualified.Fields, qt.HasLen, 1)
+			c.Assert(qualified.Fields[0].Type, qt.Equals, test.columnType)
+		})
+	}
+}
+
+// TestQualifyDeclaredUserTypesStillNamesASchemaForANameOfItsOwn is the control
+// for the row set above, and it is what keeps "leave a built-in alone" from
+// becoming "leave everything alone".
+//
+// Each row is the same shape as a shadowing row -- one declaration, one column
+// naming it bare -- with the one difference that the name is not one pg_catalog
+// answers to. These are the cells stokaro/ptah#1138 closed, and they have to
+// stay closed.
+func TestQualifyDeclaredUserTypesStillNamesASchemaForANameOfItsOwn(t *testing.T) {
+	tests := []struct {
+		name       string
+		columnType string
+		declare    func(*goschema.Database)
+		want       string
+	}{
+		{
+			name:       "a domain, scalar",
+			columnType: "positive_int",
+			declare: func(database *goschema.Database) {
+				database.Domains = []goschema.Domain{{
+					Name: "positive_int", Schema: "advm", BaseType: "integer",
+				}}
+			},
+			want: "advm.positive_int",
+		},
+		{
+			name:       "a domain, array",
+			columnType: "positive_int[]",
+			declare: func(database *goschema.Database) {
+				database.Domains = []goschema.Domain{{
+					Name: "positive_int", Schema: "advm", BaseType: "integer",
+				}}
+			},
+			want: "advm.positive_int[]",
+		},
+		{
+			name:       "a composite, array",
+			columnType: "addr[]",
+			declare: func(database *goschema.Database) {
+				database.CompositeTypes = []goschema.CompositeType{{
+					Name:   "addr",
+					Schema: "advp",
+					Fields: []goschema.CompositeTypeField{{Name: "street", Type: "text"}},
+				}}
+			},
+			want: "advp.addr[]",
+		},
+		{
+			name:       "a range, array",
+			columnType: "numrng[]",
+			declare: func(database *goschema.Database) {
+				database.Ranges = []goschema.Range{{
+					Name: "numrng", Schema: "advr", Subtype: "numeric",
+				}}
+			},
+			want: "advr.numrng[]",
+		},
+		{
+			name:       "an enum, array",
+			columnType: "mood[]",
+			declare: func(database *goschema.Database) {
+				database.Enums = []goschema.Enum{{
+					Name: "mood", Schema: "adve", Values: []string{"lo", "hi"},
+				}}
+			},
+			want: "adve.mood[]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			qualified := fromschema.QualifyDeclaredUserTypes(
+				shadowingDocument(test.columnType, test.declare), platform.Postgres,
+			)
+
+			c.Assert(qualified.Fields, qt.HasLen, 1)
+			c.Assert(qualified.Fields[0].Type, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestFromDatabaseKeepsTheScalarEnumHalfWithIssue1276 records the boundary of
+// this repair, so the split is a pinned decision rather than something the next
+// reader has to rediscover from behavior.
+//
+// handleEnumTypes re-points a bare enum name, and it does so for a BUILT-IN
+// column whose name a declared enum shadows. That predates this change --
+// stokaro/ptah#1276 added the line, stokaro/ptah#1138 did not touch it -- and it
+// is left alone for two measured reasons. On the read path there is nothing left
+// to decide by the time the name arrives: inspecting
+// `CREATE TYPE adve.money AS ENUM ('lo','hi')` beside an ordinary `money` column
+// on PostgreSQL 17.10 writes `type = enum.money` for BOTH columns, because the
+// renderer resolves a column type against the declared enum blocks. On the
+// annotation path a guard would be a regression, because `type="money"` beside a
+// declared enum `money` is an author naming their own type.
+//
+// The array spelling is the half that IS fixed, and the difference is that a
+// catalog keeps the two apart: the same read wrote `sql("money[]")` for the
+// built-in array and `sql("adve.money[]")` for the enum array.
+func TestFromDatabaseKeepsTheScalarEnumHalfWithIssue1276(t *testing.T) {
+	tests := []struct {
+		name       string
+		columnType string
+		want       string
+	}{
+		{
+			// stokaro/ptah#1276's, and still open: the column is a built-in.
+			name:       "a scalar enum name, which handleEnumTypes still re-points",
+			columnType: "money",
+			want:       "\"c\" adve.money",
+		},
+		{
+			// stokaro/ptah#1138's, and closed: a built-in array keeps its type.
+			name:       "the array spelling of the same name",
+			columnType: "money[]",
+			want:       "\"c\" money[]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			database := shadowingDocument(test.columnType, declareShadowingEnum)
+
+			statements := fromschema.FromDatabase(*database, platform.Postgres)
+
+			c.Assert(statements, qt.IsNotNil)
+
+			sql, err := renderer.RenderSQL(platform.Postgres, statements.Statements...)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Contains, test.want)
+		})
+	}
+}
+
+// TestQualifyDeclaredUserTypesKeepsUnmeasuredDialectsUnchanged pins that the
+// guard is dialect scoped rather than global.
+//
+// Only PostgreSQL's catalog was read, so only PostgreSQL is listed. A dialect
+// absent from that map has to behave the way it behaved before the guard
+// existed -- silently applying PostgreSQL's catalog to ClickHouse would be a
+// claim about a server nobody queried.
+func TestQualifyDeclaredUserTypesKeepsUnmeasuredDialectsUnchanged(t *testing.T) {
+	c := qt.New(t)
+
+	qualified := fromschema.QualifyDeclaredUserTypes(
+		shadowingDocument("money[]", declareShadowingDomain), platform.ClickHouse,
+	)
+
+	c.Assert(qualified.Fields, qt.HasLen, 1)
+	c.Assert(qualified.Fields[0].Type, qt.Equals, "advm.money[]")
+}

--- a/internal/convert/fromschema/builtintypes_test.go
+++ b/internal/convert/fromschema/builtintypes_test.go
@@ -1,6 +1,7 @@
 package fromschema_test
 
 import (
+	"slices"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -303,20 +304,105 @@ func TestFromDatabaseKeepsTheScalarEnumHalfWithIssue1276(t *testing.T) {
 	}
 }
 
-// TestQualifyDeclaredUserTypesKeepsUnmeasuredDialectsUnchanged pins that the
-// guard is dialect scoped rather than global.
+// TestQualifyDeclaredUserTypesGuardsEveryPostgresFamilySpelling is the dialect
+// axis, and it exists because an earlier revision of this file had no row on it.
 //
-// Only PostgreSQL's catalog was read, so only PostgreSQL is listed. A dialect
-// absent from that map has to behave the way it behaved before the guard
-// existed -- silently applying PostgreSQL's catalog to ClickHouse would be a
-// claim about a server nobody queried.
-func TestQualifyDeclaredUserTypesKeepsUnmeasuredDialectsUnchanged(t *testing.T) {
+// The guard was keyed on the literal platform.Postgres while
+// [fromschema.QualifyDeclaredUserTypes] runs for every dialect, so on the other
+// three PostgreSQL-family targets the PASS was present and only the GUARD was
+// absent. Measured with the shipped CLI on the commit before the fix, one
+// document declaring `CREATE DOMAIN advm.money` beside a `money` column and a
+// `money[]` column:
+//
+//	ptah schema render --dialect postgres     ->  "c" money       "arr" money[]
+//	ptah schema render --dialect cockroachdb  ->  "c" advm.money  "arr" advm.money[]
+//	ptah schema render --dialect yugabytedb   ->  "c" advm.money  "arr" advm.money[]
+//	ptah schema render --dialect spanner      ->  "c" advm.money  "arr" advm.money[]
+//
+// and the yugabytedb plan replayed into a live YugabyteDB 2026.1.0.0-b118 at
+// exit 0, where the catalog then read `c | advm.money | advm | d` against a
+// source that read `c | money | pg_catalog | b`. A base type became a domain on
+// a second engine, silently, exactly as on PostgreSQL.
+//
+// The spellings are read out of platform.NormalizeDialect's own switch rather
+// than listed here, so this asserts over every spelling ptah accepts -- the
+// aliases `pgx`, `crdb`, `ysql` and `google_spanner` included -- and a family
+// member added to platform.IsPostgresFamily later is covered without anyone
+// editing this file. That is the same reason the guard selects on that
+// predicate instead of naming four dialects.
+func TestQualifyDeclaredUserTypesGuardsEveryPostgresFamilySpelling(t *testing.T) {
 	c := qt.New(t)
 
-	qualified := fromschema.QualifyDeclaredUserTypes(
-		shadowingDocument("money[]", declareShadowingDomain), platform.ClickHouse,
-	)
+	family := slices.DeleteFunc(acceptedSpellings(c), func(spelling string) bool {
+		return !platform.IsPostgresFamily(spelling)
+	})
 
-	c.Assert(qualified.Fields, qt.HasLen, 1)
-	c.Assert(qualified.Fields[0].Type, qt.Equals, "advm.money[]")
+	// Extraction control: an empty or truncated family list would make the
+	// sweep below pass while comparing nothing.
+	for _, canonical := range []string{
+		platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner,
+	} {
+		c.Assert(family, qt.Contains, canonical)
+	}
+
+	retyped := slices.DeleteFunc(slices.Clone(family), func(spelling string) bool {
+		qualified := fromschema.QualifyDeclaredUserTypes(
+			shadowingDocument("money[]", declareShadowingDomain), spelling,
+		)
+		return qualified.Fields[0].Type == "money[]"
+	})
+
+	c.Assert(retyped, qt.HasLen, 0, qt.Commentf("these PostgreSQL-family spellings retyped a built-in column"))
+}
+
+// TestQualifyDeclaredUserTypesLeavesNonPostgresTargetsToTheirOwnCatalog is the
+// non-interference control for the sweep above: the guard reaches the
+// PostgreSQL family and stops there.
+//
+// It is not an approval of a gap. On these two engines the declaration is the
+// only thing in reach that answers to `money`, so qualifying the column is the
+// right answer rather than an unguarded one, and both halves of that were
+// measured rather than assumed:
+//
+//	MySQL 9.7.1        SELECT CAST(1 AS money)  -> ERROR 1064 (42000), exit 1
+//	                   SELECT CAST(1 AS decimal(12,2)) -> 1.00, exit 0
+//	ClickHouse 24.8.14 SELECT name FROM system.data_type_families
+//	                     WHERE lower(name) IN ('money','decimal','uuid')
+//	                     -> Decimal, UUID
+//
+// The control terms are in both queries on purpose: an empty answer to a broken
+// query looks exactly like an absent type.
+//
+// This is also the row that separates "the PostgreSQL family shares one
+// vocabulary" from "one vocabulary for every dialect". Handing these two
+// targets pg_catalog's names would strip a qualifier from a user type that is
+// the column's only possible meaning.
+func TestQualifyDeclaredUserTypesLeavesNonPostgresTargetsToTheirOwnCatalog(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{
+			name:    "mysql, which refuses money as a type name",
+			dialect: platform.MySQL,
+		},
+		{
+			name:    "clickhouse, whose data_type_families has no money",
+			dialect: platform.ClickHouse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			qualified := fromschema.QualifyDeclaredUserTypes(
+				shadowingDocument("money[]", declareShadowingDomain), test.dialect,
+			)
+
+			c.Assert(qualified.Fields, qt.HasLen, 1)
+			c.Assert(qualified.Fields[0].Type, qt.Equals, "advm.money[]")
+		})
+	}
 }

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -2062,7 +2062,7 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 
 	// Normalize once so every conversion path consumes the same names.
 	assigned := AssignDefaultForeignKeyNames(&database, targetPlatform)
-	database = *assigned
+	database = *QualifyDeclaredUserTypes(assigned, targetPlatform)
 	allFields := database.Fields
 
 	// 1. Add schema definitions first (they may be referenced by tables)

--- a/internal/convert/fromschema/usertyperef.go
+++ b/internal/convert/fromschema/usertyperef.go
@@ -1,0 +1,185 @@
+package fromschema
+
+import (
+	"maps"
+	"strings"
+
+	"go.5x5.cz/ptah/core/goschema"
+)
+
+// QualifyDeclaredUserTypes returns a clone of database whose column types name
+// the schema of the user type the same schema declares.
+//
+// A user type is created in a schema, and a column declared against it has to
+// name the same one: PostgreSQL resolves a bare type name through search_path,
+// and a plan that touches more than one schema cannot have the right
+// search_path for all of them. Measured on PostgreSQL 17.10, one schema
+// `wf1138s` holding one user type of each kind, inspected and planned back into
+// a fresh database:
+//
+//	CREATE TYPE "wf1138s"."mood" AS ENUM ('sad', 'ok', 'happy');
+//	CREATE TABLE "wf1138s"."t" (..., "c6" mood[], ...);
+//	  -> ERROR:  type "mood[]" does not exist
+//
+// [handleEnumTypes] already does this for the SCALAR spelling of an enum, and
+// carries the same measurement for `CREATE TYPE "extra"."mood"` followed by a
+// bare `mood` (stokaro/ptah#1276). That repair reached one of the eight cells
+// this boundary has -- four user-type kinds (enum, domain, composite, range)
+// times two spellings (scalar and array) -- because [declaredEnum] matches a
+// declared name exactly and `mood[]` is not `mood`. This closes the other seven
+// (stokaro/ptah#1138).
+//
+// It runs over the whole schema rather than inside [FromField] because a column
+// does not carry its type's schema; only the declaration does. Both callers are
+// AST-generation entry points, never the comparison in
+// [go.5x5.cz/ptah/migration/schemadiff]: a database read reports the column type
+// as the catalog spells it, so qualifying the generated side before a comparison
+// would invent a difference rather than remove one.
+//
+// Names deliberately left alone:
+//
+//   - a type that already carries a qualifier, which the author spelled
+//   - a type whose bare name is declared more than once, where nothing in the
+//     column says which was meant and guessing would type it against the wrong
+//     declaration
+//   - the SCALAR spelling of an enum, because [declaredEnum] is the only test
+//     for "is this column an enum" and it matches the bare name; rewriting it
+//     here would hide the enum from the standalone-versus-inline decision
+//     [handleEnumTypes] makes
+//   - every enum on a dialect that models an enum on the column instead of as a
+//     standalone type, for the same reason
+func QualifyDeclaredUserTypes(database *goschema.Database, targetPlatform string) *goschema.Database {
+	if database == nil {
+		return nil
+	}
+	clone := *database
+	scalars, arrays := declaredUserTypeQualifiers(database, targetPlatform)
+	if len(scalars) == 0 && len(arrays) == 0 {
+		return &clone
+	}
+	clone.Fields = make([]goschema.Field, len(database.Fields))
+	copy(clone.Fields, database.Fields)
+	for i := range clone.Fields {
+		clone.Fields[i].Type = qualifyUserTypeReference(clone.Fields[i].Type, scalars, arrays)
+	}
+	return &clone
+}
+
+// declaredUserTypeQualifiers maps the bare name of every unambiguously declared
+// user type to its qualified spelling, once for the scalar spelling and once for
+// the array spelling.
+//
+// The two maps differ only in the enums, which the array map carries and the
+// scalar map does not; see [QualifyDeclaredUserTypes] for why. A name declared
+// twice is mapped to the empty string rather than dropped, so that a later
+// declaration of the same name cannot re-add it.
+func declaredUserTypeQualifiers(
+	database *goschema.Database,
+	targetPlatform string,
+) (scalars, arrays map[string]string) {
+	declare := func(into map[string]string, name, schema, qualified string) {
+		name = strings.TrimSpace(name)
+		if name == "" || strings.TrimSpace(schema) == "" {
+			return
+		}
+		if _, seen := into[name]; seen {
+			into[name] = ""
+			return
+		}
+		into[name] = qualified
+	}
+	base := make(map[string]string)
+	for _, domain := range database.Domains {
+		declare(base, domain.Name, domain.Schema, domain.QualifiedName())
+	}
+	for _, composite := range database.CompositeTypes {
+		declare(base, composite.Name, composite.Schema, composite.QualifiedName())
+	}
+	for _, rangeType := range database.Ranges {
+		declare(base, rangeType.Name, rangeType.Schema, rangeType.QualifiedName())
+	}
+
+	scalars = make(map[string]string, len(base))
+	maps.Copy(scalars, base)
+	// An enum name never participates in the scalar map, even when no enum
+	// block claims a schema: a scalar column typed with it belongs to
+	// [handleEnumTypes], which finds it by the bare name.
+	for _, enum := range database.Enums {
+		if name := strings.TrimSpace(enum.Name); name != "" {
+			scalars[name] = ""
+		}
+	}
+	if !emitsStandaloneEnumDefinitions(targetPlatform) {
+		return scalars, scalars
+	}
+
+	arrays = make(map[string]string, len(base)+len(database.Enums))
+	maps.Copy(arrays, base)
+	for _, enum := range database.Enums {
+		name := strings.TrimSpace(enum.Name)
+		if strings.TrimSpace(enum.Schema) == "" {
+			// A schemaless enum still shadows a same-named declaration of
+			// another kind, because `mood[]` where both answer to `mood` names
+			// neither unambiguously.
+			if name != "" {
+				arrays[name] = ""
+			}
+			continue
+		}
+		declare(arrays, name, enum.Schema, enum.QualifiedName())
+	}
+	return scalars, arrays
+}
+
+// qualifyUserTypeReference rewrites a column type that names a declared user
+// type, keeping any array brackets.
+func qualifyUserTypeReference(columnType string, scalars, arrays map[string]string) string {
+	trimmed := strings.TrimSpace(columnType)
+	name, brackets := splitArraySuffix(trimmed)
+	if name == "" || strings.Contains(name, ".") {
+		return columnType
+	}
+	qualifiers := scalars
+	if brackets != "" {
+		qualifiers = arrays
+	}
+	qualified := qualifiers[name]
+	if qualified == "" {
+		return columnType
+	}
+	return qualified + brackets
+}
+
+// splitArraySuffix splits a column type into the type it is an array of and the
+// bracket run that says so, returning an empty suffix for a scalar.
+//
+// Every bracket group PostgreSQL accepts is consumed, empty or dimensioned, so
+// `mood[]`, `mood[3]` and `mood[][1]` all reduce to `mood`. The dimensions are
+// kept verbatim rather than normalized: PostgreSQL discards them itself, and
+// rewriting them here would change a spelling this function has no reason to
+// touch.
+func splitArraySuffix(columnType string) (name, brackets string) {
+	end := len(columnType)
+	for end > 0 && columnType[end-1] == ']' {
+		open := strings.LastIndexByte(columnType[:end-1], '[')
+		if open < 0 {
+			break
+		}
+		if !isArrayDimension(columnType[open+1 : end-1]) {
+			break
+		}
+		end = open
+	}
+	return strings.TrimRight(columnType[:end], " "), columnType[end:]
+}
+
+// isArrayDimension reports whether the text between one pair of brackets is an
+// array dimension rather than part of the type itself.
+func isArrayDimension(text string) bool {
+	for _, r := range strings.TrimSpace(text) {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/convert/fromschema/usertyperef.go
+++ b/internal/convert/fromschema/usertyperef.go
@@ -42,6 +42,11 @@ import (
 //   - a type whose bare name is declared more than once, where nothing in the
 //     column says which was meant and guessing would type it against the wrong
 //     declaration
+//   - a type whose bare name the server resolves through its own catalog, which
+//     is the same situation reached through a different second declaration: the
+//     column names a built-in and a user type at once. Rewriting it retypes a
+//     column that was correct, at exit 0, and the catalog of the replayed
+//     database is where it shows up. See [namesABuiltInType]
 //   - the SCALAR spelling of an enum, because [declaredEnum] is the only test
 //     for "is this column an enum" and it matches the bare name; rewriting it
 //     here would hide the enum from the standalone-versus-inline decision
@@ -80,6 +85,14 @@ func declaredUserTypeQualifiers(
 	declare := func(into map[string]string, name, schema, qualified string) {
 		name = strings.TrimSpace(name)
 		if name == "" || strings.TrimSpace(schema) == "" {
+			return
+		}
+		if namesABuiltInType(targetPlatform, name) {
+			// Ambiguous with the server's own catalog, and handled the same way
+			// as ambiguous with a second declaration: mapped to the empty
+			// string, so nothing later in this function can re-add it. See
+			// [namesABuiltInType] for the measurement.
+			into[name] = ""
 			return
 		}
 		if _, seen := into[name]; seen {

--- a/internal/convert/fromschema/usertyperef_test.go
+++ b/internal/convert/fromschema/usertyperef_test.go
@@ -1,0 +1,293 @@
+package fromschema_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/convert/fromschema"
+)
+
+// userTypeDocument is the IR a PostgreSQL read of one schema produces: one
+// declaration of each user-type kind, each carrying the schema it lives in, and
+// one table whose column type is whatever the row is about.
+func userTypeDocument(columnType string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t", Schema: "app"}},
+		Fields: []goschema.Field{{StructName: "T", Name: "c", Type: columnType}},
+		Enums: []goschema.Enum{{
+			Name: "mood", Schema: "app", Values: []string{"sad", "ok"},
+		}},
+		Domains: []goschema.Domain{{
+			Name: "positive_int", Schema: "app", BaseType: "integer",
+		}},
+		CompositeTypes: []goschema.CompositeType{{
+			Name:   "addr",
+			Schema: "app",
+			Fields: []goschema.CompositeTypeField{{Name: "street", Type: "text"}},
+		}},
+		Ranges: []goschema.Range{{Name: "numrng", Schema: "app", Subtype: "numeric"}},
+	}
+}
+
+// TestQualifyDeclaredUserTypesNamesTheDeclarationsSchema pins the whole
+// boundary: four user-type kinds times two spellings.
+//
+// PostgreSQL resolves a bare type name through search_path, so a column typed
+// against a user type in another schema is created against whatever that name
+// resolves to at replay time -- or fails outright. Measured on PostgreSQL 17.10
+// by inspecting a schema `wf1138s` holding one of each and planning the result
+// into a fresh database with `psql -v ON_ERROR_STOP=1`:
+//
+//	CREATE TYPE "wf1138s"."mood" AS ENUM ('sad', 'ok', 'happy');
+//	CREATE TABLE "wf1138s"."t" (..., "enum_array" mood[], ...);
+//	  -> ERROR:  type "mood[]" does not exist                exit 3
+//
+// One of the eight cells was already right: the scalar spelling of an enum,
+// closed by stokaro/ptah#1276. The other seven are stokaro/ptah#1138, and the
+// enum row makes the split visible -- the same table wrote `wf1138s.mood` for
+// the scalar column and `mood[]` for the array one.
+//
+// The scalar enum row expects NO rewrite here on purpose. [declaredEnum] is the
+// only test for "is this column an enum" and it matches the bare name, so the
+// qualifier for that cell belongs to handleEnumTypes and putting it on twice
+// would hide the enum from the standalone-versus-inline decision.
+func TestQualifyDeclaredUserTypesNamesTheDeclarationsSchema(t *testing.T) {
+	tests := []struct {
+		name       string
+		columnType string
+		want       string
+	}{
+		{
+			name:       "a domain, scalar",
+			columnType: "positive_int",
+			want:       "app.positive_int",
+		},
+		{
+			name:       "a domain, array",
+			columnType: "positive_int[]",
+			want:       "app.positive_int[]",
+		},
+		{
+			name:       "a composite type, scalar",
+			columnType: "addr",
+			want:       "app.addr",
+		},
+		{
+			name:       "a composite type, array",
+			columnType: "addr[]",
+			want:       "app.addr[]",
+		},
+		{
+			name:       "a range type, scalar",
+			columnType: "numrng",
+			want:       "app.numrng",
+		},
+		{
+			name:       "a range type, array",
+			columnType: "numrng[]",
+			want:       "app.numrng[]",
+		},
+		{
+			name:       "an enum, array",
+			columnType: "mood[]",
+			want:       "app.mood[]",
+		},
+		{
+			name:       "an enum, scalar, which handleEnumTypes owns",
+			columnType: "mood",
+			want:       "mood",
+		},
+		{
+			name:       "a dimensioned array keeps its dimensions",
+			columnType: "positive_int[3][]",
+			want:       "app.positive_int[3][]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			qualified := fromschema.QualifyDeclaredUserTypes(
+				userTypeDocument(test.columnType), platform.Postgres,
+			)
+
+			c.Assert(qualified.Fields, qt.HasLen, 1)
+			c.Assert(qualified.Fields[0].Type, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestQualifyDeclaredUserTypesLeavesEverythingElseAlone is the half that keeps
+// the rewrite from becoming "prefix every type with the read's schema".
+//
+// Each row is a spelling that must survive untouched, and each names a distinct
+// way of being wrong: qualifying a built-in type, re-qualifying one the author
+// already spelled, guessing between two declarations of one name, and inventing
+// a schema for a declaration that has none -- which is every document an author
+// wrote by hand.
+func TestQualifyDeclaredUserTypesLeavesEverythingElseAlone(t *testing.T) {
+	tests := []struct {
+		name       string
+		columnType string
+		amend      func(*goschema.Database)
+		want       string
+	}{
+		{
+			name:       "a built-in scalar type",
+			columnType: "varchar(100)",
+			amend:      func(_ *goschema.Database) {},
+			want:       "varchar(100)",
+		},
+		{
+			name:       "a built-in array type",
+			columnType: "character varying(100)[]",
+			amend:      func(_ *goschema.Database) {},
+			want:       "character varying(100)[]",
+		},
+		{
+			name:       "a type the author already qualified",
+			columnType: "other.positive_int",
+			amend:      func(_ *goschema.Database) {},
+			want:       "other.positive_int",
+		},
+		{
+			name:       "a name two schemas both declare",
+			columnType: "positive_int",
+			amend: func(db *goschema.Database) {
+				db.Domains = append(db.Domains, goschema.Domain{
+					Name: "positive_int", Schema: "other", BaseType: "integer",
+				})
+			},
+			want: "positive_int",
+		},
+		{
+			name:       "an array of a name two schemas both declare",
+			columnType: "positive_int[]",
+			amend: func(db *goschema.Database) {
+				db.Domains = append(db.Domains, goschema.Domain{
+					Name: "positive_int", Schema: "other", BaseType: "integer",
+				})
+			},
+			want: "positive_int[]",
+		},
+		{
+			name:       "an array whose element name an enum also answers to",
+			columnType: "addr[]",
+			amend: func(db *goschema.Database) {
+				db.Enums = append(db.Enums, goschema.Enum{
+					Name: "addr", Schema: "app", Values: []string{"home"},
+				})
+			},
+			want: "addr[]",
+		},
+		{
+			name:       "a declaration that carries no schema, as an author writes it",
+			columnType: "positive_int",
+			amend: func(db *goschema.Database) {
+				db.Domains = []goschema.Domain{{Name: "positive_int", BaseType: "integer"}}
+			},
+			want: "positive_int",
+		},
+		{
+			name:       "an array of a declaration that carries no schema",
+			columnType: "mood[]",
+			amend: func(db *goschema.Database) {
+				db.Enums = []goschema.Enum{{Name: "mood", Values: []string{"sad", "ok"}}}
+			},
+			want: "mood[]",
+		},
+		{
+			name:       "a bracket run that is part of the type, not a dimension",
+			columnType: "positive_int[a]",
+			amend:      func(_ *goschema.Database) {},
+			want:       "positive_int[a]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := userTypeDocument(test.columnType)
+			test.amend(db)
+
+			qualified := fromschema.QualifyDeclaredUserTypes(db, platform.Postgres)
+
+			c.Assert(qualified.Fields, qt.HasLen, 1)
+			c.Assert(qualified.Fields[0].Type, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestQualifyDeclaredUserTypesLeavesInlineEnumDialectsAlone pins that a dialect
+// which models an enum ON the column never has its enum names rewritten here.
+//
+// MySQL, MariaDB, SQLite and SQL Server all reach applyInlineEnumModel, which
+// finds the enum by the bare name and replaces the column type outright. A
+// qualifier written before that lookup would make the enum invisible to it and
+// leave `app.mood` in the DDL as a type name no such server has.
+func TestQualifyDeclaredUserTypesLeavesInlineEnumDialectsAlone(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "MySQL", dialect: platform.MySQL},
+		{name: "MariaDB", dialect: platform.MariaDB},
+		{name: "SQLite", dialect: platform.SQLite},
+		{name: "SQL Server", dialect: platform.SQLServer},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			qualified := fromschema.QualifyDeclaredUserTypes(
+				userTypeDocument("mood[]"), test.dialect,
+			)
+
+			c.Assert(qualified.Fields, qt.HasLen, 1)
+			c.Assert(qualified.Fields[0].Type, qt.Equals, "mood[]")
+		})
+	}
+}
+
+// TestQualifyDeclaredUserTypesDoesNotMutateItsInput pins that the pass is a
+// clone, because both callers hand it a value they keep using afterwards.
+func TestQualifyDeclaredUserTypesDoesNotMutateItsInput(t *testing.T) {
+	c := qt.New(t)
+
+	db := userTypeDocument("mood[]")
+
+	qualified := fromschema.QualifyDeclaredUserTypes(db, platform.Postgres)
+
+	c.Assert(qualified.Fields[0].Type, qt.Equals, "app.mood[]")
+	c.Assert(db.Fields[0].Type, qt.Equals, "mood[]")
+}
+
+// TestFromDatabaseQualifiesDeclaredUserTypes pins the first of the two entry
+// points the pass is wired into.
+//
+// Wiring it into only one of them is the plausible half-fix: FromDatabase is
+// the obvious whole-schema conversion, and the planner is where a diff-driven
+// CREATE TABLE is actually built. Each of the two tests fails when the pass is
+// wired only into the other, so neither call site can be dropped quietly.
+func TestFromDatabaseQualifiesDeclaredUserTypes(t *testing.T) {
+	c := qt.New(t)
+
+	statements := fromschema.FromDatabase(*userTypeDocument("mood[]"), platform.Postgres)
+
+	c.Assert(statements, qt.IsNotNil)
+
+	sql, err := renderer.RenderSQL(platform.Postgres, statements.Statements...)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "\"c\" app.mood[]")
+}

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -481,7 +481,14 @@ func GenerateSchemaDiffASTWithOptions(
 ) ([]ast.Node, error) {
 	caps := opts.CapabilitiesFor(dialect)
 	semantics := diff.EffectiveIdentifierSemantics(dialect)
-	preparedGenerated := fromschema.AssignDefaultForeignKeyNames(generated, dialect)
+	// Both normalizations belong here rather than in the dialect planners: a
+	// column does not carry the schema of the user type it names, only the
+	// declaration does, and every dialect planner reads its columns out of this
+	// one value (stokaro/ptah#1138).
+	preparedGenerated := fromschema.QualifyDeclaredUserTypes(
+		fromschema.AssignDefaultForeignKeyNames(generated, dialect),
+		dialect,
+	)
 	if diff != nil &&
 		diff.IdentifierSemantics != nil &&
 		!diff.IdentifierSemantics.IsZero() &&

--- a/migration/planner/user_type_reference_test.go
+++ b/migration/planner/user_type_reference_test.go
@@ -1,0 +1,90 @@
+package planner_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/migration/planner"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// TestGenerateSchemaDiffSQLQualifiesDeclaredUserTypes pins the second of the
+// two entry points fromschema.QualifyDeclaredUserTypes is wired into.
+//
+// The planner is where a diff-driven CREATE TABLE is built, and it reads its
+// columns out of one prepared value that every dialect planner shares. Wiring
+// the pass into fromschema.FromDatabase alone is the plausible half-fix -- that
+// is the obvious whole-schema conversion -- and it leaves every `schema diff`
+// and every generated migration untouched, which is the path an inspected
+// database actually travels.
+//
+// Measured on PostgreSQL 17.10 through `ptah-compat schema diff`, planning an
+// inspected schema `wf1138s` into a fresh database:
+//
+//	before   CREATE TABLE "wf1138s"."t" (..., "enum_array" mood[], ...)
+//	         psql -v ON_ERROR_STOP=1   ERROR: type "mood[]" does not exist   exit 3
+//	after    CREATE TABLE "wf1138s"."t" (..., "enum_array" wf1138s.mood[], ...)
+//	         psql -v ON_ERROR_STOP=1   exit 0
+//
+// See stokaro/ptah#1138.
+func TestGenerateSchemaDiffSQLQualifiesDeclaredUserTypes(t *testing.T) {
+	tests := []struct {
+		name       string
+		columnType string
+		want       string
+	}{
+		{
+			name:       "an enum array",
+			columnType: "mood[]",
+			want:       "\"c\" app.mood[]",
+		},
+		{
+			name:       "a domain",
+			columnType: "positive_int",
+			want:       "\"c\" app.positive_int",
+		},
+		{
+			name:       "a domain array",
+			columnType: "positive_int[]",
+			want:       "\"c\" app.positive_int[]",
+		},
+		{
+			// The control. A built-in type has no declaration to name, and
+			// prefixing it would produce a type no server has.
+			name:       "a built-in array",
+			columnType: "character varying(100)[]",
+			want:       "\"c\" character varying(100)[]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			schema := plannerUserTypeSchema(test.columnType)
+			diff := &types.SchemaDiff{TablesAdded: []string{"t"}}
+
+			sql, err := planner.GenerateSchemaDiffSQL(diff, schema, platform.Postgres)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Contains, test.want)
+		})
+	}
+}
+
+func plannerUserTypeSchema(columnType string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t", Schema: "app"}},
+		Fields: []goschema.Field{{StructName: "T", Name: "c", Type: columnType}},
+		Enums: []goschema.Enum{{
+			Name: "mood", Schema: "app", Values: []string{"sad", "ok"},
+		}},
+		Domains: []goschema.Domain{{
+			Name: "positive_int", Schema: "app", BaseType: "integer",
+		}},
+	}
+}

--- a/migration/planner/user_type_reference_test.go
+++ b/migration/planner/user_type_reference_test.go
@@ -76,6 +76,69 @@ func TestGenerateSchemaDiffSQLQualifiesDeclaredUserTypes(t *testing.T) {
 	}
 }
 
+// TestGenerateSchemaDiffSQLLeavesABuiltInTypeAlone is the same enumeration at
+// the planner, and it is here rather than only in the fromschema package
+// because this is the path an inspected database travels: `schema diff` builds
+// its CREATE TABLE here, and a guard that holds in the pass but is bypassed on
+// the way to this call site would still ship the retyped column.
+//
+// Measured on PostgreSQL 17.10 through `ptah-compat schema diff`, source seeded
+// as `CREATE DOMAIN advm.money AS numeric(12,2)` beside an ordinary `money`
+// column, each plan replayed into a fresh database at exit 0 and the catalog
+// read back:
+//
+//	before this guard   "builtin_col" advm.money   ->  advm.money | advm       | d
+//	with it             "builtin_col" money        ->  money      | pg_catalog | b
+//
+// The source column is `money | pg_catalog | b`.
+func TestGenerateSchemaDiffSQLLeavesABuiltInTypeAlone(t *testing.T) {
+	tests := []struct {
+		name       string
+		columnType string
+		want       string
+	}{
+		{
+			name:       "a domain shadowing money, scalar",
+			columnType: "money",
+			want:       "\"c\" money",
+		},
+		{
+			name:       "a domain shadowing money, array",
+			columnType: "money[]",
+			want:       "\"c\" money[]",
+		},
+		{
+			// The control, and the cell stokaro/ptah#1138 closed. Same
+			// document, same call, a name pg_catalog does not answer to.
+			name:       "a domain with a name of its own",
+			columnType: "positive_int",
+			want:       "\"c\" advm.positive_int",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			schema := &goschema.Database{
+				Tables: []goschema.Table{{StructName: "T", Name: "t", Schema: "advm"}},
+				Fields: []goschema.Field{{StructName: "T", Name: "c", Type: test.columnType}},
+				Domains: []goschema.Domain{
+					{Name: "money", Schema: "advm", BaseType: "numeric(12,2)"},
+					{Name: "positive_int", Schema: "advm", BaseType: "integer"},
+				},
+			}
+			diff := &types.SchemaDiff{TablesAdded: []string{"t"}}
+
+			sql, err := planner.GenerateSchemaDiffSQL(diff, schema, platform.Postgres)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Contains, test.want)
+		})
+	}
+}
+
 func plannerUserTypeSchema(columnType string) *goschema.Database {
 	return &goschema.Database{
 		Tables: []goschema.Table{{StructName: "T", Name: "t", Schema: "app"}},


### PR DESCRIPTION
Refs #1138.

## What this is, and what it is not

Two boundaries lost the read's schema on the way out of `schema inspect`, and this closes both:

- **Blocks.** Seven of the nine schema-scoped HCL block types wrote the `schema` attribute only when the object already carried one, so an inspected object of the read's own schema was replayed into whatever schema the replaying connection pointed at.
- **Column type references.** A column typed against a user type kept the bare name, so it resolved through `search_path` at replay -- or failed outright.

It does **not** touch the view/materialized-view *body*, and it makes no claim about the conformance fixtures #1138 names. Both are under "Out of scope" below, the second with the reason it cannot move today.

Everything below is a run made on this branch's code against live servers, with binaries built into a directory inside the worktree and every probe database created for the probe.

**Which revision measured what.** This description has been revised more than once and the numbers come from more than one session, so the provenance is stated rather than implied. Measured in **this** revision, on containers started for it: the whole of "The same collision, live on the rest of the PostgreSQL family"; "The scalar spelling of an enum stays with #1276"; the whole of "Oracle parity"; mutants P and Q; the count correction under "The two boundaries, enumerated"; and every row of "Gates". Every database name in those sections begins `wfa65_`. Carried over from earlier revisions of this same branch, unchanged: "The defect, applied", the diff and catalogs under "The collision this had to solve first", the block diff under "The two boundaries, enumerated", "Both directions, on both control documents", mutants A, B, H, K, I, J and N, and the conformance-fixture measurement under "Out of scope". Those database names begin `wf8266_` and the control documents are named `ctl_`.

**Branch base, and the rebase that is still owed.** The branch is based on `22895782`. Master has since moved to `1fd469be`. `list_commits` filtered on `internal/atlashclrender`, `internal/convert/fromschema` and `migration/planner` -- the three packages this branch changes -- returns an empty list for all three since the base commit, so no file this branch touches has moved on master, and `git pull --rebase origin master` applied the branch's first commit onto `1fd469be` reporting "all conflicts fixed" before it stopped for the reason below.

Every gate in the Gates section was run on a tree at master `1fd469be` carrying this branch's version of every file the branch touches, so the numbers are the merged tree rather than the branch in isolation.

The branch itself was **not** rebased and force-pushed. Commit signing is on in this environment and gpg cannot reach a pinentry, so both `git commit` and `git pull --rebase` die with `gpg: signing failed: Inappropriate ioctl for device`; disabling the signing is not something this work may do. The two commits added in this revision were written through the GitHub API instead, and each pushed file was read back from `raw.githubusercontent.com` at the resulting commit and `diff`ed against the local file that the gates were run on -- both `diff` exit 0. The rebase is still owed and is the merging party's to do.

**The catalog query.** Every catalog block below is the output of one query, referred to as `catalog(db, schema, table)`:

```sql
SELECT a.attname AS column, format_type(a.atttypid, a.atttypmod) AS ftype,
       tn.nspname AS type_schema, t.typtype
FROM pg_attribute a
JOIN pg_class c ON c.oid = a.attrelid
JOIN pg_namespace n ON n.oid = c.relnamespace
JOIN pg_type t ON t.oid = a.atttypid
JOIN pg_namespace tn ON tn.oid = t.typnamespace
WHERE n.nspname = :schema AND c.relname = :table
  AND a.attnum > 0 AND NOT a.attisdropped
ORDER BY a.attname;
```

It is read from the catalog rather than from the rendered SQL on purpose: `format_type` says how the server itself spells the column's type, and `typtype` says what kind of thing it is -- `b` base, `d` domain, `e` enum.

## The defect, applied

Source, seeded by hand:

```sql
CREATE SCHEMA advm;
CREATE DOMAIN advm.money AS numeric(12,2);
CREATE DOMAIN advm.positive_int AS integer;
CREATE TYPE advm.mood AS ENUM ('sad','ok');
CREATE TABLE advm.prices (id integer, domain_col advm.money, builtin_col money,
                          builtin_arr money[], dom_arr advm.positive_int[],
                          enum_arr advm.mood[]);
```

```
$ catalog(wf8266_src, advm, prices)
   column    |        ftype        | type_schema | typtype
-------------+---------------------+-------------+---------
 builtin_arr | money[]             | pg_catalog  | b
 builtin_col | money               | pg_catalog  | b
 dom_arr     | advm.positive_int[] | advm        | b
 domain_col  | advm.money          | advm        | d
 enum_arr    | advm.mood[]         | advm        | b
 id          | integer             | pg_catalog  | b
(6 rows)
```

`ptah-compat schema inspect` reads it at exit 0. The table block it writes, verbatim:

```
table "prices" {
  schema = schema.advm
  column "builtin_arr" {
    type = sql("money[]")
    null = true
  }
  column "builtin_col" {
    type = money
    null = true
  }
  column "dom_arr" {
    type = sql("positive_int[]")
    null = true
  }
  column "domain_col" {
    type = sql("advm.money")
    null = true
  }
  column "enum_arr" {
    type = sql("mood[]")
    null = true
  }
  column "id" {
    type = integer
    null = true
  }
}
```

Two things are visible in it at once. `dom_arr` and `enum_arr` are the #1138 cells: the catalog reported them relative to the read's own `search_path`, so the array element name arrives bare and resolves to nothing at replay. And the read has *already* separated a built-in column from a user-type one -- `type = money` against `type = sql("advm.money")` -- which is the fact the next section turns on.

Planned with `schema diff` into a fresh database and replayed with `psql -v ON_ERROR_STOP=1`:

```
DIFF_FINAL_RC=0
PSQL_FINAL_RC=0
```

```
$ catalog(wf8266_dst_final, advm, prices)
   column    |        ftype        | type_schema | typtype
-------------+---------------------+-------------+---------
 builtin_arr | money[]             | pg_catalog  | b
 builtin_col | money               | pg_catalog  | b
 dom_arr     | advm.positive_int[] | advm        | b
 domain_col  | advm.money          | advm        | d
 enum_arr    | advm.mood[]         | advm        | b
 id          | integer             | pg_catalog  | b
(6 rows)
```

Row for row identical to the source. That is what "the round trip agrees" means here: applied-catalog equality, judged by the type's namespace and its `typtype`, not by the SQL text.

## The collision this had to solve first

Qualifying a column by matching its bare type name against the declared user types is the obvious implementation, and it is wrong in a way that is invisible at exit 0. `advm.money` is a domain and `money` is a base type; one name-keyed map answers `advm.money` to both.

Same source, same inspected document, planned by a binary with the guard removed and by this branch:

```
$ diff -u unguarded.sql guarded.sql
@@
 CREATE TABLE "advm"."prices" (
-  "builtin_arr" advm.money[],
-  "builtin_col" advm.money,
+  "builtin_arr" money[],
+  "builtin_col" money,
   "dom_arr" advm.positive_int[],
   "domain_col" advm.money,
   "enum_arr" advm.mood[],
   "id" integer
 );
```

Both plans applied at exit 0. The unguarded one produced:

```
$ catalog(wf8266_dst_prhead, advm, prices)
   column    |        ftype        | type_schema | typtype
-------------+---------------------+-------------+---------
 builtin_arr | advm.money[]        | advm        | b
 builtin_col | advm.money          | advm        | d
 dom_arr     | advm.positive_int[] | advm        | b
 domain_col  | advm.money          | advm        | d
 enum_arr    | advm.mood[]         | advm        | b
 id          | integer             | pg_catalog  | b
(6 rows)
```

`builtin_col` went from `money | pg_catalog | b` to `advm.money | advm | d`. A base type became a domain, silently, at exit 0, and `builtin_arr` went with it. The same happens for a composite named `point` in both spellings and for a range named `numrange`.

`namesABuiltInType` is the missing test. A declaration whose bare name the server resolves through its own catalog is treated as ambiguous and mapped to the empty string -- the identical treatment a name two schemas both declare already gets. The refusal direction is deliberate and asymmetric: leaving a built-in alone costs a shadow-named user type its qualifier, which is how that column planned before this branch; rewriting the other way changes a live column's type and reports success.

The vocabulary is the server's own, read out of a live PostgreSQL 17.10 rather than remembered:

```sql
SELECT typname FROM pg_type
WHERE typnamespace = 'pg_catalog'::regnamespace
  AND typtype IN ('b','r','m','p') AND typname NOT LIKE '\_%'
ORDER BY typname;   -- 107 rows
```

plus 23 grammar spellings the catalog does not store under that name, each measured on the same server: seventeen aliases through `to_regtype`, every one resolving into `pg_catalog`, and the six `SERIAL` shorthands through a `CREATE TABLE`:

```
 attname |  ftype   |  nspname
---------+----------+------------
 a       | integer  | pg_catalog
 b       | smallint | pg_catalog
 c       | integer  | pg_catalog
 d       | bigint   | pg_catalog
 e       | bigint   | pg_catalog
 f       | smallint | pg_catalog
(6 rows)
```

The list carries no conformance run, and does not need one, because its failure directions are not symmetric: a name wrongly present costs one user type its qualifier (the pre-#1138 behavior for that name), while a name missing re-exposes the collision for that one name only, and only when a schema declares a user type answering to it. No entry can produce a spelling the source did not already carry.

## The same collision, live on the rest of the PostgreSQL family

An earlier revision of this description ended the section above with "A dialect absent from the map treats no name as built in, so only PostgreSQL changes. CockroachDB, YugabyteDB and Spanner reuse much of the PostgreSQL type namespace, but none of them was queried, so none is listed." Every clause of that is literally true, and together they hid the defect. `QualifyDeclaredUserTypes` runs for **every** dialect. The PASS was never absent for cockroachdb, yugabytedb or spanner -- only the GUARD was, and those three are exactly the targets Ptah plans and renders as PostgreSQL.

Measured with a `ptah` binary built from `204dd5fe`, the revision before this one, into `.wfbin/` inside the worktree. The model is one file: a domain `money` in schema `advm`, and a table with a `money` column and a `money[]` column.

```
$ ./.wfbin/ptah schema render --root-dir .wfscratch/model --dialect yugabytedb
Scanning directory: /Users/buster/Work/denis/ptah/.claude/worktrees/wf_a65a18e1-ea3-2/.wfscratch/model
Found 1 tables, 3 fields, 0 indexes, 0 enums, 0 embedded fields

Table Dependencies:
==================
prices: (no dependencies)

Table Creation Order:
====================
1. prices

-- Statement 1/2
CREATE DOMAIN "advm"."money" AS numeric(12,2);

-- Statement 2/2
-- YUGABYTEDB TABLE: advm.prices --
CREATE TABLE "advm"."prices" (
  "id" INTEGER,
  "c" advm.money NOT NULL,
  "arr" advm.money[] NOT NULL
);
```

The same command was run four times with `--dialect` substituted. The two column lines from each run, which are the only lines that differ apart from the `-- <DIALECT> TABLE:` comment:

| `--dialect` | `"c"` | `"arr"` |
|---|---|---|
| `postgres` | `money NOT NULL` | `money[] NOT NULL` |
| `cockroachdb` | `advm.money NOT NULL` | `advm.money[] NOT NULL` |
| `yugabytedb` | `advm.money NOT NULL` | `advm.money[] NOT NULL` |
| `spanner` | `advm.money NOT NULL` | `advm.money[] NOT NULL` |

Rendered is not applied, so the yugabytedb plan was replayed into a live YugabyteDB started for this measurement -- `yugabytedb/yugabyte:2026.1.0.0-b118`, which reports `PostgreSQL 15.12-YB-2026.1.0.0-b0`. `money` there is the same pg_catalog base type PostgreSQL has:

```
$ docker exec wfa65-yb bin/ysqlsh -h 192.168.215.31 -p 5433 -U yugabyte -d yugabyte -c "select version();" -c "select typname, typtype, typnamespace::regnamespace::text as ns from pg_type where typname='money';" < /dev/null
                                                                                             version
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 15.12-YB-2026.1.0.0-b0 on aarch64-unknown-linux-gnu, compiled by clang version 21.1.1 (https://github.com/yugabyte/llvm-project.git efca861cc42178cc4c555d605b36c79d7d121cc1), 64-bit
(1 row)

 typname | typtype |     ns
---------+---------+------------
 money   | b       | pg_catalog
(1 row)
```

(`192.168.215.31` is the container's own address; yugabyted binds the interface rather than the loopback, so `-h 127.0.0.1` inside the container is refused. `< /dev/null` is there because `docker exec` otherwise consumes the caller's stdin.)

Source database, seeded by hand with `CREATE SCHEMA advm; CREATE DOMAIN advm.money AS numeric(12,2); CREATE TABLE advm.prices (id integer, c money NOT NULL, arr money[] NOT NULL);`:

```
$ catalog(wfa65_src, advm, prices)
 column |  ftype  | type_schema | typtype
--------+---------+-------------+---------
 arr    | money[] | pg_catalog  | b
 c      | money   | pg_catalog  | b
 id     | integer | pg_catalog  | b
(3 rows)
```

The plan is the render above with its two statements extracted by `sed -n '/^-- Statement 1\/2/,$p'`, replayed after a `CREATE SCHEMA advm;` the render does not emit because the model declares no schema object:

```
$ docker cp .wfscratch/yb_unguarded.sql wfa65-yb:/tmp/yb_unguarded.sql && docker exec wfa65-yb bin/ysqlsh -h 192.168.215.31 -p 5433 -U yugabyte -d wfa65_unguarded -v ON_ERROR_STOP=1 -c "CREATE SCHEMA advm;" -f /tmp/yb_unguarded.sql < /dev/null; echo "REPLAY_RC=$?"
CREATE SCHEMA
CREATE DOMAIN
CREATE TABLE
REPLAY_RC=0
```

```
$ catalog(wfa65_unguarded, advm, prices)
 column |    ftype     | type_schema | typtype
--------+--------------+-------------+---------
 arr    | advm.money[] | advm        | b
 c      | advm.money   | advm        | d
 id     | integer      | pg_catalog  | b
(3 rows)
```

A base type became a domain on a second engine, at exit 0. With this revision's binary the same replay gives back the source:

```
$ catalog(wfa65_fixed, advm, prices)
 column |  ftype  | type_schema | typtype
--------+---------+-------------+---------
 arr    | money[] | pg_catalog  | b
 c      | money   | pg_catalog  | b
 id     | integer | pg_catalog  | b
(3 rows)
```

**The fix is the predicate, not three more strings.** `builtInTypeNames`, a map keyed by dialect name, is gone; `builtInTypeNamesFor` answers from `platform.IsPostgresFamily`, which is the same predicate that decides which targets the guarded pass emits PostgreSQL DDL for. A family member added to that function later is covered without a second edit here, which is the difference between fixing the class and fixing three instances of it.

**How well one vocabulary fits each family member was measured, not assumed.** The catalog query above, run on each server that could be run:

- **YugabyteDB 2026.1.0.0-b118** returns the **same 107 names**, no additions and no omissions. Compared as sets against the list in `builtintypes.go`: `in ptah list, missing from yugabyte: []`, `in yugabyte, missing from ptah list: []`. For YugabyteDB this list is exact.
- **CockroachDB v26.2.5** returns 52 names. Sixty-one of the 107 are absent, `money` among them (the same query returns `numeric | b | pg_catalog` as the control term, so the empty answer for `money` is an absent type and not a broken query), and six names CockroachDB does have are absent from the list: `box2d`, `citext`, `geography`, `geometry`, `ltree`, `vector`. It also refuses `CREATE DOMAIN advm.money AS DECIMAL(12,2)` outright -- `unimplemented: this syntax`, exit 1 -- so the domain half of the collision cannot arise there at all.
- **Spanner's PostgreSQL dialect** was not run.

So the shared vocabulary is exact for one member and an over-approximation for another, and that is tolerable only because the two directions are not symmetric, which was also measured rather than argued. On the same CockroachDB, the enum-array column resolves and the built-in-array column does not:

```
$ docker exec wfa65-crdb ./cockroach sql --insecure --host=localhost:26259 --database=wfa65 -e "CREATE SCHEMA advm;" -e "CREATE TYPE advm.money AS ENUM ('lo','hi');" -e "CREATE TABLE advm.t (c advm.money[]);" -e "CREATE TABLE advm.t2 (c money[]);" < /dev/null; echo "RC=$?"
CREATE SCHEMA
CREATE TYPE
NOTICE: waiting for job(s) to complete: 1200067236767039489, 1200067236764057601
If the statement is canceled, jobs will continue in the background.
CREATE TABLE
ERROR: at or near "[": syntax error: unimplemented: this syntax
SQLSTATE: 0A000
DETAIL: source SQL:
CREATE TABLE advm.t2 (c money[])
                             ^
HINT: You have attempted to use a feature that is not yet implemented.
See: https://go.crdb.dev/issue-v/41578/v26.2
Failed running "sql"
RC=1
```

A name listed here that the target does not have costs the shadowed user type its qualifier, which is how that column planned before #1138, and the replay then fails **loudly** at exit 1. A name missing from the list retypes a live column and reports success, which is the YugabyteDB catalog above. Only the second is a defect. The six CockroachDB names the list lacks leave #1138's collision open there for those six names, exactly the way it is open for any name not listed -- name by name, never wholesale -- and they are named in the source comment rather than left for the next reader to find.

**And the row that read as approval is gone.** `TestQualifyDeclaredUserTypesKeepsUnmeasuredDialectsUnchanged` was the only test on the dialect axis. It used ClickHouse and asserted `advm.money[]`, so it pinned the unguarded answer, and applying the family fix left `go test ./... -count=1` at exit 0. Two tests replace it:

- `TestQualifyDeclaredUserTypesGuardsEveryPostgresFamilySpelling` reads the spellings out of `platform.NormalizeDialect`'s own switch body (the same extraction `TestAcceptedSpellings_ExtractionControls` already guards), keeps the ones `platform.IsPostgresFamily` answers true for, and asserts none of them retypes the built-in column. That is 13 spellings, aliases included, and a family member added later joins the sweep with no edit here. It carries a `qt.Contains` row for each of the four canonical names so an empty extraction cannot make it pass vacuously.
- `TestQualifyDeclaredUserTypesLeavesNonPostgresTargetsToTheirOwnCatalog` is the non-interference control, and it is a decision rather than an approval: on both engines it names, the declaration is the column's only possible meaning, and that was measured rather than assumed. MySQL 9.7.1 answers `SELECT CAST(1 AS money)` with `ERROR 1064 (42000)` at exit 1 while answering `SELECT CAST(1 AS decimal(12,2))` with `1.00` at exit 0; ClickHouse 24.8.14.39 answers `SELECT name FROM system.data_type_families WHERE lower(name) IN ('money','decimal','uuid')` with `Decimal` and `UUID` and nothing else. Both queries carry their control terms so an empty answer cannot be read as an absent type when it is really a broken query.

## The scalar spelling of an enum stays with #1276

`handleEnumTypes` re-points a bare enum name and is deliberately left unguarded, so this half of the collision is referred rather than closed. That is a decision, and it is measured.

Source: `CREATE SCHEMA adve; CREATE TYPE adve.money AS ENUM ('lo','hi');` and a table with `builtin_col money`, `enum_col adve.money`, `builtin_arr money[]`, `enum_arr adve.money[]`. The inspected document's table block, written by a `ptah-compat` built from this revision:

```
table "t" {
  schema = schema.adve
  column "builtin_arr" {
    type = sql("money[]")
    null = true
  }
  column "builtin_col" {
    type = enum.money
    null = true
  }
  column "enum_arr" {
    type = sql("adve.money[]")
    null = true
  }
  column "enum_col" {
    type = enum.money
    null = true
  }
  column "id" {
    type = integer
    null = true
  }
}
```

`builtin_col` and `enum_col` are the same string. The renderer resolves a column type against the declared enum blocks, so by the time a name reaches `handleEnumTypes` the two columns are indistinguishable and a guard there could only move which of them is wrong -- while on the annotation path it would be a plain regression, because `type="money"` beside a declared enum `money` is an author naming their own type. The array spelling has no such problem: the catalog keeps `money[]` and `adve.money[]` apart, and the read did too.

Planned into a fresh database and replayed at exit 0 on PostgreSQL 17.10:

```
$ catalog(wfa65_enum, adve, t)              # source
   column    |    ftype     | type_schema | typtype
-------------+--------------+-------------+---------
 builtin_arr | money[]      | pg_catalog  | b
 builtin_col | money        | pg_catalog  | b
 enum_arr    | adve.money[] | adve        | b
 enum_col    | adve.money   | adve        | e
 id          | integer      | pg_catalog  | b
(5 rows)

$ catalog(wfa65_enum_dst, adve, t)          # replayed from this revision's inspect
   column    |    ftype     | type_schema | typtype
-------------+--------------+-------------+---------
 builtin_arr | money[]      | pg_catalog  | b
 builtin_col | adve.money   | adve        | e
 enum_arr    | adve.money[] | adve        | b
 enum_col    | adve.money   | adve        | e
 id          | integer      | pg_catalog  | b
(5 rows)
```

`builtin_arr` is repaired and `builtin_col` is left exactly as #1276 left it. `TestFromDatabaseKeepsTheScalarEnumHalfWithIssue1276` pins both, so the split cannot drift silently in either direction.

## The two boundaries, enumerated

**Blocks.** `internal/atlashclrender` writes nine schema-scoped block types. Two reached the read's-schema fallback; seven wrote the attribute only when the object already carried one. The diff between the two inspect documents is exactly seven added lines:

```
 sequence "seq1" {
+  schema = schema.wf1138s
 domain "positive_int" {
+  schema = schema.wf1138s
 composite "addr" {
+  schema = schema.wf1138s
 range "numrng" {
+  schema = schema.wf1138s
 function "f" {
+  schema = schema.wf1138s
 view "v" {
+  schema = schema.wf1138s
 materialized "mv" {
+  schema = schema.wf1138s
```

(`enum` and `table` already carried it -- #1276. Not schema-scoped, and unchanged: `extension`, `role`, `trigger`, `policy`, `data`.)

**Column type references.** Four user-type kinds times two spellings is eight cells. One was already right -- the scalar spelling of an enum, from #1276. `QualifyDeclaredUserTypes` closes the other seven.

An earlier revision of this description ended that paragraph with "and `namesABuiltInType` keeps all eight away from a column that never named a user type at all." It keeps **seven**. The eighth cell -- enum, scalar -- is the one the section above refers to #1276, and on this revision a built-in column is still retyped there at exit 0: the inspect writes `column "builtin_col" { type = enum.money }` for a column whose real type is `money | pg_catalog | b`, and the replayed catalog reads `adve.money | adve | e`. Both are quoted in that section, from runs on this tree. Seven of the eight cells are closed against a shadow name, and the eighth is named, pinned and open.

## Both directions, on both control documents

The read direction is the broken one. Parse-and-re-render is the control, and an earlier revision of this description overstated it: the sentence held only for the document that revision chose, whose `domain` and `composite` blocks declare no schema. Measured on two hand-written documents, each planned by a binary with the pass removed and by this branch.

*Declarations carrying no schema* -- the original control:

```
$ diff -u ctl_schemaless_nopass.sql ctl_schemaless_fixed.sql
@@
   "dom_scalar" positive_int NOT NULL,
   "dom_array" positive_int[] NOT NULL,
   "comp_scalar" addr NOT NULL,
-  "enum_array" mood[] NOT NULL,
+  "enum_array" public.mood[] NOT NULL,
   "builtin_col" money NOT NULL
 );
```

Three schemaless declarations untouched; the one line that moves is the enum the author *did* give `schema = schema.public`.

*Declarations carrying `schema = schema.app`* -- the normal Atlas style, and the style the pinned binary requires for `enum` blocks:

```
$ diff -u ctl_schemaful_nopass.sql ctl_schemaful_fixed.sql
@@
 CREATE TABLE "app"."t" (
-  "dom_scalar" positive_int NOT NULL,
-  "dom_array" positive_int[] NOT NULL,
-  "comp_scalar" addr NOT NULL,
-  "enum_array" mood[] NOT NULL,
+  "dom_scalar" app.positive_int NOT NULL,
+  "dom_array" app.positive_int[] NOT NULL,
+  "comp_scalar" app.addr NOT NULL,
+  "enum_array" app.mood[] NOT NULL,
   "builtin_col" money NOT NULL
 );
```

Every user-type column moves. So the accurate statement is narrower than "the control stays put": a declaration that names **no** schema is never given one, and a declaration that names one has its columns pointed at it. Both spellings are equivalent to what the document already said, and `builtin_col` stays `money` in both -- the guard holding on the control documents too.

## Oracle parity

The question is narrow: can the `schema` attribute this change adds to seven block types move the pinned community binary from exit 0 to exit 1? The conclusion has survived every revision -- no such case was found -- but the stated basis has been wrong twice, and this revision replaces it with a measurement that discriminates.

The first revision measured documents the binary already refuses at `domain.check` and `function.arg.type`, so both sides exited 1 for a reason unrelated to the change. The second replaced that with a document the binary **accepts** at exit 0 with and without the attribute, and concluded "the binary accepted both documents, so the attribute was actually exercised rather than shadowed by an earlier refusal." Accepting is not exercising. Six of the seven blocks never appear in that binary's output at all, so acceptance on its own is equally consistent with the block -- and the attribute inside it -- being discarded before anything looks at it.

Everything below uses `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas` by absolute path, which self-reports:

```
$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas version
atlas community version v1.3.0
https://github.com/ariga/atlas/releases/tag/v1.3.0
To download an official version, visit: https://atlasgo.io/getting-started#installation
RC=0
```

The document under test is the one `ptah-compat` now writes, not a hand-written stand-in. A throwaway PostgreSQL 17.10 was started for this section (`postgres:17.10`, published on 16471) and seeded with one schema holding a sequence, a domain, a composite, a range, an enum, a table, a function, a view and a materialized view:

```
$ ./.wfbin/ptah-compat schema inspect --url "postgres://postgres:pw@localhost:16471/wfa65_hcl?sslmode=disable&search_path=wf1138s" --dev-url "postgres://postgres:pw@localhost:16471/wfa65_dev?sslmode=disable" > .wfscratch/inspected.hcl
warning: extensions.plpgsql: omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses a postgres schema file that declares any extension block, and one of them makes the whole document unreadable to it; set PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 to keep every block Ptah models
warning: sequences.seq1: omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses a postgres schema file that declares any sequence block, and one of them makes the whole document unreadable to it; set PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 to keep every block Ptah models
```

The without-attribute control is that document with the added line deleted from the six blocks it appears in, by a sed script committed to no tree and shown here in full:

```
$ cat .wfscratch/strip.sed
/^domain "positive_int" {$/,/^}$/{/  schema = schema.wf1138s/d;}
/^composite "addr" {$/,/^}$/{/  schema = schema.wf1138s/d;}
/^range "numrng" {$/,/^}$/{/  schema = schema.wf1138s/d;}
/^function "f" {$/,/^}$/{/  schema = schema.wf1138s/d;}
/^view "v" {$/,/^}$/{/  schema = schema.wf1138s/d;}
/^materialized "mv" {$/,/^}$/{/  schema = schema.wf1138s/d;}

$ sed -f .wfscratch/strip.sed .wfscratch/inspected.hcl > .wfscratch/inspected_nosch.hcl
$ diff -u .wfscratch/inspected_nosch.hcl .wfscratch/inspected.hcl
--- .wfscratch/inspected_nosch.hcl
+++ .wfscratch/inspected.hcl
@@ -7,16 +7,19 @@
 }

 domain "positive_int" {
+  schema = schema.wf1138s
   type = sql("integer")
 }

 composite "addr" {
+  schema = schema.wf1138s
   field "street" {
     type = sql("text")
   }
 }

 range "numrng" {
+  schema = schema.wf1138s
   subtype = sql("numeric")
 }

@@ -34,6 +37,7 @@
 }

 function "f" {
+  schema = schema.wf1138s
   lang = "SQL"
   return = "integer"
   security = "INVOKER"
@@ -42,10 +46,12 @@
 }

 view "v" {
+  schema = schema.wf1138s
   as = " SELECT id\n   FROM t;"
 }

 materialized "mv" {
+  schema = schema.wf1138s
   as = " SELECT id\n   FROM t;"
 }

DIFF_RC=1
```

Fed to the binary, the two documents are indistinguishable:

```
$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas schema inspect --url "file://.wfscratch/inspected.hcl" --dev-url "postgres://postgres:pw@localhost:16471/wfa65_dev?sslmode=disable&search_path=public"
table "t" {
  schema = schema.wf1138s
  column "id" {
    null = true
    type = integer
  }
}
enum "mood" {
  schema = schema.wf1138s
  values = ["sad", "ok"]
}
schema "wf1138s" {
  comment = "standard public schema"
}
ORACLE_FULL_RC=0

$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas schema inspect --url "file://.wfscratch/inspected_nosch.hcl" --dev-url "postgres://postgres:pw@localhost:16471/wfa65_dev?sslmode=disable&search_path=public"
table "t" {
  schema = schema.wf1138s
  column "id" {
    null = true
    type = integer
  }
}
enum "mood" {
  schema = schema.wf1138s
  values = ["sad", "ok"]
}
schema "wf1138s" {
  comment = "standard public schema"
}
ORACLE_BEFORE_RC=0
```

That is where the previous revision stopped, and on its own it proves nothing: the output carries `table`, `enum` and `schema` and **none of the six blocks the diff touched**. So two questions have to be answered separately.

**Is the attribute reached at all?** Yes, and this is the control that discriminates. Point the block's own `schema` attribute at a schema the document does not declare, one block per document, each produced by one sed range substitution verified to have changed exactly one line (`grep -c nosuchschema` returns 1 for each of the nine files):

```
$ sed '/^domain "positive_int" {$/,/^}$/ s/schema = schema.wf1138s/schema = schema.nosuchschema/' .wfscratch/inspected.hcl > .wfscratch/undef_domain.hcl
$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas schema inspect --url "file://.wfscratch/undef_domain.hcl" --dev-url "postgres://postgres:pw@localhost:16471/wfa65_dev?sslmode=disable&search_path=public"
Error: .wfscratch/undef_domain.hcl:10,18-31: Unsupported attribute; This object does not have an attribute named "nosuchschema".
UNDEF_domain_RC=1
```

Every one of the seven changed block types answers the same way, and so do the two blocks that already carried the attribute, which are the positive controls:

| block | document | binary's answer | rc |
|---|---|---|---|
| `domain` | `undef_domain.hcl` | `:10,18-31: Unsupported attribute; This object does not have an attribute named "nosuchschema".` | 1 |
| `composite` | `undef_composite.hcl` | `:15,18-31:` same message | 1 |
| `range` | `undef_range.hcl` | `:22,18-31:` same message | 1 |
| `function` | `undef_function.hcl` | `:40,18-31:` same message | 1 |
| `view` | `undef_view.hcl` | `:49,18-31:` same message | 1 |
| `materialized` | `undef_materialized.hcl` | `:54,18-31:` same message | 1 |
| `sequence` | `undef_sequence.hcl` | `:13,18-31:` same message | 1 |
| `table` (control) | `undef_table.hcl` | `:32,18-31:` same message | 1 |
| `enum` (control) | `undef_enum.hcl` | `:27,18-31:` same message | 1 |

So the reference this change writes is resolved inside all seven blocks: an unresolvable one is refused at exit 1, a resolvable one is accepted at exit 0. That is the discrimination the previous revision's "it accepted both documents" did not have -- and it is the discrimination that matters for parity rule (a), because a value that must resolve and does resolve cannot be the reason a run exits 1.

A weaker control was tried first and is recorded because it does **not** discriminate: inserting a nonsense attribute (`bogus_attr = "zzz"`) into the `domain` block leaves the binary at exit 0 with identical output -- but inserting the same line into the `table` block, which the binary certainly models, also leaves it at exit 0 with identical output. The binary ignores unknown attribute NAMES everywhere, so that control cannot separate "block discarded" from "block parsed". Only an unresolvable reference can.

**Does the attribute have an effect?** For six of the seven, no -- and that is the second half of the honest answer. With a second schema declared and the block pointed at it (dev-url database-scoped, because a two-schema document is refused against a schema-limited one):

```
$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas schema inspect --url "file://.wfscratch/two_domain.hcl" --dev-url "postgres://postgres:pw@localhost:16471/wfa65_dev?sslmode=disable"
table "t" {
  schema = schema.wf1138s
  column "id" {
    null = true
    type = integer
  }
}
enum "mood" {
  schema = schema.wf1138s
  values = ["sad", "ok"]
}
schema "advn" {
}
schema "wf1138s" {
}
TWO_DOMAIN_RC=0

$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas schema inspect --url "file://.wfscratch/two_table.hcl" --dev-url "postgres://postgres:pw@localhost:16471/wfa65_dev?sslmode=disable"
table "t" {
  schema = schema.advn
  column "id" {
    null = true
    type = integer
  }
}
enum "mood" {
  schema = schema.wf1138s
  values = ["sad", "ok"]
}
schema "advn" {
}
schema "wf1138s" {
}
TWO_TABLE_RC=0
```

The `table` block moves to `schema.advn`; the `domain` block does not materialize in either. So the binary resolves the reference in a `domain` block and then models nothing from that block, which is a different statement from "it accepted the document" and is the one that is true.

**`sequence` is refused either way, for its own reason.** With `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` the sequence block is kept, and the binary refuses the document with the attribute and without it, identically:

```
$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas schema inspect --url "file://.wfscratch/inspected_all.hcl" --dev-url "postgres://postgres:pw@localhost:16471/wfa65_dev?sslmode=disable&search_path=public"
Error: postgres: sequences are not supported by this version. Use: https://atlasgo.io/getting-started
SEQ_WITH_RC=1

$ sed '/^sequence "seq1" {$/,/^}$/{/schema = schema.wf1138s/d;}' .wfscratch/inspected_all.hcl > .wfscratch/seq_nosch.hcl
$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas schema inspect --url "file://.wfscratch/seq_nosch.hcl" --dev-url "postgres://postgres:pw@localhost:16471/wfa65_dev?sslmode=disable&search_path=public"
Error: postgres: sequences are not supported by this version. Use: https://atlasgo.io/getting-started
SEQ_WITHOUT_RC=1
```

That is why `ptah-compat` omits the block by default and says so on stderr, which is behavior this branch does not change.

**Conclusion, with the basis it actually rests on.** Across the nine block types measured -- the seven this change touches plus `table` and `enum` as controls -- the added `schema` reference is resolved by the pinned binary and accepted when it resolves. No document in this section moves from that binary's exit 1 to `ptah-compat`'s exit 0. The sequence document is exit 1 on that binary and is omitted by `ptah-compat` by default, so it does not either.

## Mutants

Every new test was watched red under a cheaper wrong implementation and green when restored. Each mutant is a version somebody would plausibly write, not a deletion.

| # | mutant | command | result |
|---|---|---|---|
| A | `schemaFor` returns the object's schema verbatim -- the rule the seven sites used | `go test ./internal/atlashclrender/ -run 'TestRenderInspectedAttributesEverySchemaScopedBlock\|TestRenderInspectedKeepsASchemaTheReaderReported' -count=1` | rc 1, **all 9** rows of the positive table red; the reported-schema control stayed green |
| B | `renderViews` alone reverted to `schemaNameFromQualified(view.Name)` | same | rc 1, **exactly the `a view` row** red -- the table is site-discriminating |
| H | the built-in lookup compares the name verbatim instead of case folding | `go test ./internal/convert/fromschema/ ./migration/planner/ -count=1` | rc 1, **only** the upper-case row red |
| K | the built-in set is the catalog list without the grammar spellings | same | rc 1, **only** the `serial` row red |
| I | the guard applied to the scalar map only -- "an array bracket already means user type" | same | rc 1, **exactly the four array rows** red, plus both rendered-DDL array rows; every scalar row green |
| J | the guard applied to the domains loop only -- the kind the issue named | same | rc 1, **exactly the composite, range and enum rows** red; both domain rows green, planner test green |
| N | the guard extended to `handleEnumTypes` -- the decision above, reversed | same | rc 1, **only** the pinned #1276 row red |
| P | `builtInTypeNamesFor` keyed on `platform.NormalizeDialect(dialect) != platform.Postgres` -- the previous revision's rule, still compiling | same | rc 1, **only** the family sweep red, naming exactly the ten non-postgres spellings: `cloudspanner cockroach cockroachdb crdb google-spanner google_spanner spanner ysql yugabyte yugabytedb`. The three postgres spellings and both non-family rows stayed green |
| Q | one vocabulary for every dialect: `_ = platform.IsPostgresFamily(dialect); return postgresBuiltInTypeNames` | same | rc 1, **exactly the two non-family rows** red (`mysql`, `clickhouse`, both `got "money[]" want "advm.money[]"`); the family sweep green |

I and J are the pair that makes the kind/spelling enumeration load bearing: one separates the two spellings, the other separates the four kinds, and neither is caught by the row the other one catches. P and Q are the same pair on the dialect axis: P is the guard too narrow, Q is the guard too wide, and no single row catches both. N is what keeps the referred half from being closed by accident.

Mutant L from the previous revision -- "one type vocabulary for every dialect, no `NormalizeDialect` lookup" -- is superseded by Q. Its named row was the ClickHouse assertion in `TestQualifyDeclaredUserTypesKeepsUnmeasuredDialectsUnchanged`, which no longer exists. The mutant table an earlier revision carried for the user-type pass (C through G) was already superseded by H through N.

P and Q were run on the branch tree with the fix applied, each mutant edited in and reverted in place; the rest were run by the revision that introduced them.

Restored, the three packages are green on the merged tree:

```
$ go test ./migration/planner/ ./internal/convert/fromschema/ ./internal/atlashclrender/ -count=1; echo "GO_TEST_RC=$?"
ok  	go.5x5.cz/ptah/migration/planner	6.777s
ok  	go.5x5.cz/ptah/internal/convert/fromschema	6.253s
ok  	go.5x5.cz/ptah/internal/atlashclrender	5.976s
GO_TEST_RC=0
```

Both call sites of the pass remain separately covered by `TestFromDatabaseQualifiesDeclaredUserTypes` and `TestGenerateSchemaDiffSQLQualifiesDeclaredUserTypes`.

## Three existing assertions changed, and why

`TestRenderedRelationTargetRoundTrips` (view, materialized), `TestRenderedTriggerOnAViewRoundTrips` and the second rows of `TestRenderedRelationTargetKeepsItsSchema` / `TestRenderedSequenceTargetKeepsItsSchema` expected a bare `v` / `mv` / `order_seq` from an **inspected** render. The table target in the same table always came back `public.t`. Those rows were pinning the asymmetry, not the rule; they now expect the qualified spelling, and the grant written into the document is separated from the one expected back so each row asserts the restore rather than echoing itself.

## Out of scope, named

**A view or materialized view body** still carries unqualified relation references, so the view statements of a full document fail on replay:

```
CREATE VIEW "wf1138s"."v" AS SELECT id FROM t;
  ->  ERROR:  relation "t" does not exist
```

Same class -- the read's implicit schema not surviving -- but not the same fix. The body is opaque SQL text from `pg_get_viewdef`, which qualifies relative to the reading connection's `search_path`; correcting it means either resolving names inside arbitrary SQL or reading the definition under a forced `search_path`, and the second changes the body string `migration/schemadiff` compares against Go-annotation views. That needs its own measurement, so it is not claimed here, and the applied section above is measured on a source without views precisely so the residual is not smuggled into an exit code.

**The scalar spelling of an enum** is the eighth cell, and it stays with #1276. It is measured in its own section above rather than left implicit.

**The six CockroachDB catalog names this vocabulary lacks** -- `box2d`, `citext`, `geography`, `geometry`, `ltree`, `vector` -- keep #1138's collision open on that engine for those six names. Adding them would be adding one engine's catalog to another's list, and `citext`, `ltree`, `geometry` and `vector` are extension types on PostgreSQL rather than `pg_catalog` names, so the provenance of the list would stop being "one query on one server". A per-dialect vocabulary for the family is the real answer and is not attempted here.

**The conformance fixtures #1138 names cannot move from this branch, and this is the reason rather than an assertion.** The mechanism to move them is real: `atlascompat/atlascompat.go:75` returns `fromschema.FromDatabase(...)`, which this branch routes through `QualifyDeclaredUserTypes`, and the harness consumes exactly that. Measured on the fixture's own input -- section `1.hcl` of `third_party/atlas/.../internal/integration/testdata/postgres/column-enum-array.txtar`, with `$db` substituted -- planned two ways:

```
pass removed    "statuses" status[]
this branch     "statuses" script_column_enum_array.status[]
```

and the fixture's own `want` in `1.sql`, `3.sql` and `4.sql` is `script_column_enum_array.status[]`. So the planned type does change, in the direction of the fixture.

The rows still cannot move, because the harness does not consume this branch. `stokaro/ptah-atlas-conformance` depends on `go.5x5.cz/ptah v0.2.1-0.20260807050200-47e1bee26ad2` as a published module version, with no `replace` in its `go.mod`, no `go.work` beside it, and `GOWORK=off` on every probe target in its Makefile. Nothing here reaches those rows until that pin advances, which is why running the harness today would measure the pinned module and say nothing about this change.

## Gates

Each run on the merged tree described under "Branch base" -- master `1fd469be` carrying this branch's version of every file it touches -- and each exit code read directly, never through a pipe.

```
go build ./...                                 0
go vet ./...                                   0
go vet -tags integration ./integration/...     0
go test ./... -count=1                         0
go tool qtlint ./...                           0
golangci-lint run ./...                        0   (0 issues)
scripts/check-test-style.sh                    0   (175 conditional groups, 42 white-box files)
scripts/check-public-api.sh                    0
scripts/check-public-api-snapshot.sh           0
scripts/check-public-api-released.sh           0
```

Every `check:*` in `docs/site/package.json`, all exit 0, with the work each reported:

```
check:exit-codes             OK (60 reference rows)
check:exit-codes:selftest    OK
check:core-doc-links         OK (7 protected core references)
check:page-health            OK (59 sidebar entries)
check:links                  OK (60 pages, 60 routes, 616 heading anchors)
check:links:selftest         OK
check:redirects              OK (30 redirects)
check:redirects:selftest     OK
check:style                  OK (100 documentation files)
check:style:selftest         OK (16 rule assertions via analyze())
check:limitations            OK (1 governed page(s))
check:limitations:selftest   OK (7 assertions via analyze())
check:responsive             OK (60 routes x 2 viewports, cells within 8 lines)
check:responsive:selftest    OK (overflow, wide-table, tall-cell and unstyled-page guards verified)
```

`check:responsive` needs `npm ci` and `npm run build` in the worktree before it measures anything; the row above is from the run after that, which reports the 60 routes it actually walked.

`go test ./... -count=1` failed once before this set, in `cmd/viz`, on `TestSVGReportsGraphvizStderrOnFailure` after a 10.01s wait. That package passes on its own (`go test ./cmd/viz/ -count=1`, rc 0) and the full suite passes on a rerun; the test is timing sensitive under load and touches nothing this branch changes.