### PR TITLE
Capability probe matrix: measure each preset against the server it describes (#1339)

### DIFF
--- a/cmd/capability-probe/main.go
+++ b/cmd/capability-probe/main.go
@@ -1,0 +1,82 @@
+// Command capability-probe measures a live database server against the
+// capability preset Ptah hands out for it.
+//
+// It answers one question per capability: does the server actually behave the
+// way core/platform/capability says it does? A disagreement exits non-zero. So
+// does a run that decided nothing — a probe that skipped every row must not
+// read as a probe that passed every row.
+//
+//	capability-probe --db-url postgres://user:pw@localhost:5432/db
+//	capability-probe --db-url mysql://root:pw@localhost:3306/db --evidence
+//	capability-probe --list-cells
+//
+// Wiring this into CI is stokaro/ptah#1341 and is deliberately not done here.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"go.5x5.cz/ptah/internal/capabilityprobe"
+)
+
+func main() {
+	if err := newCommand().Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "capability-probe: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newCommand() *cobra.Command {
+	var (
+		dbURL     string
+		listCells bool
+		evidence  bool
+	)
+	cmd := &cobra.Command{
+		Use:           "capability-probe",
+		Short:         "Measure a live server against the capability preset Ptah gives it",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if listCells {
+				capabilityprobe.WriteCells(cmd.OutOrStdout())
+				return nil
+			}
+			if dbURL == "" {
+				return fmt.Errorf("--db-url is required (or --list-cells)")
+			}
+			var extra []sectionWriter
+			if evidence {
+				extra = append(extra, capabilityprobe.WriteEvidence)
+			}
+			return probe(cmd.Context(), cmd.OutOrStdout(), dbURL, extra)
+		},
+	}
+	cmd.Flags().StringVar(&dbURL, "db-url", "", "URL of the live server to probe")
+	cmd.Flags().BoolVar(&listCells, "list-cells", false, "print the matrix cell list and exit")
+	cmd.Flags().BoolVar(&evidence, "evidence", false, "print every statement executed and the server's answer")
+	return cmd
+}
+
+// sectionWriter renders one optional section of the report.
+type sectionWriter func(io.Writer, *capabilityprobe.Report)
+
+func probe(ctx context.Context, out io.Writer, dbURL string, extra []sectionWriter) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	report, err := capabilityprobe.Run(ctx, dbURL)
+	if err != nil {
+		return err
+	}
+	capabilityprobe.WriteReport(out, report)
+	for _, section := range extra {
+		section(out, report)
+	}
+	return report.Err()
+}

--- a/internal/capabilityprobe/cells.go
+++ b/internal/capabilityprobe/cells.go
@@ -1,0 +1,326 @@
+package capabilityprobe
+
+import (
+	"fmt"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
+)
+
+// Refinement records HOW capability.ResolveServerVersion reaches a cell's
+// preset. It is declared here as data rather than read back from
+// capability.VersionResolution, because that struct cannot tell the three
+// mechanisms apart:
+//
+//   - a banner-matched dialect reports VersionSpecific=true without a version
+//     ever being parsed, so it is indistinguishable from a successful ladder
+//     match;
+//   - a dialect with no ladder reports VersionSpecific=false, which is exactly
+//     what an unparseable banner on a laddered dialect reports.
+//
+// Deriving undecidability from the returned struct would therefore record a
+// CockroachDB v26.2.5 as an agreeing version-specific match and a
+// cleanly-parsed SQL Server as an unreadable banner.
+type Refinement string
+
+const (
+	// RefinedByVersion: the dialect has a version ladder and the parsed
+	// version selects which arm of it answers. Only these lines can be
+	// measured per line, because only here does the version change the answer.
+	RefinedByVersion Refinement = "version-ladder"
+
+	// RefinedByBanner: the preset is selected by a substring of the banner
+	// before any version is parsed, so every release of the engine receives
+	// the same set and no observation can be attributed to one line rather
+	// than another.
+	RefinedByBanner Refinement = "banner-substring"
+
+	// NotRefined: the version is parsed and then discarded; the dialect
+	// default is returned for every release.
+	NotRefined Refinement = "dialect-default"
+)
+
+// Cell is one release line the capability matrix covers.
+//
+// Cells is the ONLY place a line is declared. Adding a release line is one
+// literal below and no code change anywhere else: the probe reads the line to
+// match a live server, the preset to compare against, and the refinement to
+// decide whether an observation can be attributed to this line at all.
+type Cell struct {
+	// Dialect is the normalized platform dialect this line belongs to.
+	Dialect string
+
+	// Line is the release line in the numbering the CORRECTED version parse
+	// produces (see version.go), not the vendor's marketing name. A server
+	// matches when its parsed version begins with these components, so "17"
+	// matches every PostgreSQL 17.x and "10.11" matches only MariaDB 10.11.x.
+	Line string
+
+	// Label is the line's human name where it differs from Line, for example
+	// "SQL Server 2025" for line "17.0". Empty means Line reads well enough.
+	Label string
+
+	// Preset is the capability preset this line claims, or nil when Ptah has
+	// no measured preset for the line yet.
+	//
+	// A nil Preset is the declared gap that issue #916 is about, and it is
+	// what makes "adding a cell and adding a preset entry are the same
+	// change" enforceable: the probe refuses to report success against a
+	// server on a nil-preset line, naming the line instead. Filling this in
+	// is what promotes a line to measured.
+	Preset func() capability.Capabilities
+
+	// PresetName names Preset for the report. It is written out rather than
+	// recovered by comparing sets, because MySQLLegacy and MariaDBLegacy are
+	// byte-identical and a set comparison would label MariaDB rows MySQL.
+	PresetName string
+
+	// Refinement says how the preset is reached. Anything other than
+	// RefinedByVersion makes every capability row on this line UNDECIDABLE:
+	// the observation is still taken and printed, but it cannot be credited
+	// to this line rather than to the line's siblings, which receive the
+	// identical set.
+	Refinement Refinement
+
+	// Image reproduces the line locally, empty when there is no container for
+	// it.
+	Image string
+
+	// Note records why a line is shaped the way it is: a missing preset, a
+	// missing server, a version axis that does not exist.
+	Note string
+}
+
+// Match reports whether a parsed server version falls on this cell's line.
+// The comparison is component-wise on the dotted line, so "17" accepts every
+// 17.x and "10.11" accepts only 10.11.x.
+func (c Cell) Match(v Version) bool {
+	want := strings.Split(c.Line, ".")
+	got := v.Components()
+	if len(want) > len(got) {
+		return false
+	}
+	for i, component := range want {
+		if got[i] != component {
+			return false
+		}
+	}
+	return true
+}
+
+// Measured reports whether the line claims a capability preset at all.
+func (c Cell) Measured() bool {
+	return c.Preset != nil
+}
+
+// String renders the cell as "dialect line" plus its label.
+func (c Cell) String() string {
+	if c.Label == "" {
+		return c.Dialect + " " + c.Line
+	}
+	return fmt.Sprintf("%s %s (%s)", c.Dialect, c.Line, c.Label)
+}
+
+// Cells is the capability matrix: every release line Ptah covers, in one
+// place.
+//
+// The lines are the vendor-supported ones, checked against the vendors on
+// 2026-08-09, plus any line whose preset Ptah still ships — a preset with no
+// cell is a claim nothing in this repository can measure.
+//
+// Four presets still have no cell, and each absence is deliberate:
+//
+//   - MySQLLegacy, MySQL8016 and MySQL8019 describe the MySQL 8.0 line, which
+//     left vendor support on 2026-04-30 and is not one line in any case: the
+//     three presets split it at 8.0.16 and 8.0.19, so a single "8.0" cell
+//     could not name one preset. Giving them cells means three cells keyed on
+//     the patch component, which the Line matcher already supports.
+//   - MariaDBLegacy describes MariaDB before 10.2, whose newest release left
+//     support in 2022.
+//
+// MariaDB 10.6 left community support on 2026-07-06 and is absent for that
+// reason alone.
+//
+// A nil Preset is a line the matrix wants and Ptah has not measured. Those are
+// the cells PRs bumping a container tag are waiting on, and probing a server
+// on one of them fails rather than reporting a green row against a preset
+// chosen by saturation.
+var Cells = []Cell{
+	// PostgreSQL: five supported majors (postgresql.org/support/versioning,
+	// read 2026-08-09 — 18.4, 17.10, 16.14, 15.18, 14.23; the project does not
+	// use the term LTS). Postgres16's own doc covers 14 through 16.
+	{
+		Dialect: platform.Postgres, Line: "18",
+		Preset: nil, PresetName: "",
+		Refinement: RefinedByVersion, Image: "postgres:18",
+		Note: "no measured PostgreSQL 18 preset: newestMeasuredPostgresMajor is 17, so an 18 server resolves saturated onto Postgres17",
+	},
+	{
+		Dialect: platform.Postgres, Line: "17",
+		Preset: capability.Postgres17, PresetName: "Postgres17",
+		Refinement: RefinedByVersion, Image: "postgres:17",
+	},
+	{
+		Dialect: platform.Postgres, Line: "16",
+		Preset: capability.Postgres16, PresetName: "Postgres16",
+		Refinement: RefinedByVersion, Image: "postgres:16",
+	},
+	{
+		Dialect: platform.Postgres, Line: "15",
+		Preset: capability.Postgres16, PresetName: "Postgres16",
+		Refinement: RefinedByVersion, Image: "postgres:15",
+	},
+	{
+		Dialect: platform.Postgres, Line: "14",
+		Preset: capability.Postgres16, PresetName: "Postgres16",
+		Refinement: RefinedByVersion, Image: "postgres:14",
+		Note: "final PostgreSQL 14 release is November 2026",
+	},
+	{
+		Dialect: platform.Postgres, Line: "13",
+		Preset: capability.Postgres13, PresetName: "Postgres13",
+		Refinement: RefinedByVersion, Image: "postgres:13",
+		Note: "past its final vendor release; the cell exists because Ptah still ships a Postgres13 preset " +
+			"and a preset with no cell is a claim nothing can measure. The preset's doc covers PostgreSQL " +
+			"12 as well and there is no 12 cell: 12 was never probed, so a 12 server correctly falls off " +
+			"the matrix rather than borrowing this line's result",
+	},
+
+	// MySQL: the two LTS lines (endoflife.date/api/mysql.json, read
+	// 2026-08-09 — 9.7 latest 9.7.2 EOL 2034-04-21, 8.4 latest 8.4.11 EOL
+	// 2032-04-30; both flagged LTS).
+	{
+		Dialect: platform.MySQL, Line: "9.7",
+		Preset: capability.MySQL84, PresetName: "MySQL84",
+		Refinement: RefinedByVersion, Image: "mysql:9.7",
+	},
+	{
+		Dialect: platform.MySQL, Line: "8.4",
+		Preset: capability.MySQL84, PresetName: "MySQL84",
+		Refinement: RefinedByVersion, Image: "mysql:8.4",
+	},
+
+	// MariaDB: the maintained LTS lines (mariadb.org/about/maintenance-policy,
+	// read 2026-08-09 — 11.8 EOL 2028-06-04, 11.4 EOL 2029-05-29, 10.11 EOL
+	// 2028-02-16) plus 12.3, which the vendor KB names as the latest
+	// long-term stable series.
+	{
+		Dialect: platform.MariaDB, Line: "12.3",
+		Preset: nil, PresetName: "",
+		Refinement: RefinedByVersion, Image: "mariadb:12.3",
+		Note: "no measured MariaDB 12 preset: newestMeasuredMariaDBMajor is 11, so a 12 server resolves saturated onto MariaDB1011",
+	},
+	{
+		Dialect: platform.MariaDB, Line: "11.8",
+		Preset: capability.MariaDB1011, PresetName: "MariaDB1011",
+		Refinement: RefinedByVersion, Image: "mariadb:11.8",
+	},
+	{
+		Dialect: platform.MariaDB, Line: "11.4",
+		Preset: capability.MariaDB1011, PresetName: "MariaDB1011",
+		Refinement: RefinedByVersion, Image: "mariadb:11.4",
+	},
+	{
+		Dialect: platform.MariaDB, Line: "10.11",
+		Preset: capability.MariaDB1011, PresetName: "MariaDB1011",
+		Refinement: RefinedByVersion, Image: "mariadb:10.11",
+	},
+
+	// ClickHouse has no version ladder: ResolveServerVersion parses the
+	// version and then discards it, so all three lines receive ClickHouse24.
+	{
+		Dialect: platform.ClickHouse, Line: "26.7",
+		Preset: capability.ClickHouse24, PresetName: "ClickHouse24",
+		Refinement: NotRefined, Image: "clickhouse/clickhouse-server:26.7",
+	},
+	{
+		Dialect: platform.ClickHouse, Line: "26.3",
+		Preset: capability.ClickHouse24, PresetName: "ClickHouse24",
+		Refinement: NotRefined, Image: "clickhouse/clickhouse-server:26.3",
+	},
+	{
+		Dialect: platform.ClickHouse, Line: "25.8",
+		Preset: capability.ClickHouse24, PresetName: "ClickHouse24",
+		Refinement: NotRefined, Image: "clickhouse/clickhouse-server:25.8",
+	},
+
+	// SQL Server lines are numbered by product version here, not by the
+	// marketing year: the year is what the shared parseVersion reads out of
+	// @@VERSION, and reading "2025" as a major version is the defect
+	// version.go corrects.
+	{
+		Dialect: platform.SQLServer, Line: "17.0", Label: "SQL Server 2025",
+		Preset: capability.SQLServer2022, PresetName: "SQLServer2022",
+		Refinement: NotRefined, Image: "mcr.microsoft.com/mssql/server:2025-latest",
+	},
+	{
+		Dialect: platform.SQLServer, Line: "16.0", Label: "SQL Server 2022",
+		Preset: capability.SQLServer2022, PresetName: "SQLServer2022",
+		Refinement: NotRefined, Image: "mcr.microsoft.com/mssql/server:2022-latest",
+	},
+	{
+		Dialect: platform.SQLServer, Line: "15.0", Label: "SQL Server 2019",
+		Preset: capability.SQLServer2022, PresetName: "SQLServer2022",
+		Refinement: NotRefined, Image: "mcr.microsoft.com/mssql/server:2019-latest",
+	},
+
+	// CockroachDB and YugabyteDB are matched on a banner substring before any
+	// version is parsed, so their lines all receive one preset.
+	{
+		Dialect: platform.CockroachDB, Line: "26.2",
+		Preset: capability.CockroachDB23, PresetName: "CockroachDB23",
+		Refinement: RefinedByBanner, Image: "cockroachdb/cockroach:v26.2.5",
+	},
+	{
+		Dialect: platform.CockroachDB, Line: "25.4",
+		Preset: capability.CockroachDB23, PresetName: "CockroachDB23",
+		Refinement: RefinedByBanner, Image: "cockroachdb/cockroach:v25.4.5",
+	},
+	{
+		Dialect: platform.YugabyteDB, Line: "2026.1",
+		Preset: capability.YugabyteDB25, PresetName: "YugabyteDB25",
+		Refinement: RefinedByBanner, Image: "yugabytedb/yugabyte:2026.1.0.0-b118",
+	},
+	{
+		Dialect: platform.YugabyteDB, Line: "2025.2",
+		Preset: capability.YugabyteDB25, PresetName: "YugabyteDB25",
+		Refinement: RefinedByBanner, Image: "yugabytedb/yugabyte:2025.2.0.0-b0",
+	},
+
+	// SQLite is not a server line. Its version is whatever the driver pinned
+	// in go.mod compiles in, so the cell matches any 3.x and the "line" is a
+	// dependency bump rather than a release a vendor supports.
+	{
+		Dialect: platform.SQLite, Line: "3",
+		Preset: capability.SQLite3, PresetName: "SQLite3",
+		Refinement: NotRefined,
+		Note:       "no container: the version is the modernc.org/sqlite amalgamation pinned in go.mod",
+	},
+
+	// Spanner is a managed service with no version axis and no local server.
+	// SpannerPostgres' own doc concedes that nothing in it was executed
+	// against a server; issue #942 is the missing container.
+	{
+		Dialect: platform.Spanner, Line: "0",
+		Preset: capability.SpannerPostgres, PresetName: "SpannerPostgres",
+		Refinement: RefinedByBanner,
+		Note:       "no Spanner server exists in this repository (stokaro/ptah#942), so no row on this line has ever been executed",
+	},
+}
+
+// CellFor returns the matrix cell a live server falls on.
+//
+// A server with no cell is a failure and not a default: it is a release line
+// the matrix does not cover, which is precisely the missing-cell signal issue
+// #916 asks for. Returning some neighboring cell would report a green matrix
+// for a line nobody declared.
+func CellFor(dialect string, v Version) (Cell, bool) {
+	normalized := platform.NormalizeDialect(dialect)
+	for _, cell := range Cells {
+		if cell.Dialect == normalized && cell.Match(v) {
+			return cell, true
+		}
+	}
+	return Cell{}, false
+}

--- a/internal/capabilityprobe/cells_test.go
+++ b/internal/capabilityprobe/cells_test.go
@@ -1,0 +1,180 @@
+package capabilityprobe_test
+
+import (
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/internal/capabilityprobe"
+)
+
+func TestCells_IsNotEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	// A matrix with no cells covers no line, and every run against it would
+	// report a line the matrix does not know. Asserting the list is populated
+	// is the same refusal the repository's shell gates make when their input
+	// list comes back empty.
+	c.Assert(len(capabilityprobe.Cells) > 0, qt.IsTrue)
+}
+
+func TestCells_AreWellFormed(t *testing.T) {
+	c := qt.New(t)
+
+	seen := map[string]bool{}
+	for _, cell := range capabilityprobe.Cells {
+		c.Run(cell.String(), func(c *qt.C) {
+			c.Assert(platform.NormalizeDialect(cell.Dialect), qt.Equals, cell.Dialect,
+				qt.Commentf("a cell dialect must already be normalized or CellFor will never match it"))
+			c.Assert(cell.Line, qt.Not(qt.Equals), "")
+
+			key := cell.Dialect + "/" + cell.Line
+			c.Assert(seen[key], qt.IsFalse, qt.Commentf("two cells claim %s; the first one found would always win", key))
+			seen[key] = true
+
+			c.Assert(cell.Refinement, qt.Not(qt.Equals), capabilityprobe.Refinement(""))
+		})
+	}
+}
+
+// TestCells_MeasuredCellsNameAValidPreset checks the half of a cell a reader
+// cannot verify by eye: that PresetName describes the set Preset returns, and
+// that the set is one the registry accepts.
+func TestCells_MeasuredCellsNameAValidPreset(t *testing.T) {
+	c := qt.New(t)
+
+	named := map[string]func() capability.Capabilities{
+		"Postgres17":      capability.Postgres17,
+		"Postgres16":      capability.Postgres16,
+		"Postgres13":      capability.Postgres13,
+		"MySQL84":         capability.MySQL84,
+		"MariaDB1011":     capability.MariaDB1011,
+		"ClickHouse24":    capability.ClickHouse24,
+		"SQLite3":         capability.SQLite3,
+		"SQLServer2022":   capability.SQLServer2022,
+		"CockroachDB23":   capability.CockroachDB23,
+		"YugabyteDB25":    capability.YugabyteDB25,
+		"SpannerPostgres": capability.SpannerPostgres,
+	}
+	for _, cell := range capabilityprobe.Cells {
+		c.Run(cell.String(), func(c *qt.C) {
+			c.Assert(cell.Measured(), qt.Equals, cell.PresetName != "",
+				qt.Commentf("a cell either names a preset and has one, or names neither"))
+			for _, check := range measuredChecks(cell, named) {
+				check(c)
+			}
+		})
+	}
+}
+
+// measuredChecks returns the assertions that only apply to a cell that names a
+// preset, so the loop body above stays free of a conditional.
+func measuredChecks(cell capabilityprobe.Cell, named map[string]func() capability.Capabilities) []func(*qt.C) {
+	if !cell.Measured() {
+		return nil
+	}
+	return []func(*qt.C){
+		func(c *qt.C) {
+			build, known := named[cell.PresetName]
+			c.Assert(known, qt.IsTrue, qt.Commentf("cell names preset %q, which this test does not know", cell.PresetName))
+			c.Assert(cell.Preset(), qt.DeepEquals, build(),
+				qt.Commentf("cell names preset %q but carries a different set", cell.PresetName))
+			c.Assert(cell.Preset().Validate(), qt.IsNil)
+		},
+	}
+}
+
+func TestCellFor(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range []struct {
+		name    string
+		dialect string
+		version string
+		assert  func(c *qt.C, cell capabilityprobe.Cell, found bool)
+	}{{
+		name: "a PostgreSQL 17 patch release lands on the 17 line", dialect: platform.Postgres, version: "17.10",
+		assert: func(c *qt.C, cell capabilityprobe.Cell, found bool) {
+			c.Assert(found, qt.IsTrue)
+			c.Assert(cell.Line, qt.Equals, "17")
+			c.Assert(cell.PresetName, qt.Equals, "Postgres17")
+		},
+	}, {
+		name: "a MySQL LTS line is matched on major and minor", dialect: platform.MySQL, version: "9.7.1",
+		assert: func(c *qt.C, cell capabilityprobe.Cell, found bool) {
+			c.Assert(found, qt.IsTrue)
+			c.Assert(cell.Line, qt.Equals, "9.7")
+		},
+	}, {
+		name: "a MySQL release on no LTS line matches nothing", dialect: platform.MySQL, version: "9.6.1",
+		assert: func(c *qt.C, cell capabilityprobe.Cell, found bool) {
+			c.Assert(found, qt.IsFalse)
+			c.Assert(cell.Line, qt.Equals, "")
+		},
+	}, {
+		// The Postgres13 preset's own doc covers PostgreSQL 12 and 13, and the
+		// matrix declares only 13 because only 13 was probed. A 12 server must
+		// therefore fall off the matrix rather than borrow the 13 cell's
+		// result, or the matrix certifies a line nobody measured.
+		name: "a PostgreSQL major the matrix does not declare matches nothing", dialect: platform.Postgres, version: "12.22",
+		assert: func(c *qt.C, cell capabilityprobe.Cell, found bool) {
+			c.Assert(found, qt.IsFalse)
+		},
+	}, {
+		name:    "SQL Server matches on the product version, not the marketing year",
+		dialect: platform.SQLServer, version: "17.0.4065.4",
+		assert: func(c *qt.C, cell capabilityprobe.Cell, found bool) {
+			c.Assert(found, qt.IsTrue)
+			c.Assert(cell.Label, qt.Equals, "SQL Server 2025")
+		},
+	}, {
+		name: "the marketing year matches no SQL Server cell", dialect: platform.SQLServer, version: "2025",
+		assert: func(c *qt.C, cell capabilityprobe.Cell, found bool) {
+			c.Assert(found, qt.IsFalse)
+		},
+	}, {
+		name: "a dialect with no cells matches nothing", dialect: "nonsense", version: "1.2.3",
+		assert: func(c *qt.C, cell capabilityprobe.Cell, found bool) {
+			c.Assert(found, qt.IsFalse)
+		},
+	}} {
+		c.Run(tc.name, func(c *qt.C) {
+			version, err := capabilityprobe.ParseVersion(tc.dialect, tc.version, "")
+			c.Assert(err, qt.IsNil)
+			cell, found := capabilityprobe.CellFor(tc.dialect, version)
+			tc.assert(c, cell, found)
+		})
+	}
+}
+
+// TestCells_CoverEveryLineTheRepositoryRuns keeps the matrix honest about the
+// containers this repository actually starts: a line CI runs and the matrix
+// does not declare is a line whose preset nothing measures.
+func TestCells_CoverEveryLineTheRepositoryRuns(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range []struct {
+		dialect string
+		version string
+	}{
+		{platform.Postgres, "18.4"},
+		{platform.Postgres, "17.10"},
+		{platform.MySQL, "9.7.1"},
+		{platform.MariaDB, "10.11.18"},
+		{platform.MariaDB, "11.4.12"},
+		{platform.MariaDB, "12.3.2"},
+		{platform.CockroachDB, "26.2.5"},
+		{platform.YugabyteDB, "2026.1.0.0"},
+		{platform.SQLServer, "17.0.4065.4"},
+	} {
+		c.Run(fmt.Sprintf("%s %s", tc.dialect, tc.version), func(c *qt.C) {
+			version, err := capabilityprobe.ParseVersion(tc.dialect, tc.version, "")
+			c.Assert(err, qt.IsNil)
+			_, found := capabilityprobe.CellFor(tc.dialect, version)
+			c.Assert(found, qt.IsTrue)
+		})
+	}
+}

--- a/internal/capabilityprobe/doc.go
+++ b/internal/capabilityprobe/doc.go
@@ -1,0 +1,61 @@
+// Package capabilityprobe measures a live database server against the
+// capability preset Ptah hands out for it.
+//
+// A preset in core/platform/capability is a written claim: "a PostgreSQL 17
+// server accepts ALTER COLUMN ... SET EXPRESSION". Nothing in the build
+// executes that claim, so a preset can be wrong for years and the first
+// symptom is a user's failed migration. This package turns each claim into a
+// measurement: for one capability it emits the DDL whose acceptance the
+// capability governs, executes it against the live server, and compares what
+// the server did to what the preset promised (stokaro/ptah#1339, Tier 2 of
+// stokaro/ptah#916).
+//
+// # Three outcomes, never two
+//
+// Every row is [Agrees], [Disagrees] or [Undecidable]. A disagreement is a
+// failure, not a warning. Undecidable is a first-class answer with a mandatory
+// reason and it is NOT a synonym for agreement: a harness that folds the two
+// together reports a green matrix for capabilities nobody measured, which is
+// worse than no harness at all because it manufactures evidence. [Report.Err]
+// therefore also fails a run that decided nothing — a probe that skipped every
+// row must not read as a probe that passed every row.
+//
+// # Why the deciding statement is not always the obvious one
+//
+// Four shapes of statement decide nothing on their own, and each of them was
+// measured rather than assumed:
+//
+//   - Acceptance without enforcement. MySQL before 8.0.16 accepted a CHECK
+//     clause and ignored it, which is the entire reason
+//     [capability.CheckConstraintsEnforced] exists. DDL acceptance is
+//     identical on both sides of that boundary, so the deciding statement is a
+//     row the constraint must reject, with a row it must accept as the control
+//     that proves the rejection was the constraint talking.
+//   - Acceptance of a keyword the server parses and drops. MySQL 9.7.1 accepts
+//     CREATE MATERIALIZED VIEW and then recomputes the query on every read, so
+//     the decider inserts into the source table and re-reads: a stored result
+//     does not move.
+//   - Acceptance as a compatibility no-op. CockroachDB parses CREATE INDEX
+//     CONCURRENTLY without changing behavior. Real PostgreSQL refuses that
+//     statement inside an explicit transaction block and a keyword-only parser
+//     has no reason to, so the transaction block is the discriminator.
+//   - Acceptance of a same-spelled feature that is a different surface. MySQL
+//     9.7.1 accepts CREATE ROLE and GRANT while [capability.RoleManagement] is
+//     false for it, because that key names the PostgreSQL role surface Ptah's
+//     PostgreSQL planner gates on and no MySQL code path reads. Those keys are
+//     declared undecidable per dialect in advance, as data, in plans.go — never
+//     derived from an outcome the run did not like.
+//
+// # Isolation
+//
+// The probe does not wrap its statements in a transaction it rolls back.
+// PostgreSQL refuses CREATE INDEX CONCURRENTLY inside an explicit transaction
+// block, so transaction-based isolation would report two true capabilities as
+// false. Each run creates a throwaway namespace (a schema on the PostgreSQL
+// family, a database on the MySQL family) and drops it at the end.
+//
+// # Scope
+//
+// Adding a release line is a data change in cells.go and nothing else. Wiring
+// this into CI is stokaro/ptah#1341 and is deliberately not done here.
+package capabilityprobe

--- a/internal/capabilityprobe/experiment.go
+++ b/internal/capabilityprobe/experiment.go
@@ -1,0 +1,243 @@
+package capabilityprobe
+
+import (
+	"context"
+	"fmt"
+
+	"go.5x5.cz/ptah/core/platform/capability"
+)
+
+// observation is what one experiment concluded about one capability key.
+type observation struct {
+	// does is what the server does. It is meaningful only when undecidable is
+	// empty.
+	does bool
+	// undecidable, when non-empty, is why this run did not establish what the
+	// server does. An observation with a reason NEVER becomes an agreement.
+	undecidable string
+	// note is context that belongs on the row even when it was decided —
+	// typically that the key names one dialect's spelling of an ability other
+	// dialects also have under a different one.
+	note string
+}
+
+func decided(does bool) observation                { return observation{does: does} }
+func annotated(does bool, note string) observation { return observation{does: does, note: note} }
+func cannotDecide(format string, args ...any) observation {
+	return observation{undecidable: fmt.Sprintf(format, args...)}
+}
+
+// verdicts maps each key an experiment decides to its observation.
+type verdicts map[capability.Capability]observation
+
+// decider observes a live session and reports one observation per key the
+// experiment decides, together with every statement it ran.
+type decider func(ctx context.Context, s *session) (verdicts, []Attempt)
+
+// experiment is one measurement against a live server.
+//
+// It is not "one capability, one statement". Three of the twenty-four keys are
+// a mutual-exclusion group decided by two statements, and running them as
+// three independent experiments would let the group report a combination
+// Validate rejects. Two more need a DML follow-up because DDL acceptance is
+// identical on both sides of the boundary the key names.
+type experiment struct {
+	// decides lists every key this experiment answers.
+	decides []capability.Capability
+
+	// requires lists keys that must already have been decided TRUE. When one
+	// was not, every key here is undecidable rather than false: the
+	// registry's own edge says DropConstraintIfExists presupposes
+	// DropConstraintGeneric, so on a server without the generic clause the
+	// guarded statement is refused for the clause, not for the guard, and
+	// scoring it false would answer a question the run never asked.
+	requires []capability.Capability
+
+	// setup must succeed in full. A refused setup statement makes every key
+	// in decides undecidable: a deciding statement whose precondition was
+	// never created has observed the missing precondition, not the
+	// capability.
+	setup []string
+
+	decide decider
+}
+
+// plan is one dialect's complete answer for the capability registry: every
+// registered key is either decided by an experiment here or declared
+// undecidable with its reason.
+//
+// The exactly-once rule is enforced by a test, so a key added to the registry
+// turns the build red until this file answers for it. Without that, a new
+// capability would silently be absent from every matrix row and the report
+// would still say the run was complete.
+type plan struct {
+	experiments []experiment
+	// undecided declares, in advance and as data, keys this dialect cannot
+	// decide by asking the server. A reason recorded here is a property of the
+	// dialect that was known before the run; it is never derived from an
+	// outcome somebody did not like.
+	undecided map[capability.Capability]string
+}
+
+// acceptance decides one key by whether the server accepts a single statement.
+func acceptance(key capability.Capability, setup []string, statement string) experiment {
+	return acceptanceNote(key, setup, statement, "")
+}
+
+// acceptanceNote is acceptance with a note carried onto the row.
+func acceptanceNote(key capability.Capability, setup []string, statement, note string) experiment {
+	return experiment{
+		decides: []capability.Capability{key},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			attempt := s.exec(ctx, statement)
+			return verdicts{key: annotated(attempt.Accepted, note)}, []Attempt{attempt}
+		},
+	}
+}
+
+// all decides one key by whether the server accepts every statement in a
+// sequence. It stops at the first refusal, so the evidence names the statement
+// that answered.
+func all(key capability.Capability, setup []string, statements ...string) experiment {
+	return experiment{
+		decides: []capability.Capability{key},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			attempts, ok := s.runAll(ctx, statements)
+			return verdicts{key: decided(ok)}, attempts
+		},
+	}
+}
+
+// guarded decides an IF EXISTS-style key.
+//
+// Acceptance of the guarded statement alone does not isolate the guard: it
+// would also pass on a server that accepts a drop of an absent object outright.
+// So the unguarded spelling of the same statement must be REFUSED. When both
+// are accepted the key is undecidable, with that stated, rather than recorded
+// as support the run did not separate from permissiveness.
+func guarded(key capability.Capability, setup []string, guardedStmts []string, unguarded string) experiment {
+	return experiment{
+		decides: []capability.Capability{key},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			attempts, accepted := s.runAll(ctx, guardedStmts)
+			control := s.exec(ctx, unguarded)
+			attempts = append(attempts, control)
+			if accepted && control.Accepted {
+				return verdicts{key: cannotDecide(
+					"the server also accepted the unguarded spelling %q against an absent object, "+
+						"so accepting the IF EXISTS form does not separate the guard from general permissiveness",
+					collapse(unguarded),
+				)}, attempts
+			}
+			return verdicts{key: decided(accepted)}, attempts
+		},
+	}
+}
+
+// enforced decides a key whose statement the server may accept and then
+// ignore.
+//
+// MySQL before 8.0.16 accepted a CHECK clause and did not enforce it, which is
+// the entire reason CheckConstraintsEnforced exists: DDL acceptance is byte
+// for byte the same on both sides of that boundary. So the deciding statement
+// is one the constraint must REFUSE, and the control is one it must ACCEPT —
+// without the control, a table that rejects every insert for an unrelated
+// reason would read as an enforced constraint.
+func enforced(key capability.Capability, setup []string, accept, reject string) experiment {
+	return experiment{
+		decides: []capability.Capability{key},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			control := s.exec(ctx, accept)
+			violation := s.exec(ctx, reject)
+			attempts := []Attempt{control, violation}
+			if !control.Accepted {
+				return verdicts{key: cannotDecide(
+					"the control row %q was refused too (%s), so a refusal does not show the constraint is enforced",
+					collapse(accept), collapse(control.ServerErr),
+				)}, attempts
+			}
+			return verdicts{key: decided(!violation.Accepted)}, attempts
+		},
+	}
+}
+
+// concurrentIndex decides one of the CONCURRENTLY keys.
+//
+// Acceptance is the wrong test on its own. CockroachDB parses the keyword as a
+// compatibility no-op, so an acceptance probe records support the engine does
+// not provide. Real PostgreSQL refuses the statement inside an explicit
+// transaction block — a build that cannot be rolled back cannot live in one —
+// and a parser that merely swallows the word has no reason to refuse. The
+// transaction block is therefore the discriminator, and it runs only after the
+// standalone form was accepted.
+func concurrentIndex(key capability.Capability, setup []string, standalone, insideTx string) experiment {
+	return experiment{
+		decides: []capability.Capability{key},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			first := s.exec(ctx, standalone)
+			attempts := []Attempt{first}
+			if !first.Accepted {
+				return verdicts{key: decided(false)}, attempts
+			}
+
+			inTx, started := s.tryInTransaction(ctx, insideTx)
+			attempts = append(attempts, inTx...)
+			if !started {
+				return verdicts{key: cannotDecide(
+					"the server accepted %q but refused BEGIN (%s), so the transaction-block discriminator "+
+						"that separates a real concurrent build from a parsed no-op could not run",
+					collapse(standalone), collapse(inTx[0].ServerErr),
+				)}, attempts
+			}
+			if second := inTx[1]; second.Accepted {
+				return verdicts{key: annotated(false,
+					"the server accepted the statement inside an explicit transaction block as well, "+
+						"so the keyword is parsed and dropped rather than changing how the index is built",
+				)}, attempts
+			}
+			return verdicts{key: decided(true)}, attempts
+		},
+	}
+}
+
+// storedResult decides MaterializedViews.
+//
+// MySQL 9.7.1 accepts CREATE MATERIALIZED VIEW, reports the object as a plain
+// VIEW, and recomputes the query on every read. This key names a view whose
+// result is STORED, so the decider inserts a row into the source table between
+// two reads: a stored result does not move, a recomputed one does.
+func storedResult(key capability.Capability, setup []string, create, read, mutate string) experiment {
+	return experiment{
+		decides: []capability.Capability{key},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			created := s.exec(ctx, create)
+			attempts := []Attempt{created}
+			if !created.Accepted {
+				return verdicts{key: decided(false)}, attempts
+			}
+			before, readBefore := s.query(ctx, read)
+			mutated := s.exec(ctx, mutate)
+			after, readAfter := s.query(ctx, read)
+			attempts = append(attempts, readBefore, mutated, readAfter)
+			if !readBefore.Accepted || !mutated.Accepted || !readAfter.Accepted {
+				return verdicts{key: cannotDecide(
+					"the statement was accepted but the storedness check could not run, " +
+						"so acceptance of the keyword is all this run saw",
+				)}, attempts
+			}
+			if before == after {
+				return verdicts{key: decided(true)}, attempts
+			}
+			return verdicts{key: annotated(false, fmt.Sprintf(
+				"the keyword was accepted and then dropped: the view reported %d before the source row was "+
+					"inserted and %d after, so the result is recomputed rather than stored", before, after,
+			))}, attempts
+		},
+	}
+}

--- a/internal/capabilityprobe/plans.go
+++ b/internal/capabilityprobe/plans.go
@@ -1,0 +1,437 @@
+package capabilityprobe
+
+import (
+	"context"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
+)
+
+// planFor returns the experiment table for a dialect, or false when the probe
+// has none.
+//
+// A dialect with no plan is not a dialect that agrees with its preset. Every
+// one of its rows is undecidable with that stated, which is the honest reading
+// of "nobody wrote a decider for this yet".
+func planFor(dialect string) (plan, bool) {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		return postgresPlan(), true
+	case platform.MySQL, platform.MariaDB:
+		return mysqlFamilyPlan(platform.NormalizeDialect(dialect)), true
+	default:
+		return plan{}, false
+	}
+}
+
+// postgresPlan is the statement table for the PostgreSQL wire family.
+//
+// Every object name is unqualified so it lands in the throwaway schema the
+// session entered, and every experiment creates its own objects rather than
+// borrowing another's: an experiment that depends on a neighbor's setup
+// reports that neighbor's failure as its own answer.
+func postgresPlan() plan {
+	experiments := []experiment{
+		acceptance(capability.DropConstraintGeneric,
+			[]string{"CREATE TABLE dcg (n int, CONSTRAINT dcg_uq UNIQUE (n))"},
+			"ALTER TABLE dcg DROP CONSTRAINT dcg_uq",
+		),
+		{
+			decides:  []capability.Capability{capability.DropConstraintIfExists},
+			requires: []capability.Capability{capability.DropConstraintGeneric},
+			setup:    []string{"CREATE TABLE dcie (n int)"},
+			decide: guarded(capability.DropConstraintIfExists, nil,
+				[]string{"ALTER TABLE dcie DROP CONSTRAINT IF EXISTS dcie_absent"},
+				"ALTER TABLE dcie DROP CONSTRAINT dcie_absent",
+			).decide,
+		},
+		guarded(capability.DropIndexIfExists, nil,
+			[]string{"DROP INDEX IF EXISTS dii_absent"},
+			"DROP INDEX dii_absent",
+		),
+		enforced(capability.CheckConstraintsEnforced,
+			[]string{"CREATE TABLE cce (n int, CONSTRAINT cce_ck CHECK (n > 0))"},
+			"INSERT INTO cce (n) VALUES (1)",
+			"INSERT INTO cce (n) VALUES (-1)",
+		),
+		acceptance(capability.DropCheckClause,
+			[]string{"CREATE TABLE dcc (n int, CONSTRAINT dcc_ck CHECK (n > 0))"},
+			"ALTER TABLE dcc DROP CHECK dcc_ck",
+		),
+		acceptance(capability.EnumInlineColumn, nil,
+			"CREATE TABLE eic (c ENUM('a','b'))",
+		),
+		acceptance(capability.EnumCustomType, nil,
+			"CREATE TYPE ect AS ENUM ('a','b')",
+		),
+		concurrentIndex(capability.CreateIndexConcurrently,
+			[]string{"CREATE TABLE cic (n int)"},
+			"CREATE INDEX CONCURRENTLY cic_one ON cic (n)",
+			"CREATE INDEX CONCURRENTLY cic_two ON cic (n)",
+		),
+		concurrentIndex(capability.DropIndexConcurrently,
+			[]string{
+				"CREATE TABLE dic (n int)",
+				"CREATE INDEX dic_one ON dic (n)",
+				"CREATE INDEX dic_two ON dic (n)",
+			},
+			"DROP INDEX CONCURRENTLY dic_one",
+			"DROP INDEX CONCURRENTLY dic_two",
+		),
+		acceptance(capability.Views,
+			[]string{"CREATE TABLE vsrc (n int)"},
+			"CREATE VIEW vw AS SELECT n FROM vsrc",
+		),
+		storedResult(capability.MaterializedViews,
+			[]string{"CREATE TABLE mvs (n int)"},
+			"CREATE MATERIALIZED VIEW mvw AS SELECT COUNT(*) AS c FROM mvs",
+			"SELECT c FROM mvw",
+			"INSERT INTO mvs (n) VALUES (1)",
+		),
+		acceptance(capability.Functions, nil,
+			"CREATE FUNCTION fn() RETURNS int LANGUAGE sql AS 'SELECT 1'",
+		),
+		all(capability.Triggers,
+			[]string{"CREATE TABLE trg_t (n int)"},
+			"CREATE FUNCTION trg_fn() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+			"CREATE TRIGGER trg BEFORE INSERT ON trg_t FOR EACH ROW EXECUTE FUNCTION trg_fn()",
+		),
+		{
+			decides:  []capability.Capability{capability.CreateOrReplaceTrigger},
+			requires: []capability.Capability{capability.Triggers},
+			setup: []string{
+				"CREATE TABLE cort_t (n int)",
+				"CREATE FUNCTION cort_fn() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+			},
+			decide: acceptance(capability.CreateOrReplaceTrigger, nil,
+				"CREATE OR REPLACE TRIGGER cort BEFORE INSERT ON cort_t FOR EACH ROW EXECUTE FUNCTION cort_fn()",
+			).decide,
+		},
+		acceptance(capability.AlterGeneratedColumnExpression,
+			[]string{"CREATE TABLE agc (n int, g int GENERATED ALWAYS AS (n + 1) STORED)"},
+			"ALTER TABLE agc ALTER COLUMN g SET EXPRESSION AS (n + 2)",
+		),
+		all(capability.RowLevelSecurity,
+			[]string{"CREATE TABLE rls (n int)"},
+			"ALTER TABLE rls ENABLE ROW LEVEL SECURITY",
+			"CREATE POLICY rls_p ON rls USING (true)",
+		),
+		roleManagement(),
+		foreignKeys(
+			[]string{
+				"CREATE TABLE fk_parent (id int PRIMARY KEY)",
+				"CREATE TABLE fk_child (id int)",
+			},
+			"ALTER TABLE fk_child ADD CONSTRAINT fk_child_fk FOREIGN KEY (id) REFERENCES fk_parent (id)",
+			"INSERT INTO fk_parent (id) VALUES (1)",
+			"INSERT INTO fk_child (id) VALUES (1)",
+			"INSERT INTO fk_child (id) VALUES (99)",
+		),
+		referencePolicy(referencePolicyStatements{
+			setup: []string{
+				"CREATE TABLE fkp_uni (k int NOT NULL, CONSTRAINT fkp_uni_uq UNIQUE (k))",
+				"CREATE TABLE fkp_idx (k int NOT NULL)",
+				"CREATE INDEX fkp_idx_k ON fkp_idx (k)",
+				"CREATE TABLE fkp_none (k int NOT NULL)",
+				"CREATE TABLE fkp_c0 (k int)",
+				"CREATE TABLE fkp_c1 (k int)",
+				"CREATE TABLE fkp_c2 (k int)",
+			},
+			unique:  "ALTER TABLE fkp_c0 ADD CONSTRAINT fkp_s0 FOREIGN KEY (k) REFERENCES fkp_uni (k)",
+			indexed: "ALTER TABLE fkp_c1 ADD CONSTRAINT fkp_s1 FOREIGN KEY (k) REFERENCES fkp_idx (k)",
+			bare:    "ALTER TABLE fkp_c2 ADD CONSTRAINT fkp_s2 FOREIGN KEY (k) REFERENCES fkp_none (k)",
+		}),
+		all(capability.Sequences, nil,
+			"CREATE SEQUENCE sq",
+			"CREATE TABLE ser (id SERIAL PRIMARY KEY)",
+		),
+		acceptance(capability.XMLType, nil,
+			"CREATE TABLE xmlt (c XML)",
+		),
+		all(capability.AdvisoryLocks, nil,
+			"SELECT pg_advisory_lock(1)",
+			"SELECT pg_advisory_unlock(1)",
+		),
+	}
+	return plan{experiments: experiments, undecided: map[capability.Capability]string{}}
+}
+
+// mysqlFamilyPlan is the statement table for MySQL and MariaDB.
+func mysqlFamilyPlan(dialect string) plan {
+	experiments := []experiment{
+		acceptance(capability.DropConstraintGeneric,
+			[]string{"CREATE TABLE dcg (n int, CONSTRAINT dcg_uq UNIQUE (n))"},
+			"ALTER TABLE dcg DROP CONSTRAINT dcg_uq",
+		),
+		{
+			decides:  []capability.Capability{capability.DropConstraintIfExists},
+			requires: []capability.Capability{capability.DropConstraintGeneric},
+			setup:    []string{"CREATE TABLE dcie (n int)"},
+			// The key names two spellings, and a probe that tests only the
+			// first reports the row as agreeing while half of what the flag
+			// gates went unmeasured: the MySQL-family renderer puts the same
+			// guard on the FOREIGN KEY branch.
+			decide: guarded(capability.DropConstraintIfExists, nil,
+				[]string{
+					"ALTER TABLE dcie DROP CONSTRAINT IF EXISTS dcie_absent",
+					"ALTER TABLE dcie DROP FOREIGN KEY IF EXISTS dcie_absent_fk",
+				},
+				"ALTER TABLE dcie DROP CONSTRAINT dcie_absent",
+			).decide,
+		},
+		guarded(capability.DropIndexIfExists,
+			[]string{"CREATE TABLE dii (n int)"},
+			[]string{"DROP INDEX IF EXISTS dii_absent ON dii"},
+			"DROP INDEX dii_absent ON dii",
+		),
+		enforced(capability.CheckConstraintsEnforced,
+			[]string{"CREATE TABLE cce (n int, CONSTRAINT cce_ck CHECK (n > 0))"},
+			"INSERT INTO cce (n) VALUES (1)",
+			"INSERT INTO cce (n) VALUES (-1)",
+		),
+		acceptance(capability.DropCheckClause,
+			[]string{"CREATE TABLE dcc (n int, CONSTRAINT dcc_ck CHECK (n > 0))"},
+			"ALTER TABLE dcc DROP CHECK dcc_ck",
+		),
+		acceptance(capability.EnumInlineColumn, nil,
+			"CREATE TABLE eic (c ENUM('a','b'))",
+		),
+		acceptance(capability.EnumCustomType, nil,
+			"CREATE TYPE ect AS ENUM ('a','b')",
+		),
+		concurrentIndex(capability.CreateIndexConcurrently,
+			[]string{"CREATE TABLE cic (n int)"},
+			"CREATE INDEX CONCURRENTLY cic_one ON cic (n)",
+			"CREATE INDEX CONCURRENTLY cic_two ON cic (n)",
+		),
+		concurrentIndex(capability.DropIndexConcurrently,
+			[]string{
+				"CREATE TABLE dic (n int)",
+				"CREATE INDEX dic_one ON dic (n)",
+				"CREATE INDEX dic_two ON dic (n)",
+			},
+			"DROP INDEX CONCURRENTLY dic_one ON dic",
+			"DROP INDEX CONCURRENTLY dic_two ON dic",
+		),
+		acceptance(capability.Views,
+			[]string{"CREATE TABLE vsrc (n int)"},
+			"CREATE VIEW vw AS SELECT n FROM vsrc",
+		),
+		storedResult(capability.MaterializedViews,
+			[]string{"CREATE TABLE mvs (n int)"},
+			"CREATE MATERIALIZED VIEW mvw AS SELECT COUNT(*) AS c FROM mvs",
+			"SELECT c FROM mvw",
+			"INSERT INTO mvs (n) VALUES (1)",
+		),
+		acceptance(capability.Functions, nil,
+			"CREATE FUNCTION fn() RETURNS INT DETERMINISTIC RETURN 1",
+		),
+		acceptance(capability.Triggers,
+			[]string{"CREATE TABLE trg_t (n int)"},
+			"CREATE TRIGGER trg BEFORE INSERT ON trg_t FOR EACH ROW SET NEW.n = NEW.n",
+		),
+		{
+			decides:  []capability.Capability{capability.CreateOrReplaceTrigger},
+			requires: []capability.Capability{capability.Triggers},
+			setup:    []string{"CREATE TABLE cort_t (n int)"},
+			decide: acceptance(capability.CreateOrReplaceTrigger, nil,
+				"CREATE OR REPLACE TRIGGER cort BEFORE INSERT ON cort_t FOR EACH ROW SET NEW.n = NEW.n",
+			).decide,
+		},
+		acceptanceNote(capability.AlterGeneratedColumnExpression,
+			[]string{"CREATE TABLE agc (n int, g int GENERATED ALWAYS AS (n + 1) STORED)"},
+			"ALTER TABLE agc ALTER COLUMN g SET EXPRESSION AS (n + 2)",
+			"this key names PostgreSQL 17's SET EXPRESSION spelling, which is what was probed; "+
+				"the MySQL family can change a generated column expression under its own "+
+				"MODIFY COLUMN spelling, so a false row here means \"not this statement\", not \"not this ability\"",
+		),
+		all(capability.RowLevelSecurity,
+			[]string{"CREATE TABLE rls (n int)"},
+			"ALTER TABLE rls ENABLE ROW LEVEL SECURITY",
+			"CREATE POLICY rls_p ON rls USING (true)",
+		),
+		foreignKeys(
+			[]string{
+				"CREATE TABLE fk_parent (id int PRIMARY KEY)",
+				"CREATE TABLE fk_child (id int)",
+			},
+			"ALTER TABLE fk_child ADD CONSTRAINT fk_child_fk FOREIGN KEY (id) REFERENCES fk_parent (id)",
+			"INSERT INTO fk_parent (id) VALUES (1)",
+			"INSERT INTO fk_child (id) VALUES (1)",
+			"INSERT INTO fk_child (id) VALUES (99)",
+		),
+		referencePolicy(referencePolicyStatements{
+			setup: []string{
+				"CREATE TABLE fkp_uni (k int NOT NULL, CONSTRAINT fkp_uni_uq UNIQUE (k))",
+				"CREATE TABLE fkp_idx (k int NOT NULL)",
+				"CREATE INDEX fkp_idx_k ON fkp_idx (k)",
+				"CREATE TABLE fkp_none (k int NOT NULL)",
+				"CREATE TABLE fkp_c0 (k int)",
+				"CREATE TABLE fkp_c1 (k int)",
+				"CREATE TABLE fkp_c2 (k int)",
+			},
+			unique:  "ALTER TABLE fkp_c0 ADD CONSTRAINT fkp_s0 FOREIGN KEY (k) REFERENCES fkp_uni (k)",
+			indexed: "ALTER TABLE fkp_c1 ADD CONSTRAINT fkp_s1 FOREIGN KEY (k) REFERENCES fkp_idx (k)",
+			bare:    "ALTER TABLE fkp_c2 ADD CONSTRAINT fkp_s2 FOREIGN KEY (k) REFERENCES fkp_none (k)",
+		}),
+		acceptance(capability.XMLType, nil,
+			"CREATE TABLE xmlt (c XML)",
+		),
+		all(capability.AdvisoryLocks, nil,
+			"SELECT pg_advisory_lock(1)",
+			"SELECT pg_advisory_unlock(1)",
+		),
+	}
+
+	undecided := map[capability.Capability]string{
+		// Measured live on MySQL 9.7.1: CREATE ROLE and GRANT SELECT are both
+		// accepted at exit 0 while MySQL84 records this key false. The two are
+		// not in conflict — the key names the PostgreSQL role and object
+		// privilege surface that the PostgreSQL planner, renderer and reader
+		// gate on, and no MySQL-family code path reads it. An acceptance probe
+		// here would manufacture exactly the false disagreement this harness
+		// exists to avoid.
+		capability.RoleManagement: "the key names the PostgreSQL role and privilege surface no MySQL-family " +
+			"code path consults; this server's own CREATE ROLE and GRANT are a different surface, " +
+			"so accepting them would not decide the key",
+	}
+	if dialect == platform.MariaDB {
+		// MariaDB has had SEQUENCE objects since 10.3 and the preset still
+		// says false, deliberately: the key describes Ptah's generator, and
+		// there is no MariaDB sequence introspection and no MySQL-family
+		// sequence planning. The two answers are known in advance to differ on
+		// this dialect, so the engine cannot decide the key.
+		undecided[capability.Sequences] = "the key describes Ptah's generator rather than the engine " +
+			"(stokaro/ptah#931 item 8): MariaDB has had SEQUENCE since 10.3 while no MySQL-family " +
+			"renderer or planner emits, reads or plans one, so the server's answer is to a different question"
+	} else {
+		experiments = append(experiments, all(capability.Sequences, nil,
+			"CREATE SEQUENCE sq",
+			"CREATE TABLE ser (id SERIAL PRIMARY KEY)",
+		))
+	}
+	return plan{experiments: experiments, undecided: undecided}
+}
+
+// roleManagement decides RoleManagement on the PostgreSQL family and registers
+// the role it created for cleanup: a role is cluster-scoped, so dropping the
+// probe schema does not remove it.
+func roleManagement() experiment {
+	const role = "ptah_capprobe_role"
+	return experiment{
+		decides: []capability.Capability{capability.RoleManagement},
+		setup:   []string{"CREATE TABLE rm_t (n int)"},
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			created := s.exec(ctx, "CREATE ROLE "+role)
+			attempts := []Attempt{created}
+			if !created.Accepted {
+				return verdicts{capability.RoleManagement: decided(false)}, attempts
+			}
+			s.roles = append(s.roles, role)
+			granted := s.exec(ctx, "GRANT SELECT ON rm_t TO "+role)
+			attempts = append(attempts, granted)
+			return verdicts{capability.RoleManagement: decided(granted.Accepted)}, attempts
+		},
+	}
+}
+
+// foreignKeys decides ForeignKeys.
+//
+// DDL acceptance is not enough: SQLite parses a foreign key clause and does not
+// enforce it unless PRAGMA foreign_keys is on for the connection, and a MySQL
+// table on a non-InnoDB engine has the same parse-and-ignore shape. So the
+// constraint has to bite — an orphan row must be refused — and a row that
+// satisfies it must be accepted, or a table refusing every insert would read
+// as an enforced foreign key.
+func foreignKeys(setup []string, add, seedParent, validChild, orphanChild string) experiment {
+	return experiment{
+		decides: []capability.Capability{capability.ForeignKeys},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			added := s.exec(ctx, add)
+			attempts := []Attempt{added}
+			if !added.Accepted {
+				return verdicts{capability.ForeignKeys: decided(false)}, attempts
+			}
+			seeded := s.exec(ctx, seedParent)
+			valid := s.exec(ctx, validChild)
+			orphan := s.exec(ctx, orphanChild)
+			attempts = append(attempts, seeded, valid, orphan)
+			if !seeded.Accepted || !valid.Accepted {
+				return verdicts{capability.ForeignKeys: cannotDecide(
+					"the constraint was accepted but the control rows were refused (%s), "+
+						"so refusing the orphan row would not show the constraint is enforced",
+					collapse(firstError(seeded, valid)),
+				)}, attempts
+			}
+			return verdicts{capability.ForeignKeys: decided(!orphan.Accepted)}, attempts
+		},
+	}
+}
+
+func firstError(attempts ...Attempt) string {
+	for _, attempt := range attempts {
+		if !attempt.Accepted {
+			return attempt.ServerErr
+		}
+	}
+	return ""
+}
+
+// referencePolicyStatements is the two-statement experiment that decides the
+// whole foreign-key reference policy group.
+type referencePolicyStatements struct {
+	setup []string
+	// unique adds a foreign key to a declared unique key. It is the control:
+	// a server that refuses even this one is refusing foreign keys, not
+	// choosing a reference policy.
+	unique string
+	// indexed adds a foreign key to a nonunique but indexed key.
+	indexed string
+	// bare adds a foreign key to a column with no index at all.
+	bare string
+}
+
+// referencePolicy decides ForeignKeysRequireUniqueReference,
+// ForeignKeysRequireIndexedReference and ForeignKeysCreateBackingIndex.
+//
+// These are one mutual-exclusion group and Validate accepts exactly one of them
+// enabled. Three independent experiments could therefore produce a combination
+// no preset is allowed to hold; two statements produce all three answers
+// consistently:
+//
+//	indexed refused                  -> the target requires a unique key
+//	indexed accepted, bare refused   -> the target requires an indexed key
+//	indexed accepted, bare accepted  -> the target builds the backing index
+func referencePolicy(stmts referencePolicyStatements) experiment {
+	keys := []capability.Capability{
+		capability.ForeignKeysRequireUniqueReference,
+		capability.ForeignKeysRequireIndexedReference,
+		capability.ForeignKeysCreateBackingIndex,
+	}
+	return experiment{
+		decides:  keys,
+		requires: []capability.Capability{capability.ForeignKeys},
+		setup:    stmts.setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			control := s.exec(ctx, stmts.unique)
+			attempts := []Attempt{control}
+			if !control.Accepted {
+				reason := cannotDecide(
+					"the server refused a foreign key to a declared unique key as well (%s), "+
+						"so refusing the other two says nothing about which reference policy it uses",
+					collapse(control.ServerErr),
+				)
+				return verdicts{keys[0]: reason, keys[1]: reason, keys[2]: reason}, attempts
+			}
+			indexed := s.exec(ctx, stmts.indexed)
+			bare := s.exec(ctx, stmts.bare)
+			attempts = append(attempts, indexed, bare)
+			return verdicts{
+				keys[0]: decided(!indexed.Accepted),
+				keys[1]: decided(indexed.Accepted && !bare.Accepted),
+				keys[2]: decided(indexed.Accepted && bare.Accepted),
+			}, attempts
+		},
+	}
+}

--- a/internal/capabilityprobe/probe.go
+++ b/internal/capabilityprobe/probe.go
@@ -1,0 +1,463 @@
+package capabilityprobe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// Outcome is the verdict for one capability row.
+//
+// There are three, and the third is the point of the deliverable. A harness
+// with only AGREES and DISAGREES has to put every capability it did not
+// measure into one of them, and whichever it picks is a lie: folded into
+// agreement it manufactures evidence, folded into disagreement it cries wolf.
+type Outcome string
+
+const (
+	// Agrees: the server was measured and behaves the way the preset says.
+	Agrees Outcome = "AGREES"
+	// Disagrees: the server was measured and does not. This is a failure.
+	Disagrees Outcome = "DISAGREES"
+	// Undecidable: this run did not establish what the server does, or
+	// established it and cannot credit it to this release line. Reason is
+	// always populated and it never counts as agreement.
+	Undecidable Outcome = "UNDECIDABLE"
+)
+
+// Row is one capability measured against one server.
+type Row struct {
+	Capability capability.Capability
+	Dialect    string
+	Version    string
+	// PresetSays is what the capability set Ptah plans with for this server
+	// claims.
+	PresetSays bool
+	// ServerDoes is what the server was observed doing. Valid only when
+	// Observed is true.
+	ServerDoes bool
+	// Observed is true when the deciding statements ran and answered, even if
+	// the row is undecidable because the answer cannot be credited to this
+	// release line. Keeping the observation is what stops an unattributable
+	// row from also being an invisible one.
+	Observed bool
+	Outcome  Outcome
+	// Reason is why the row is undecidable. Empty otherwise.
+	Reason string
+	// Note is context that belongs on the row whatever its outcome.
+	Note string
+	// Attempts are the statements this row was decided from, with the
+	// server's own answers.
+	Attempts []Attempt
+}
+
+// Mismatch reports whether the observation contradicts the preset. It is
+// independent of Outcome, so a contradiction observed on a line the matrix
+// cannot credit is still visible instead of vanishing into UNDECIDABLE.
+func (r Row) Mismatch() bool {
+	return r.Observed && r.ServerDoes != r.PresetSays
+}
+
+// Report is one probe run.
+type Report struct {
+	// URL is the target with its secrets redacted.
+	URL string
+	// Dialect is the dialect the connection resolved to, which may differ
+	// from the one the URL declared: a CockroachDB server behind a
+	// postgres:// URL announces itself in the banner.
+	Dialect string
+	// Banner is the raw server version string.
+	Banner string
+	// Version is the corrected product version.
+	Version Version
+	// Cell is the matrix cell this server fell on.
+	Cell Cell
+	// Matched is false when no cell covers this release line.
+	Matched bool
+	// Resolution is what capability.ResolveServerVersion answered for the
+	// banner.
+	Resolution capability.VersionResolution
+	// SessionCapabilities is the set Ptah actually plans with once a physical
+	// session is pinned. It can differ from the version resolution: MySQL 8.4+
+	// reads its foreign-key reference policy from a session variable, so the
+	// same version answers differently depending on how the server is
+	// configured.
+	SessionCapabilities capability.Capabilities
+	// SessionDeltas names the keys where SessionCapabilities differs from the
+	// version resolution.
+	SessionDeltas []capability.Capability
+	// Rows is one entry per registered capability, sorted by key.
+	Rows []Row
+	// Planned is false when the probe has no statement table for this
+	// dialect, so nothing was executed at all.
+	Planned bool
+	// Control is the statement the server had to refuse for any acceptance in
+	// this run to be worth reading.
+	Control Attempt
+	// Namespace is the throwaway schema or database the run used.
+	Namespace string
+	// Cleanup records the teardown statements.
+	Cleanup []Attempt
+}
+
+// Count returns how many rows carry an outcome.
+func (r *Report) Count(outcome Outcome) int {
+	n := 0
+	for _, row := range r.Rows {
+		if row.Outcome == outcome {
+			n++
+		}
+	}
+	return n
+}
+
+// Decided returns how many rows this run actually decided.
+func (r *Report) Decided() int {
+	return r.Count(Agrees) + r.Count(Disagrees)
+}
+
+// Mismatches returns every row whose observation contradicts the preset,
+// including rows the matrix cannot credit to this line.
+func (r *Report) Mismatches() []Row {
+	var out []Row
+	for _, row := range r.Rows {
+		if row.Mismatch() {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+// Err returns the reason this run must fail, or nil.
+//
+// Failing on "decided nothing" is not defensive padding. A skipped check that
+// reads as a passed check is how a matrix comes to certify lines nobody ever
+// probed, and this repository has been bitten by that shape before.
+func (r *Report) Err() error {
+	var problems []error
+
+	switch {
+	case !r.Planned:
+		problems = append(problems, fmt.Errorf(
+			"the probe has no statement table for the %s dialect, so it executed nothing against this server", r.Dialect))
+	case r.Control.Statement == "":
+		problems = append(problems, errors.New("the refusal control never ran"))
+	case r.Control.Accepted:
+		problems = append(problems, fmt.Errorf(
+			"the server ACCEPTED the nonsense control %q, so no acceptance in this run distinguishes "+
+				"a supported statement from a connection that agrees with everything",
+			collapse(r.Control.Statement)))
+	}
+	if !r.Matched {
+		problems = append(problems, fmt.Errorf(
+			"no matrix cell covers %s %s: this release line is not in the matrix, "+
+				"so nothing here promotes it to measured (add a cell in cells.go)",
+			r.Dialect, r.Version))
+	}
+	problems = append(problems, r.cellProblems()...)
+
+	for _, row := range r.Mismatches() {
+		problems = append(problems, fmt.Errorf(
+			"%s: preset says %t, server does %t", row.Capability, row.PresetSays, row.ServerDoes))
+	}
+	if r.Decided() == 0 {
+		problems = append(problems, fmt.Errorf(
+			"this run decided 0 of %d capability rows; a probe that measured nothing must not read as a probe that passed",
+			len(r.Rows)))
+	}
+	return errors.Join(problems...)
+}
+
+// cellProblems reports the ways a matched cell can be a lie about the server
+// it matched.
+func (r *Report) cellProblems() []error {
+	if !r.Matched {
+		return nil
+	}
+	var problems []error
+	if !r.Cell.Measured() {
+		problems = append(problems, fmt.Errorf(
+			"matrix cell %s has no measured capability preset (%s)", r.Cell, r.Cell.Note))
+		return problems
+	}
+	if r.Resolution.Saturated {
+		problems = append(problems, fmt.Errorf(
+			"matrix cell %s claims a measured preset, but the resolver reports the server as past the "+
+				"newest measured line (%s): a saturated version receives the dialect default, not this line's answer",
+			r.Cell, r.Resolution.NewestMeasured))
+	}
+	if !maps.Equal(r.Resolution.Capabilities, r.Cell.Preset()) {
+		problems = append(problems, fmt.Errorf(
+			"matrix cell %s names preset %s, but the resolver handed this server a different set",
+			r.Cell, r.Cell.PresetName))
+	}
+	return problems
+}
+
+// Run probes one live server and returns one row per registered capability.
+//
+// It never wraps the measurement in a transaction. PostgreSQL refuses CREATE
+// INDEX CONCURRENTLY inside an explicit transaction block, so BEGIN/ROLLBACK
+// isolation would report two true capabilities as false; the run works in a
+// throwaway namespace and drops it instead.
+func Run(ctx context.Context, dbURL string) (*Report, error) {
+	if len(Cells) == 0 {
+		return nil, errors.New("the capability matrix declares no cells; refusing to report a vacuous pass")
+	}
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		return nil, fmt.Errorf("connect to %s: %w", dbschema.FormatDatabaseURL(dbURL), err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+
+	report := &Report{
+		URL:     dbschema.FormatDatabaseURL(dbURL),
+		Dialect: platform.NormalizeDialect(conn.Info().Dialect),
+		Banner:  conn.Info().Version,
+	}
+	report.Version, err = ParseVersion(report.Dialect, report.Banner, productVersion(ctx, conn, report.Dialect))
+	if err != nil {
+		return nil, fmt.Errorf("read the product version of %s: %w", report.URL, err)
+	}
+	report.Cell, report.Matched = CellFor(report.Dialect, report.Version)
+	report.Resolution = capability.ResolveServerVersion(report.Dialect, report.Banner)
+
+	if err := conn.WithSession(ctx, func(pinned *dbschema.DatabaseConnection) error {
+		report.SessionCapabilities = pinned.Info().Capabilities
+		report.SessionDeltas = deltas(report.Resolution.Capabilities, report.SessionCapabilities)
+		return measure(ctx, pinned, report)
+	}); err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+// productVersion asks the server for a version surface cleaner than its
+// banner, where one exists. Today only SQL Server has one, and it is the fix
+// for the marketing-year parse: SERVERPROPERTY('ProductVersion') answers
+// 17.0.4065.4 where @@VERSION opens with "Microsoft SQL Server 2025".
+func productVersion(ctx context.Context, conn *dbschema.DatabaseConnection, dialect string) string {
+	if dialect != platform.SQLServer {
+		return ""
+	}
+	var value string
+	if err := conn.QueryRowContext(ctx, "SELECT CONVERT(nvarchar(128), SERVERPROPERTY('ProductVersion'))").Scan(&value); err != nil {
+		return ""
+	}
+	return value
+}
+
+// deltas names the keys where two capability sets differ.
+func deltas(before, after capability.Capabilities) []capability.Capability {
+	var out []capability.Capability
+	for _, key := range capability.All() {
+		if before.Has(key) != after.Has(key) {
+			out = append(out, key)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// measure runs the plan inside a throwaway namespace and fills in the rows.
+func measure(ctx context.Context, pinned *dbschema.DatabaseConnection, report *Report) error {
+	dialectPlan, planned := planFor(report.Dialect)
+	report.Planned = planned
+	if !planned {
+		report.Rows = rowsWithoutPlan(report)
+		return nil
+	}
+
+	namespace, err := newNamespace()
+	if err != nil {
+		return err
+	}
+	report.Namespace = namespace
+	s := &session{conn: pinned, dialect: report.Dialect, namespace: namespace}
+
+	enter, leave := namespaceSQL(report.Dialect, namespace)
+	if attempts, ok := s.runAll(ctx, enter); !ok {
+		return fmt.Errorf("create the throwaway probe namespace: %s", attempts[len(attempts)-1].ServerErr)
+	}
+	defer func() {
+		report.Cleanup = append(s.dropRoles(ctx), s.exec(ctx, leave))
+	}()
+
+	report.Control = s.exec(ctx, nonsenseControl)
+	observations, attempts := runPlan(ctx, s, dialectPlan)
+	if s.broken != nil {
+		// A dead session cannot run its own teardown, so the namespace stays
+		// behind. Name it: a probe that loses a connection and then silently
+		// litters the server is how the next run inherits objects it did not
+		// create and reads them as findings.
+		return fmt.Errorf("%w (the throwaway namespace %s could not be dropped and is still on the server)",
+			s.broken, namespace)
+	}
+	report.Rows = assemble(report, observations, attempts)
+	return nil
+}
+
+// runPlan executes a dialect's experiments in order and collects one
+// observation per key.
+func runPlan(ctx context.Context, s *session, p plan) (map[capability.Capability]observation, map[capability.Capability][]Attempt) {
+	observations := make(map[capability.Capability]observation, len(capability.All()))
+	attempts := make(map[capability.Capability][]Attempt, len(capability.All()))
+
+	for key, reason := range p.undecided {
+		observations[key] = observation{undecidable: reason}
+	}
+	for _, current := range p.experiments {
+		record := func(obs observation, ran []Attempt) {
+			for _, key := range current.decides {
+				observations[key] = obs
+				attempts[key] = ran
+			}
+		}
+		if missing, ok := unmetRequirement(current, observations); !ok {
+			record(cannotDecide(
+				"this key presupposes %q, which this run did not decide true, so the deciding statement "+
+					"would be refused for the missing statement rather than for this key",
+				missing), nil)
+			continue
+		}
+		ran, prepared := s.runAll(ctx, current.setup)
+		if !prepared {
+			record(cannotDecide(
+				"the precondition %q was refused (%s), so the deciding statement never had anything to decide against",
+				collapse(ran[len(ran)-1].Statement), collapse(ran[len(ran)-1].ServerErr)), ran)
+			continue
+		}
+		results, decidingAttempts := current.decide(ctx, s)
+		executed := make([]Attempt, 0, len(ran)+len(decidingAttempts))
+		executed = append(executed, ran...)
+		executed = append(executed, decidingAttempts...)
+		for _, key := range current.decides {
+			observations[key] = results[key]
+			attempts[key] = executed
+		}
+	}
+	return observations, attempts
+}
+
+// unmetRequirement returns the first requirement that was not decided true.
+func unmetRequirement(e experiment, observations map[capability.Capability]observation) (capability.Capability, bool) {
+	for _, required := range e.requires {
+		obs, seen := observations[required]
+		if !seen || obs.undecidable != "" || !obs.does {
+			return required, false
+		}
+	}
+	return "", true
+}
+
+// rowsWithoutPlan builds the all-undecidable row set for a dialect the probe
+// has no statements for.
+func rowsWithoutPlan(report *Report) []Row {
+	reason := fmt.Sprintf("no probe plan exists for the %s dialect, so no statement was executed for this key", report.Dialect)
+	rows := make([]Row, 0, len(capability.All()))
+	for _, key := range sortedCapabilities() {
+		rows = append(rows, Row{
+			Capability: key,
+			Dialect:    report.Dialect,
+			Version:    report.Version.String(),
+			PresetSays: report.SessionCapabilities.Has(key),
+			Outcome:    Undecidable,
+			Reason:     reason,
+		})
+	}
+	return rows
+}
+
+// assemble turns observations into rows, applying the two undecidability
+// layers in order: what the run could not decide, then what the matrix cannot
+// credit to this line.
+func assemble(report *Report, observations map[capability.Capability]observation, attempts map[capability.Capability][]Attempt) []Row {
+	unattributable := lineReason(report)
+	rows := make([]Row, 0, len(observations))
+	for _, key := range sortedCapabilities() {
+		obs, seen := observations[key]
+		row := Row{
+			Capability: key,
+			Dialect:    report.Dialect,
+			Version:    report.Version.String(),
+			PresetSays: report.SessionCapabilities.Has(key),
+			Note:       obs.note,
+			Attempts:   attempts[key],
+		}
+		switch {
+		case !seen:
+			row.Outcome = Undecidable
+			row.Reason = "the probe plan for this dialect does not answer for this key"
+		case obs.undecidable != "":
+			row.Outcome = Undecidable
+			row.Reason = obs.undecidable
+		default:
+			row.Observed = true
+			row.ServerDoes = obs.does
+			row.Outcome = outcomeFor(row, unattributable)
+			row.Reason = unattributable
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func outcomeFor(row Row, unattributable string) Outcome {
+	if unattributable != "" {
+		return Undecidable
+	}
+	if row.ServerDoes == row.PresetSays {
+		return Agrees
+	}
+	return Disagrees
+}
+
+// lineReason says why an observation cannot be credited to the cell's release
+// line, or returns "" when it can.
+//
+// This is the mechanism issue #1339 predicts will produce whole columns of
+// undecidable rows, and that first output is the correct result rather than a
+// defect to paper over: for six of the nine dialects the resolver hands every
+// release the same set, so an observation taken on one release is being
+// attributed to releases it was never taken from.
+func lineReason(report *Report) string {
+	if !report.Matched {
+		return fmt.Sprintf(
+			"no matrix cell covers %s %s, so this observation belongs to no declared release line",
+			report.Dialect, report.Version)
+	}
+	if !report.Cell.Measured() {
+		return fmt.Sprintf("matrix cell %s has no measured capability preset: %s", report.Cell, report.Cell.Note)
+	}
+	switch report.Cell.Refinement {
+	case RefinedByBanner:
+		return fmt.Sprintf(
+			"the %s preset is selected by a banner substring before any version is parsed, so every "+
+				"release of this engine receives %s and an observation on one release cannot be credited to this line",
+			report.Dialect, report.Cell.PresetName)
+	case NotRefined:
+		return fmt.Sprintf(
+			"the %s dialect has no version ladder: the resolver parses the version and discards it, so "+
+				"every release receives %s and an observation on one release cannot be credited to this line",
+			report.Dialect, report.Cell.PresetName)
+	case RefinedByVersion:
+		return ""
+	default:
+		return fmt.Sprintf("unknown refinement %q for matrix cell %s", report.Cell.Refinement, report.Cell)
+	}
+}
+
+func sortedCapabilities() []capability.Capability {
+	keys := capability.All()
+	slices.SortFunc(keys, func(a, b capability.Capability) int {
+		return strings.Compare(string(a), string(b))
+	})
+	return keys
+}

--- a/internal/capabilityprobe/probe_internal_test.go
+++ b/internal/capabilityprobe/probe_internal_test.go
@@ -1,0 +1,372 @@
+package capabilityprobe
+
+// White-box testing required: the properties that keep this harness from
+// manufacturing evidence are properties of unexported machinery. The
+// statement table (plan), the
+// three-way outcome assignment (assemble), and the requirement ordering
+// (unmetRequirement) are not reachable from outside the package, and testing
+// them through a live server instead would make the guard depend on which
+// container happens to be running.
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
+)
+
+// TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce is the guard that keeps
+// the matrix complete as the registry grows.
+//
+// Without it, adding a capability to core/platform/capability would leave every
+// dialect silently missing a row while the report still called the run
+// complete. "Exactly once" rather than "at least once" is deliberate: two
+// experiments deciding the same key would let the later one overwrite the
+// earlier answer depending on table order.
+func TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce(t *testing.T) {
+	c := qt.New(t)
+
+	registered := map[capability.Capability]bool{}
+	for _, key := range capability.All() {
+		registered[key] = true
+	}
+
+	for _, dialect := range []string{platform.Postgres, platform.MySQL, platform.MariaDB} {
+		c.Run(dialect, func(c *qt.C) {
+			dialectPlan, ok := planFor(dialect)
+			c.Assert(ok, qt.IsTrue)
+
+			answered := map[capability.Capability]int{}
+			for key := range dialectPlan.undecided {
+				answered[key]++
+			}
+			for _, current := range dialectPlan.experiments {
+				c.Assert(len(current.decides) > 0, qt.IsTrue, qt.Commentf("an experiment that decides nothing cannot be run"))
+				for _, key := range current.decides {
+					answered[key]++
+				}
+			}
+
+			for key := range registered {
+				c.Assert(answered[key], qt.Equals, 1,
+					qt.Commentf("%s: capability %q is answered %d times, want exactly once", dialect, key, answered[key]))
+			}
+			for key := range answered {
+				c.Assert(registered[key], qt.IsTrue,
+					qt.Commentf("%s: plan answers %q, which is not in the capability registry", dialect, key))
+			}
+		})
+	}
+}
+
+// TestPlans_DeclaredUndecidablesCarryAReason pins the shape that makes
+// undecidable an answer rather than a shrug.
+func TestPlans_DeclaredUndecidablesCarryAReason(t *testing.T) {
+	c := qt.New(t)
+
+	for _, dialect := range []string{platform.Postgres, platform.MySQL, platform.MariaDB} {
+		c.Run(dialect, func(c *qt.C) {
+			dialectPlan, ok := planFor(dialect)
+			c.Assert(ok, qt.IsTrue)
+			for key, reason := range dialectPlan.undecided {
+				c.Assert(len(reason) > 40, qt.IsTrue,
+					qt.Commentf("%s/%s: an undecidable reason has to say why, not just that", dialect, key))
+			}
+		})
+	}
+}
+
+// reportOn builds a minimal report for the assembly tests.
+func reportOn(cell Cell, matched bool, preset capability.Capabilities) *Report {
+	return &Report{
+		Dialect:             cell.Dialect,
+		Version:             Version{Numbers: []int{17, 10}},
+		Cell:                cell,
+		Matched:             matched,
+		SessionCapabilities: preset,
+	}
+}
+
+var measuredCell = Cell{
+	Dialect: platform.Postgres, Line: "17",
+	Preset: capability.Postgres17, PresetName: "Postgres17",
+	Refinement: RefinedByVersion,
+}
+
+// TestAssemble_ThreeOutcomes pins the whole verdict table, including the one
+// row a cheaper implementation folds into agreement.
+func TestAssemble_ThreeOutcomes(t *testing.T) {
+	c := qt.New(t)
+
+	const key = capability.XMLType // Postgres17 says true.
+
+	for _, tc := range []struct {
+		name   string
+		obs    observation
+		assert func(c *qt.C, row Row)
+	}{{
+		name: "the server does what the preset says",
+		obs:  decided(true),
+		assert: func(c *qt.C, row Row) {
+			c.Assert(row.Outcome, qt.Equals, Agrees)
+			c.Assert(row.Observed, qt.IsTrue)
+			c.Assert(row.Reason, qt.Equals, "")
+		},
+	}, {
+		name: "the server does not, which is a disagreement and not a warning",
+		obs:  decided(false),
+		assert: func(c *qt.C, row Row) {
+			c.Assert(row.Outcome, qt.Equals, Disagrees)
+			c.Assert(row.Mismatch(), qt.IsTrue)
+		},
+	}, {
+		name: "an undecided key stays undecidable and never becomes agreement",
+		obs:  cannotDecide("the precondition was refused"),
+		assert: func(c *qt.C, row Row) {
+			c.Assert(row.Outcome, qt.Equals, Undecidable)
+			c.Assert(row.Observed, qt.IsFalse,
+				qt.Commentf("an undecided row must not carry a server answer it never obtained"))
+			c.Assert(row.Reason, qt.Equals, "the precondition was refused")
+			c.Assert(row.Mismatch(), qt.IsFalse)
+		},
+	}} {
+		c.Run(tc.name, func(c *qt.C) {
+			report := reportOn(measuredCell, true, capability.Postgres17())
+			rows := assemble(report, map[capability.Capability]observation{key: tc.obs}, nil)
+			tc.assert(c, rowFor(c, rows, key))
+		})
+	}
+}
+
+// TestAssemble_UndecidableRowsAreNotCountedAsDecided is the counter to the
+// cheapest wrong implementation of this harness: reporting every row it could
+// not decide as agreeing, so the matrix comes out green.
+func TestAssemble_UndecidableRowsAreNotCountedAsDecided(t *testing.T) {
+	c := qt.New(t)
+
+	report := reportOn(measuredCell, true, capability.Postgres17())
+	observations := map[capability.Capability]observation{}
+	for _, key := range capability.All() {
+		observations[key] = cannotDecide("nothing was executed for this key")
+	}
+	report.Rows = assemble(report, observations, nil)
+	report.Planned = true
+	report.Control = Attempt{Statement: nonsenseControl}
+
+	c.Assert(report.Count(Undecidable), qt.Equals, len(capability.All()))
+	c.Assert(report.Count(Agrees), qt.Equals, 0)
+	c.Assert(report.Decided(), qt.Equals, 0)
+	c.Assert(report.Err(), qt.ErrorMatches, `(?s).*decided 0 of \d+ capability rows.*`)
+}
+
+// TestAssemble_AnUnattributableLineKeepsTheObservation covers the six dialects
+// whose preset is not selected by a version.
+//
+// The rows must be undecidable — an observation on one CockroachDB release is
+// being credited to every other release, which is not a measurement of this
+// line — and the observation must survive anyway, so a contradiction found
+// there is reported rather than absorbed by the word UNDECIDABLE.
+func TestAssemble_AnUnattributableLineKeepsTheObservation(t *testing.T) {
+	c := qt.New(t)
+
+	bannerCell := Cell{
+		Dialect: platform.CockroachDB, Line: "26.2",
+		Preset: capability.CockroachDB23, PresetName: "CockroachDB23",
+		Refinement: RefinedByBanner,
+	}
+	report := reportOn(bannerCell, true, capability.CockroachDB23())
+	report.Planned = true
+	report.Control = Attempt{Statement: nonsenseControl}
+	// What a live CockroachDB actually resolves to. VersionSpecific is TRUE
+	// here even though no version was consulted, which is why undecidability
+	// has to come from the declared refinement: an implementation that read
+	// this field would credit the observation to a line the resolver never
+	// distinguished from its siblings.
+	report.Resolution.VersionSpecific = true
+	report.Resolution.Capabilities = capability.CockroachDB23()
+	report.Rows = assemble(report, map[capability.Capability]observation{
+		capability.Sequences: decided(true), // CockroachDB23 says false.
+		capability.Views:     decided(true), // CockroachDB23 says true.
+	}, nil)
+
+	sequences := rowFor(c, report.Rows, capability.Sequences)
+	c.Assert(sequences.Outcome, qt.Equals, Undecidable)
+	c.Assert(sequences.Observed, qt.IsTrue)
+	c.Assert(sequences.ServerDoes, qt.IsTrue)
+	c.Assert(sequences.Reason, qt.Contains, "banner substring")
+
+	views := rowFor(c, report.Rows, capability.Views)
+	c.Assert(views.Outcome, qt.Equals, Undecidable)
+
+	c.Assert(report.Mismatches(), qt.HasLen, 1)
+	c.Assert(report.Mismatches()[0].Capability, qt.Equals, capability.Sequences)
+	c.Assert(report.Err(), qt.ErrorMatches, `(?s).*sequences: preset says false, server does true.*`)
+}
+
+// TestReportErr covers the ways a run must refuse to report success.
+func TestReportErr(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range []struct {
+		name  string
+		build func() *Report
+		want  string
+	}{{
+		name: "a matched, measured, fully decided run passes",
+		build: func() *Report {
+			return decidedReport(measuredCell, true)
+		},
+		want: "",
+	}, {
+		name: "a server on no declared line fails",
+		build: func() *Report {
+			report := decidedReport(measuredCell, true)
+			report.Matched = false
+			report.Cell = Cell{}
+			return report
+		},
+		want: `(?s).*this release line is not in the matrix.*`,
+	}, {
+		name: "a line with no measured preset fails",
+		build: func() *Report {
+			report := decidedReport(Cell{
+				Dialect: platform.Postgres, Line: "18",
+				Refinement: RefinedByVersion,
+				Note:       "no measured PostgreSQL 18 preset",
+			}, true)
+			return report
+		},
+		want: `(?s).*has no measured capability preset.*`,
+	}, {
+		name: "a saturated resolution contradicts a measured cell",
+		build: func() *Report {
+			report := decidedReport(measuredCell, true)
+			report.Resolution.Saturated = true
+			report.Resolution.NewestMeasured = "17.x"
+			return report
+		},
+		want: `(?s).*past the newest measured line.*`,
+	}, {
+		name: "a cell naming a preset the resolver did not hand out fails",
+		build: func() *Report {
+			report := decidedReport(measuredCell, true)
+			report.Resolution.Capabilities = capability.Postgres13()
+			return report
+		},
+		want: `(?s).*names preset Postgres17, but the resolver handed this server a different set.*`,
+	}, {
+		name: "a server that accepts the nonsense control invalidates the run",
+		build: func() *Report {
+			report := decidedReport(measuredCell, true)
+			report.Control = Attempt{Statement: nonsenseControl, Accepted: true}
+			return report
+		},
+		want: `(?s).*ACCEPTED the nonsense control.*`,
+	}, {
+		name: "a dialect with no statement table fails rather than reporting agreement",
+		build: func() *Report {
+			report := decidedReport(measuredCell, true)
+			report.Planned = false
+			return report
+		},
+		want: `(?s).*no statement table for the postgres dialect.*`,
+	}} {
+		c.Run(tc.name, func(c *qt.C) {
+			assertErrMatches(c, tc.build().Err(), tc.want)
+		})
+	}
+}
+
+// TestRun_RefusesAnEmptyMatrix pins the guard that stops a matrix covering
+// nothing from reporting a clean run. The URL is never dialed: the refusal
+// happens before any connection is attempted, which is what makes it a matrix
+// guard rather than a connection error.
+func TestRun_RefusesAnEmptyMatrix(t *testing.T) {
+	c := qt.New(t)
+
+	original := Cells
+	defer func() { Cells = original }()
+	Cells = nil
+
+	_, err := Run(context.Background(), "postgres://nobody@127.0.0.1:1/none")
+	c.Assert(err, qt.ErrorMatches, `the capability matrix declares no cells; refusing to report a vacuous pass`)
+}
+
+// TestUnmetRequirement pins the ordering the registry's own edge implies: on a
+// server without the generic DROP CONSTRAINT clause, the guarded spelling is
+// refused for the missing clause, so scoring the guard false would answer a
+// question the run never asked.
+func TestUnmetRequirement(t *testing.T) {
+	c := qt.New(t)
+
+	guardExperiment := experiment{
+		decides:  []capability.Capability{capability.DropConstraintIfExists},
+		requires: []capability.Capability{capability.DropConstraintGeneric},
+	}
+	for _, tc := range []struct {
+		name         string
+		observations map[capability.Capability]observation
+		wantMet      bool
+	}{{
+		name:         "requirement decided true",
+		observations: map[capability.Capability]observation{capability.DropConstraintGeneric: decided(true)},
+		wantMet:      true,
+	}, {
+		name:         "requirement decided false",
+		observations: map[capability.Capability]observation{capability.DropConstraintGeneric: decided(false)},
+		wantMet:      false,
+	}, {
+		name:         "requirement itself undecidable",
+		observations: map[capability.Capability]observation{capability.DropConstraintGeneric: cannotDecide("no")},
+		wantMet:      false,
+	}, {
+		name:         "requirement not observed at all",
+		observations: map[capability.Capability]observation{},
+		wantMet:      false,
+	}} {
+		c.Run(tc.name, func(c *qt.C) {
+			_, met := unmetRequirement(guardExperiment, tc.observations)
+			c.Assert(met, qt.Equals, tc.wantMet)
+		})
+	}
+}
+
+// decidedReport builds a report whose every row agrees, so a test can add the
+// single defect it is about.
+func decidedReport(cell Cell, matched bool) *Report {
+	preset := capability.Postgres17()
+	report := reportOn(cell, matched, preset)
+	report.Planned = true
+	report.Control = Attempt{Statement: nonsenseControl}
+	report.Resolution.Capabilities = preset
+	report.Resolution.VersionSpecific = true
+
+	observations := map[capability.Capability]observation{}
+	for _, key := range capability.All() {
+		observations[key] = decided(preset.Has(key))
+	}
+	report.Rows = assemble(report, observations, nil)
+	return report
+}
+
+func rowFor(c *qt.C, rows []Row, key capability.Capability) Row {
+	for _, row := range rows {
+		if row.Capability == key {
+			return row
+		}
+	}
+	c.Fatalf("no row for capability %q", key)
+	return Row{}
+}
+
+// assertErrMatches keeps the empty-expectation branch out of the test body.
+func assertErrMatches(c *qt.C, err error, want string) {
+	checks := map[bool]func(){
+		true:  func() { c.Assert(err, qt.IsNil) },
+		false: func() { c.Assert(err, qt.ErrorMatches, want) },
+	}
+	checks[want == ""]()
+}

--- a/internal/capabilityprobe/render.go
+++ b/internal/capabilityprobe/render.go
@@ -1,0 +1,188 @@
+package capabilityprobe
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// WriteCells prints the matrix: every release line the probe covers, in
+// declaration order.
+func WriteCells(w io.Writer) {
+	fmt.Fprintf(w, "capability matrix cells (%d)\n\n", len(Cells))
+	fmt.Fprintf(w, "%-13s %-8s %-16s %-17s %s\n", "DIALECT", "LINE", "PRESET", "REFINEMENT", "IMAGE")
+	for _, cell := range Cells {
+		preset := cell.PresetName
+		if preset == "" {
+			preset = "(none)"
+		}
+		fmt.Fprintf(w, "%-13s %-8s %-16s %-17s %s\n", cell.Dialect, cell.Line, preset, cell.Refinement, cell.Image)
+		if cell.Note != "" {
+			fmt.Fprintf(w, "%-13s %-8s %s\n", "", "", "note: "+cell.Note)
+		}
+	}
+}
+
+// WriteReport prints one probe run: the table, the summary, and why each
+// undecidable row is undecidable.
+func WriteReport(w io.Writer, r *Report) {
+	writeHeader(w, r)
+	fmt.Fprintf(w, "\n%-38s %-12s %-12s %s\n", "CAPABILITY", "PRESET SAYS", "SERVER DOES", "OUTCOME")
+	for _, row := range r.Rows {
+		fmt.Fprintf(w, "%-38s %-12t %-12s %s\n", row.Capability, row.PresetSays, serverDoes(row), row.Outcome)
+	}
+	writeSummary(w, r)
+	writeAnnotations(w, r)
+}
+
+// WriteEvidence prints every statement the run executed and the server's own
+// answer to it. It is separate from WriteReport because the table is the
+// deliverable and the evidence is the appeal: a reader who doubts a row should
+// be able to re-execute it by hand from these lines.
+func WriteEvidence(w io.Writer, r *Report) {
+	fmt.Fprintf(w, "\nevidence:\n")
+	for _, row := range r.Rows {
+		if len(row.Attempts) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "  %s\n", row.Capability)
+		for _, attempt := range row.Attempts {
+			fmt.Fprintf(w, "      %s\n", attempt)
+		}
+	}
+	if len(r.Cleanup) > 0 {
+		fmt.Fprintf(w, "  cleanup\n")
+		for _, attempt := range r.Cleanup {
+			fmt.Fprintf(w, "      %s\n", attempt)
+		}
+	}
+}
+
+func serverDoes(row Row) string {
+	if !row.Observed {
+		return "-"
+	}
+	return fmt.Sprintf("%t", row.ServerDoes)
+}
+
+func writeHeader(w io.Writer, r *Report) {
+	fmt.Fprintf(w, "capability probe\n")
+	fmt.Fprintf(w, "  target       %s\n", r.URL)
+	fmt.Fprintf(w, "  dialect      %s\n", r.Dialect)
+	fmt.Fprintf(w, "  banner       %s\n", r.Banner)
+	fmt.Fprintf(w, "  version      %s (%s)\n", r.Version, r.Version.Source)
+	if r.Matched {
+		fmt.Fprintf(w, "  matrix cell  %s [preset %s, %s]\n", r.Cell, presetOrNone(r.Cell), r.Cell.Refinement)
+	} else {
+		fmt.Fprintf(w, "  matrix cell  NONE — no cell in cells.go covers this release line\n")
+	}
+	fmt.Fprintf(w, "  resolution   version-specific=%t saturated=%t newest-measured=%q\n",
+		r.Resolution.VersionSpecific, r.Resolution.Saturated, r.Resolution.NewestMeasured)
+	writeSessionDeltas(w, r)
+	if r.Namespace != "" {
+		fmt.Fprintf(w, "  namespace    %s\n", r.Namespace)
+	}
+	if r.Control.Statement == "" {
+		fmt.Fprintf(w, "  control      NOT RUN — nothing was executed against this server\n")
+		return
+	}
+	fmt.Fprintf(w, "  control      %s\n", r.Control)
+}
+
+func presetOrNone(cell Cell) string {
+	if cell.PresetName == "" {
+		return "none"
+	}
+	return cell.PresetName
+}
+
+// writeSessionDeltas names the keys the pinned session changed. MySQL 8.4+
+// reads its foreign-key reference policy from restrict_fk_on_non_standard_key,
+// so the same version answers differently depending on how the operator
+// configured the server, and a matrix row that did not say so would be a
+// version claim standing on a session fact.
+func writeSessionDeltas(w io.Writer, r *Report) {
+	if len(r.SessionDeltas) == 0 {
+		fmt.Fprintf(w, "  session      preset unchanged by the pinned session\n")
+		return
+	}
+	names := make([]string, 0, len(r.SessionDeltas))
+	for _, key := range r.SessionDeltas {
+		names = append(names, fmt.Sprintf("%s=%t", key, r.SessionCapabilities.Has(key)))
+	}
+	fmt.Fprintf(w, "  session      pinned session changed %s\n", strings.Join(names, ", "))
+}
+
+func writeSummary(w io.Writer, r *Report) {
+	fmt.Fprintf(w, "\nsummary: %d rows — %d AGREES, %d DISAGREES, %d UNDECIDABLE; decided %d\n",
+		len(r.Rows), r.Count(Agrees), r.Count(Disagrees), r.Count(Undecidable), r.Decided())
+}
+
+func writeAnnotations(w io.Writer, r *Report) {
+	writeUndecidable(w, r)
+	writeMismatches(w, r)
+	noted := rowsWith(r, func(row Row) bool { return row.Note != "" })
+	if len(noted) > 0 {
+		fmt.Fprintf(w, "\nnotes:\n")
+		for _, row := range noted {
+			fmt.Fprintf(w, "  %s\n      %s\n", row.Capability, row.Note)
+		}
+	}
+}
+
+// writeUndecidable groups undecidable rows by reason. A whole dialect can
+// share one reason — six of the nine share the "no version ladder" one — and
+// repeating it per row buries the two or three rows whose reason is their own.
+func writeUndecidable(w io.Writer, r *Report) {
+	undecidable := rowsWith(r, func(row Row) bool { return row.Outcome == Undecidable })
+	if len(undecidable) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\nundecidable rows and why:\n")
+	var order []string
+	grouped := map[string][]Row{}
+	for _, row := range undecidable {
+		if _, seen := grouped[row.Reason]; !seen {
+			order = append(order, row.Reason)
+		}
+		grouped[row.Reason] = append(grouped[row.Reason], row)
+	}
+	for _, reason := range order {
+		rows := grouped[reason]
+		fmt.Fprintf(w, "  %s\n", reason)
+		for _, row := range rows {
+			if row.Observed {
+				fmt.Fprintf(w, "      %-38s observed anyway: server does %-5t (preset says %t)\n",
+					row.Capability, row.ServerDoes, row.PresetSays)
+				continue
+			}
+			fmt.Fprintf(w, "      %s\n", row.Capability)
+		}
+	}
+}
+
+// writeMismatches prints every observation that contradicts the preset,
+// including the ones whose row is undecidable because the line cannot be
+// credited. An unattributable contradiction is still a contradiction; letting
+// UNDECIDABLE swallow it would be the same error as letting AGREES swallow it.
+func writeMismatches(w io.Writer, r *Report) {
+	mismatches := r.Mismatches()
+	if len(mismatches) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\npreset and server disagree:\n")
+	for _, row := range mismatches {
+		fmt.Fprintf(w, "  %-38s preset says %-5t server does %-5t [%s]\n",
+			row.Capability, row.PresetSays, row.ServerDoes, row.Outcome)
+	}
+}
+
+func rowsWith(r *Report, keep func(Row) bool) []Row {
+	var out []Row
+	for _, row := range r.Rows {
+		if keep(row) {
+			out = append(out, row)
+		}
+	}
+	return out
+}

--- a/internal/capabilityprobe/session.go
+++ b/internal/capabilityprobe/session.go
@@ -1,0 +1,203 @@
+package capabilityprobe
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// Attempt is one statement and the server's answer to it.
+//
+// Both halves are kept. A row that says only "the server refused" cannot be
+// argued with; a row that quotes the statement and the server's own error text
+// can be re-executed by hand from the report.
+type Attempt struct {
+	Statement string
+	Accepted  bool
+	ServerErr string
+}
+
+// String renders the attempt as one line of evidence.
+func (a Attempt) String() string {
+	if a.Accepted {
+		return "ACCEPTED  " + collapse(a.Statement)
+	}
+	return "REFUSED   " + collapse(a.Statement) + "  -> " + collapse(a.ServerErr)
+}
+
+func collapse(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// session is a pinned physical connection inside a throwaway namespace.
+//
+// It is pinned because the namespace is session state: a pooled connection
+// would run half the statements in the probe schema and half in the caller's.
+// It is a namespace rather than a transaction because PostgreSQL refuses
+// CREATE INDEX CONCURRENTLY inside an explicit transaction block, so
+// BEGIN/ROLLBACK isolation would report two true capabilities as false.
+type session struct {
+	conn      *dbschema.DatabaseConnection
+	dialect   string
+	namespace string
+	// roles are cluster-scoped objects the probe created; dropping the
+	// namespace does not remove them.
+	roles []string
+	// broken records the transport failure that ended the run, if any.
+	broken error
+	// inExplicitTransaction suspends the liveness check.
+	//
+	// One decider deliberately provokes a refusal inside an explicit
+	// transaction block, and PostgreSQL then answers every statement —
+	// including SELECT 1 — with "current transaction is aborted". Reading that
+	// as a dead session would abort the run at exactly the statement the run
+	// exists to make. The check resumes after the ROLLBACK, where a truly dead
+	// session still fails.
+	inExplicitTransaction bool
+}
+
+// exec runs one statement and reports what the server did.
+//
+// A refusal is an observation, not an error: the whole point of the probe is
+// that some statements must be refused. A DROPPED CONNECTION is a different
+// thing entirely, and reading it as a refusal would report every remaining
+// capability as absent. So after any failure the session is asked whether it
+// is still alive, and a dead session poisons the run instead of answering it.
+func (s *session) exec(ctx context.Context, statement string) Attempt {
+	if s.broken != nil {
+		return Attempt{Statement: statement, ServerErr: "session already broken: " + s.broken.Error()}
+	}
+	_, err := s.conn.ExecContext(ctx, statement)
+	if err == nil {
+		return Attempt{Statement: statement, Accepted: true}
+	}
+	if s.inExplicitTransaction {
+		return Attempt{Statement: statement, ServerErr: err.Error()}
+	}
+	if alive := s.alive(ctx); alive != nil {
+		s.broken = fmt.Errorf("session died executing %q: %w (statement error: %w)", statement, alive, err)
+		return Attempt{Statement: statement, ServerErr: s.broken.Error()}
+	}
+	return Attempt{Statement: statement, ServerErr: err.Error()}
+}
+
+// query runs a single-value query and reports the value alongside the attempt.
+func (s *session) query(ctx context.Context, statement string) (int64, Attempt) {
+	if s.broken != nil {
+		return 0, Attempt{Statement: statement, ServerErr: "session already broken: " + s.broken.Error()}
+	}
+	var value int64
+	err := s.conn.QueryRowContext(ctx, statement).Scan(&value)
+	if err == nil {
+		return value, Attempt{Statement: statement, Accepted: true}
+	}
+	if alive := s.alive(ctx); alive != nil {
+		s.broken = fmt.Errorf("session died executing %q: %w (statement error: %w)", statement, alive, err)
+		return 0, Attempt{Statement: statement, ServerErr: s.broken.Error()}
+	}
+	return 0, Attempt{Statement: statement, ServerErr: err.Error()}
+}
+
+// alive returns nil while the session can still answer.
+func (s *session) alive(ctx context.Context) error {
+	var one int
+	if err := s.conn.QueryRowContext(ctx, "SELECT 1").Scan(&one); err != nil {
+		return err
+	}
+	if one != 1 {
+		return fmt.Errorf("session answered SELECT 1 with %d", one)
+	}
+	return nil
+}
+
+// runAll executes statements in order and stops at the first refusal.
+func (s *session) runAll(ctx context.Context, statements []string) ([]Attempt, bool) {
+	attempts := make([]Attempt, 0, len(statements))
+	for _, statement := range statements {
+		attempt := s.exec(ctx, statement)
+		attempts = append(attempts, attempt)
+		if !attempt.Accepted {
+			return attempts, false
+		}
+	}
+	return attempts, true
+}
+
+// tryInTransaction runs one statement inside an explicit transaction block and
+// always rolls back.
+//
+// The block is the measurement, not the isolation: a real concurrent index
+// build cannot live inside a transaction and a parser that merely swallows the
+// CONCURRENTLY keyword has no reason to refuse it, so the refusal is the
+// evidence. Liveness checking is suspended for the duration because an aborted
+// PostgreSQL transaction answers SELECT 1 with an error too, and resumes on the
+// far side of the ROLLBACK.
+func (s *session) tryInTransaction(ctx context.Context, statement string) ([]Attempt, bool) {
+	begin := s.exec(ctx, "BEGIN")
+	if !begin.Accepted {
+		return []Attempt{begin}, false
+	}
+	s.inExplicitTransaction = true
+	inside := s.exec(ctx, statement)
+	s.inExplicitTransaction = false
+	rollback := s.exec(ctx, "ROLLBACK")
+	return []Attempt{begin, inside, rollback}, true
+}
+
+// nonsenseControl is the statement the server MUST refuse.
+//
+// Every "the server accepted it" row is only worth reading if the server is
+// capable of saying no on this session. A connection that answers OK to
+// everything — a proxy that swallows DDL, a dry-run wrapper, a driver that
+// defers errors — would otherwise fill the matrix with agreements nobody
+// earned. The capability presets already use this exact control in their own
+// doc comments; here it gates the whole run.
+const nonsenseControl = "CREATE NONSENSE ptah_capability_probe_control"
+
+// namespaceSQL returns the statements that create and enter the throwaway
+// namespace, and the statement that removes it.
+func namespaceSQL(dialect, namespace string) (enter []string, leave string) {
+	if platform.IsPostgresFamily(dialect) {
+		return []string{
+				"CREATE SCHEMA " + namespace,
+				"SET search_path TO " + namespace,
+			},
+			"DROP SCHEMA " + namespace + " CASCADE"
+	}
+	return []string{
+			"CREATE DATABASE " + namespace,
+			"USE " + namespace,
+		},
+		"DROP DATABASE " + namespace
+}
+
+// newNamespace returns a fresh identifier no other run will collide with. The
+// machine this is developed on routinely has forty containers and several
+// agents pointed at the same server, and a fixed name turns another run's
+// leftovers into this run's capability findings.
+func newNamespace() (string, error) {
+	raw := make([]byte, 8)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate probe namespace: %w", err)
+	}
+	return "ptah_capprobe_" + hex.EncodeToString(raw), nil
+}
+
+// dropRoles removes the cluster-scoped roles the probe created. Roles outlive
+// the schema, so a run that forgot them would leave the server dirtier every
+// time it ran.
+func (s *session) dropRoles(ctx context.Context) []Attempt {
+	attempts := make([]Attempt, 0, 2*len(s.roles))
+	for _, role := range s.roles {
+		attempts = append(attempts,
+			s.exec(ctx, "DROP OWNED BY "+role),
+			s.exec(ctx, "DROP ROLE IF EXISTS "+role),
+		)
+	}
+	return attempts
+}

--- a/internal/capabilityprobe/version.go
+++ b/internal/capabilityprobe/version.go
@@ -1,0 +1,142 @@
+package capabilityprobe
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// Version is a server's product version, corrected per dialect.
+//
+// It exists because one parser cannot read nine banners. The shared
+// capability.parseVersion takes the first dotted run of digits it finds, which
+// is right for six dialects and wrong for two:
+//
+//   - SQL Server's @@VERSION opens with the marketing year, so the shared parse
+//     reads "Microsoft SQL Server 2025 (RTM-CU7) ... 17.0.4065.4" as major
+//     2025. That is latent today only because the sqlserver dialect never
+//     reaches capability.go's version switch; it becomes a live mis-selection
+//     the day a `case platform.SQLServer:` is added. It is not latent HERE: a
+//     matrix cell labeled by the marketing year would be measuring a version
+//     that does not exist.
+//   - YugabyteDB's banner opens with the PostgreSQL compatibility version, so
+//     the shared parse reads "PostgreSQL 15.12-YB-2026.1.0.0-b0" as 15.12 when
+//     the product is 2026.1.0.0. That one is masked in capability.go because
+//     the "-yb-" banner match fires before the parse runs.
+//
+// MariaDB is a third instance of the same class, already special-cased in
+// capability.go by trimming the fake "5.5.5-" replication prefix. Correcting
+// the class rather than the one instance the issue named is why this is a
+// per-dialect extractor and not another single parser.
+type Version struct {
+	// Raw is the banner the extractor was given.
+	Raw string
+	// Numbers are the numeric components in order, most significant first.
+	Numbers []int
+	// Source names where the numbers came from, for the report.
+	Source string
+}
+
+// Components renders the numeric components as strings for cell matching.
+func (v Version) Components() []string {
+	out := make([]string, 0, len(v.Numbers))
+	for _, n := range v.Numbers {
+		out = append(out, strconv.Itoa(n))
+	}
+	return out
+}
+
+// String renders the dotted version.
+func (v Version) String() string {
+	return strings.Join(v.Components(), ".")
+}
+
+// mariaDBReplicationPrefix is the fake version MariaDB prepends when speaking
+// the MySQL protocol ("5.5.5-10.11.6-MariaDB").
+const mariaDBReplicationPrefix = "5.5.5-"
+
+// ParseVersion extracts the product version from a live server banner.
+//
+// productVersion, when non-empty, is a version the caller read from a
+// dedicated catalog surface rather than from the banner — today that is
+// SERVERPROPERTY('ProductVersion') on SQL Server, which reports the clean
+// four-part build with no marketing year in front of it. It wins over any
+// banner heuristic, because a heuristic is a guess about text and this is the
+// server's own answer.
+func ParseVersion(dialect, banner, productVersion string) (Version, error) {
+	if trimmed := strings.TrimSpace(productVersion); trimmed != "" {
+		numbers, ok := leadingNumbers(trimmed)
+		if !ok {
+			return Version{}, fmt.Errorf("no numeric version in product version %q", productVersion)
+		}
+		return Version{Raw: banner, Numbers: numbers, Source: "server product version"}, nil
+	}
+
+	text, source := versionText(platform.NormalizeDialect(dialect), banner)
+	numbers, ok := leadingNumbers(text)
+	if !ok {
+		return Version{}, fmt.Errorf("no numeric version in %q", banner)
+	}
+	return Version{Raw: banner, Numbers: numbers, Source: source}, nil
+}
+
+// versionText narrows a banner to the substring that holds the PRODUCT
+// version, and names which rule did the narrowing.
+func versionText(dialect, banner string) (text, source string) {
+	switch dialect {
+	case platform.SQLServer:
+		// "Microsoft SQL Server 2025 (RTM-CU7) (KB...) - 17.0.4065.4 (X64) ..."
+		// The product version is the token after the first " - "; everything
+		// before it is the marketing year and the servicing label.
+		if _, after, found := strings.Cut(banner, " - "); found {
+			return after, "banner text after the first \" - \" (the marketing year precedes it)"
+		}
+		return banner, "banner (no \" - \" separator found)"
+	case platform.YugabyteDB:
+		// "PostgreSQL 15.12-YB-2026.1.0.0-b0 on aarch64 ..." — the leading
+		// number is the PostgreSQL compatibility version, not the product.
+		if _, after, found := strings.Cut(strings.ToUpper(banner), "-YB-"); found {
+			return after, "banner text after \"-YB-\" (the PostgreSQL compatibility version precedes it)"
+		}
+		return banner, "banner (no \"-YB-\" marker found)"
+	case platform.MariaDB:
+		return strings.TrimPrefix(banner, mariaDBReplicationPrefix), "banner with the 5.5.5- replication prefix trimmed"
+	default:
+		return banner, "banner"
+	}
+}
+
+// leadingNumbers returns the first dotted run of digits in s.
+func leadingNumbers(s string) ([]int, bool) {
+	i := 0
+	for i < len(s) && !isDigit(s[i]) {
+		i++
+	}
+	if i == len(s) {
+		return nil, false
+	}
+	var numbers []int
+	for i < len(s) && isDigit(s[i]) {
+		start := i
+		value := 0
+		for i < len(s) && isDigit(s[i]) {
+			value = value*10 + int(s[i]-'0')
+			i++
+		}
+		if start == i {
+			break
+		}
+		numbers = append(numbers, value)
+		if i == len(s) || s[i] != '.' {
+			break
+		}
+		i++
+	}
+	return numbers, len(numbers) > 0
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}

--- a/internal/capabilityprobe/version_test.go
+++ b/internal/capabilityprobe/version_test.go
@@ -1,0 +1,106 @@
+package capabilityprobe_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/capabilityprobe"
+)
+
+// sqlServer2025Banner is what @@VERSION returned from a live
+// mcr.microsoft.com/mssql/server:2025-latest container, verbatim including the
+// embedded newlines.
+const sqlServer2025Banner = "Microsoft SQL Server 2025 (RTM-CU7) (KB5096981) - 17.0.4065.4 (X64) \n" +
+	"\tJul  8 2026 23:26:08 \n" +
+	"\tCopyright (C) 2025 Microsoft Corporation\n" +
+	"\tEnterprise Developer Edition (64-bit) on Linux (Ubuntu 24.04.4 LTS) <X64>"
+
+// yugabyteBanner is the shape a YugabyteDB YSQL server reports: the leading
+// number is the PostgreSQL compatibility version, not the product version.
+const yugabyteBanner = "PostgreSQL 15.12-YB-2026.1.0.0-b0 on aarch64-unknown-linux-gnu, compiled by clang, 64-bit"
+
+// TestParseVersion_CorrectsTheBannersOneParserCannotRead pins each dialect's
+// extraction rule against the banner that defeats the shared one.
+//
+// The postgres rows are the control: they use the same "first dotted run of
+// digits" rule capability.parseVersion uses, so seeing them read the SQL Server
+// banner as 2025 and the YugabyteDB banner as 15.12 is what makes the corrected
+// rows mean something. Without the control this test would only assert that a
+// function returns what it was written to return.
+func TestParseVersion_CorrectsTheBannersOneParserCannotRead(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range []struct {
+		name    string
+		dialect string
+		banner  string
+		product string
+		want    string
+	}{{
+		name:    "the shared rule reads the SQL Server marketing year",
+		dialect: platform.Postgres,
+		banner:  sqlServer2025Banner,
+		want:    "2025",
+	}, {
+		name:    "the sqlserver rule reads the product version out of the banner",
+		dialect: platform.SQLServer,
+		banner:  sqlServer2025Banner,
+		want:    "17.0.4065.4",
+	}, {
+		name:    "SERVERPROPERTY('ProductVersion') wins over every banner heuristic",
+		dialect: platform.SQLServer,
+		banner:  sqlServer2025Banner,
+		product: "17.0.4065.4",
+		want:    "17.0.4065.4",
+	}, {
+		name:    "the shared rule reads YugabyteDB's PostgreSQL compatibility version",
+		dialect: platform.Postgres,
+		banner:  yugabyteBanner,
+		want:    "15.12",
+	}, {
+		name:    "the yugabytedb rule reads the product version",
+		dialect: platform.YugabyteDB,
+		banner:  yugabyteBanner,
+		want:    "2026.1.0.0",
+	}, {
+		name:    "MariaDB's fake replication prefix is trimmed",
+		dialect: platform.MariaDB,
+		banner:  "5.5.5-10.11.6-MariaDB-1:10.11.6+maria~ubu2204",
+		want:    "10.11.6",
+	}, {
+		name:    "a MariaDB banner without the prefix is unchanged",
+		dialect: platform.MariaDB,
+		banner:  "11.4.12-MariaDB-ubu2404",
+		want:    "11.4.12",
+	}, {
+		name:    "PostgreSQL",
+		dialect: platform.Postgres,
+		banner:  "PostgreSQL 17.10 (Debian 17.10-1.pgdg13+1) on aarch64-unknown-linux-gnu",
+		want:    "17.10",
+	}, {
+		name:    "MySQL",
+		dialect: platform.MySQL,
+		banner:  "9.7.1",
+		want:    "9.7.1",
+	}, {
+		name:    "CockroachDB",
+		dialect: platform.CockroachDB,
+		banner:  "CockroachDB CCL v26.2.5 (aarch64-unknown-linux-gnu, built 2026/07/28 18:55:27, go1.25.5)",
+		want:    "26.2.5",
+	}} {
+		c.Run(tc.name, func(c *qt.C) {
+			got, err := capabilityprobe.ParseVersion(tc.dialect, tc.banner, tc.product)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got.String(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestParseVersion_RefusesABannerWithNoDigits(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := capabilityprobe.ParseVersion(platform.Postgres, "no digits at all", "")
+	c.Assert(err, qt.ErrorMatches, `no numeric version in "no digits at all"`)
+}


### PR DESCRIPTION
Closes #1339. Refs #916.

`capability-probe` takes one dialect, one version and one live URL, and returns one row per registered capability with `preset says` / `server does`. A disagreement is a failure. A capability it cannot decide is `UNDECIDABLE` with a reason, and undecidable is never folded into agreement.

CI wiring is #1341 and is deliberately not here.

```
go build -o bin/capability-probe ./cmd/capability-probe
bin/capability-probe --list-cells
bin/capability-probe --db-url postgres://postgres:pw@localhost:5432/postgres?sslmode=disable
bin/capability-probe --db-url mysql://root:pw@localhost:3306/mysql --evidence
```

## First output, verbatim

Both runs are from a binary built from this branch's pushed tree, against servers started for this work.

### PostgreSQL 17.10 — exit 0

```
capability probe
  target       postgres://postgres:***@localhost:15339/postgres?sslmode=disable
  dialect      postgres
  banner       PostgreSQL 17.10 (Debian 17.10-1.pgdg13+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 14.2.0-19) 14.2.0, 64-bit
  version      17.10 (banner)
  matrix cell  postgres 17 [preset Postgres17, version-ladder]
  resolution   version-specific=true saturated=false newest-measured="17.x"
  session      preset unchanged by the pinned session
  namespace    ptah_capprobe_235f443246597355
  control      REFUSED   CREATE NONSENSE ptah_capability_probe_control  -> ERROR: syntax error at or near "NONSENSE" (SQLSTATE 42601)

CAPABILITY                             PRESET SAYS  SERVER DOES  OUTCOME
advisory_locks                         true         true         AGREES
alter_generated_column_expression      true         true         AGREES
check_constraints_enforced             true         true         AGREES
create_index_concurrently              true         true         AGREES
create_or_replace_trigger              true         true         AGREES
drop_check_clause                      false        false        AGREES
drop_constraint_generic                true         true         AGREES
drop_constraint_if_exists              true         true         AGREES
drop_index_concurrently                true         true         AGREES
drop_index_if_exists                   true         true         AGREES
enum_custom_type                       true         true         AGREES
enum_inline_column                     false        false        AGREES
foreign_keys                           true         true         AGREES
foreign_keys_create_backing_index      false        false        AGREES
foreign_keys_require_indexed_reference false        false        AGREES
foreign_keys_require_unique_reference  true         true         AGREES
functions                              true         true         AGREES
materialized_views                     true         true         AGREES
role_management                        true         true         AGREES
row_level_security                     true         true         AGREES
sequences                              true         true         AGREES
triggers                               true         true         AGREES
views                                  true         true         AGREES
xml_type                               true         true         AGREES

summary: 24 rows — 24 AGREES, 0 DISAGREES, 0 UNDECIDABLE; decided 24
```

### MySQL 9.7.1 — exit 0

```
capability probe
  target       mysql://root:***@localhost:33339/mysql
  dialect      mysql
  banner       9.7.1
  version      9.7.1 (banner)
  matrix cell  mysql 9.7 [preset MySQL84, version-ladder]
  resolution   version-specific=true saturated=false newest-measured="9.x"
  session      preset unchanged by the pinned session
  namespace    ptah_capprobe_1754e169bc5babfc
  control      REFUSED   CREATE NONSENSE ptah_capability_probe_control  -> Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'NONSENSE ptah_capability_probe_control' at line 1

CAPABILITY                             PRESET SAYS  SERVER DOES  OUTCOME
advisory_locks                         false        false        AGREES
alter_generated_column_expression      false        false        AGREES
check_constraints_enforced             true         true         AGREES
create_index_concurrently              false        false        AGREES
create_or_replace_trigger              false        false        AGREES
drop_check_clause                      true         true         AGREES
drop_constraint_generic                true         true         AGREES
drop_constraint_if_exists              false        false        AGREES
drop_index_concurrently                false        false        AGREES
drop_index_if_exists                   false        false        AGREES
enum_custom_type                       false        false        AGREES
enum_inline_column                     true         true         AGREES
foreign_keys                           true         true         AGREES
foreign_keys_create_backing_index      false        false        AGREES
foreign_keys_require_indexed_reference false        false        AGREES
foreign_keys_require_unique_reference  true         true         AGREES
functions                              true         true         AGREES
materialized_views                     false        false        AGREES
role_management                        false        -            UNDECIDABLE
row_level_security                     false        false        AGREES
sequences                              false        false        AGREES
triggers                               true         true         AGREES
views                                  true         true         AGREES
xml_type                               false        false        AGREES

summary: 24 rows — 23 AGREES, 0 DISAGREES, 1 UNDECIDABLE; decided 23

undecidable rows and why:
  the key names the PostgreSQL role and privilege surface no MySQL-family code path consults; this server's own CREATE ROLE and GRANT are a different surface, so accepting them would not decide the key
      role_management

notes:
  alter_generated_column_expression
      this key names PostgreSQL 17's SET EXPRESSION spelling, which is what was probed; the MySQL family can change a generated column expression under its own MODIFY COLUMN spelling, so a false row here means "not this statement", not "not this ability"
  materialized_views
      the keyword was accepted and then dropped: the view reported 0 before the source row was inserted and 1 after, so the result is recomputed rather than stored
```

**No preset defect was found on PostgreSQL 17.10, MySQL 9.7.1 or MariaDB 11.4.12.** MariaDB 11.4.12 also ran clean: 22 AGREES, 0 DISAGREES, 2 UNDECIDABLE (`role_management` and `sequences`).

## The honest first output for the dialects that do not refine by version

Six of the nine dialects get whole columns of UNDECIDABLE, and that is the correct result rather than a defect. Two of them were run live.

**CockroachDB v26.2.5** — 24 UNDECIDABLE, decided 0, **exit 1**:

```
summary: 24 rows — 0 AGREES, 0 DISAGREES, 24 UNDECIDABLE; decided 0
...
capability-probe: role_management: preset says false, server does true
row_level_security: preset says false, server does true
sequences: preset says false, server does true
this run decided 0 of 24 capability rows; a probe that measured nothing must not read as a probe that passed
```

The reason on every row: *the cockroachdb preset is selected by a banner substring before any version is parsed, so every release of this engine receives CockroachDB23 and an observation on one release cannot be credited to this line.*

Two things worth noting. The observation survives the undecidable verdict, so the three places where CockroachDB v26.2.5 contradicts `CockroachDB23()` are reported and still fail the run rather than being absorbed by the word UNDECIDABLE — that is #916 material. And `create_index_concurrently` carries the note *the server accepted the statement inside an explicit transaction block as well, so the keyword is parsed and dropped rather than changing how the index is built*.

**SQL Server 2025** — 24 UNDECIDABLE, exit 1, reason *no probe plan exists for the sqlserver dialect*. The header reads `version 17.0.4065.4 (server product version)` and `matrix cell sqlserver 17.0 (SQL Server 2025)`: the corrected parse works against the live server. The shared `parseVersion` reads the same banner as major **2025**, which `version_test.go` pins as a control.

## The four ways this deliverable fails in the direction that looks like success

Each mutant was built, run, watched go red, restored, and watched go green.

### 1. A preset claiming a capability the live server does not have

`MySQL84().XMLType: false -> true`. **The entire unit suite stays green under this mutant** (`go test ./... -count=1`, 191 packages ok) — nothing in the build catches it. The probe does:

```
xml_type                               true         false        DISAGREES
...
capability-probe: xml_type: preset says true, server does false          (exit 1)
```

Restored: `xml_type false false AGREES`, exit 0.

(My first attempt used `DropIndexIfExists`, which `capability_test.go` already pins by hand — the unit suite caught it, so it did not isolate the probe. Swapping to a key nothing pins is what makes the mutant measure this PR.)

### 2. UNDECIDABLE folded into agreement

`assemble`: `row.Outcome = Undecidable` -> `row.Outcome = Agrees` for an undecided key.

```
--- FAIL: TestAssemble_ThreeOutcomes/an_undecided_key_stays_undecidable_and_never_becomes_agreement
    got "AGREES" want "UNDECIDABLE"
--- FAIL: TestAssemble_UndecidableRowsAreNotCountedAsDecided
    got int(0) want int(24)
```

**2b, the subtler fold:** derive line attribution from `VersionResolution.VersionSpecific` instead of the declared refinement — exactly the trap the field invites, because it is `true` for a banner-matched CockroachDB that never consulted a version. `TestAssemble_AnUnattributableLineKeepsTheObservation` goes red (`got "DISAGREES" want "UNDECIDABLE"`), and live CockroachDB v26.2.5 flips from 24 UNDECIDABLE to **21 AGREES / 3 DISAGREES / decided 24** — a whole release line certified by an observation the resolver cannot distinguish from v25.4's.

### 3. A run that measured nothing reporting success

- **No cell for the line.** Mutant: `CellFor` falls back to the dialect's first measured cell. `TestCellFor` goes red on three rows. Live: a PostgreSQL 13.23 server is labeled `matrix cell postgres 17 [preset Postgres17]` under the mutant. Restored, the same server reports `matrix cell NONE`, 24 UNDECIDABLE, decided 0, exit 1.
- **Zero cells.** `TestRun_RefusesAnEmptyMatrix` — `Run` refuses before dialing.
- **URL does not resolve.** Exit 1: `connect to postgres://postgres:***@localhost:1/nosuchdb...: failed to ping database: ... connection refused`.
- **A server that cannot say no.** Every run first executes `CREATE NONSENSE ptah_capability_probe_control` and fails if it is accepted.

### 4. A deciding statement accepted for an unrelated reason

Constructed twice, on live servers, and the probe is not fooled either time.

- **MySQL 9.7.1 accepts `CREATE MATERIALIZED VIEW`.** Mutant: decide `materialized_views` by acceptance alone (the cheaper implementation). Result: `materialized_views false true DISAGREES` — a false disagreement against a correct preset. The shipped decider reads the view before and after an insert into the source table, sees 0 then 1, and reports `false`.
- **CockroachDB v26.2.5 accepts `CREATE INDEX CONCURRENTLY`.** Mutant: decide by acceptance alone. Result: `create_index_concurrently ... server does true`. On real PostgreSQL the same mutant looks perfectly fine (`AGREES`) — it lies only about the server you do not have. The shipped decider requires the refusal PostgreSQL gives inside an explicit transaction block.

There is a third case I did **not** decide, by design: MySQL 9.7.1 accepts `CREATE ROLE m_role` and `GRANT SELECT ... TO m_role` (both exit 0, measured) while `MySQL84().RoleManagement` is `false`. That key names the PostgreSQL role surface no MySQL-family code path reads, so it is declared undecidable for the MySQL family in advance, as data in `plans.go` — not derived from an outcome. `MariaDB1011().Sequences` is the same shape (#931 item 8).

## Adding a release line is a data change

Added a PostgreSQL 13 cell. The whole diff:

```diff
+	{
+		Dialect: platform.Postgres, Line: "13",
+		Preset: capability.Postgres13, PresetName: "Postgres13",
+		Refinement: RefinedByVersion, Image: "postgres:13",
+		Note: "...",
+	},
```

Before, against a live PostgreSQL 13.23: `matrix cell NONE`, decided 0, exit 1. After: `matrix cell postgres 13 [preset Postgres13, version-ladder]`, **24 AGREES, decided 24, exit 0**. Adding the cell is what promoted the line, and it independently validated `Postgres13()` against a real server. The cell is kept.

`--list-cells` prints all 24 cells. `postgres 18` and `mariadb 12.3` carry no preset: probing them fails with the line named rather than quietly accepting a preset chosen by saturation. Those are the cells #1239 and #108 are waiting on.

## Two things the matrix surfaced

**MySQL 8.4+'s foreign-key reference policy is a session fact, not a version fact.** With `restrict_fk_on_non_standard_key = OFF` the same MySQL 9.7.1 server reports:

```
  session      pinned session changed foreign_keys_require_indexed_reference=true, foreign_keys_require_unique_reference=false
...
foreign_keys_require_indexed_reference true         true         AGREES
foreign_keys_require_unique_reference  false        false        AGREES
```

Both sides moved together — `dbschema.refineMySQLForeignKeyCapabilities` already reads the variable on the pinned session. No boolean keyed on version alone is correct for both settings; the probe now measures both halves and the report names the delta.

**The gating gap is wider than the version-refinement gap.** ClickHouse, SQLite and SQL Server have no probe plan here, and every row for them is undecidable with that stated rather than counted as agreement.

## Design constraints the implementation is built around

- **No transaction as the isolation mechanism.** PostgreSQL refuses `CREATE INDEX CONCURRENTLY` inside an explicit transaction block (measured: exit 0 standalone, exit 1 inside `BEGIN`), so BEGIN/ROLLBACK would report two true capabilities as false. Each run uses a throwaway schema (PostgreSQL family) or database (MySQL family) named `ptah_capprobe_<random>` and drops it. If the session dies mid-run the error names the namespace left behind rather than littering silently.
- **The foreign-key reference policy is one experiment yielding three rows**, with a control (a foreign key to a declared unique key must be accepted) so a server refusing foreign keys outright does not read as a policy choice. Three independent probes could produce a combination `Validate` rejects.
- **`drop_constraint_if_exists` is ordered after `drop_constraint_generic`** and recorded undecidable when the generic clause is absent — the registry's own `requires` edge. It also probes both spellings the key covers, including `DROP FOREIGN KEY IF EXISTS`.
- **Every IF EXISTS key needs its unguarded twin refused.** Acceptance of the guarded form alone would also pass on a permissive server.
- **Every registered capability is answered exactly once per dialect plan**, enforced by `TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce`. A new capability turns the build red until the plans answer for it, instead of silently vanishing from every row.

## Gates

All run on the pushed tree after pulling it back (the files were pushed through the GitHub API, so the compiler re-checked them rather than my eyes):

| gate | result |
|---|---|
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 0 |
| `go vet -tags integration ./integration/...` | exit 0 |
| `go test ./... -count=1` | exit 0, 191 packages ok |
| `go tool qtlint ./...` | exit 0 |
| `golangci-lint run ./...` | 0 issues |
| `scripts/check-test-style.sh` | OK (175 conditional groups, 42 white-box files) |
| `scripts/check-public-api.sh` | exit 0 |
| `scripts/check-public-api-snapshot.sh` | exit 0 |
| `scripts/check-public-api-released.sh` | exit 0 (only pre-existing approved incompatibilities) |
| `docs/site` `check:exit-codes` (+selftest) | OK (60 reference rows) |
| `docs/site` `check:core-doc-links` | OK (7 protected core references) |
| `docs/site` `check:page-health` | OK (59 sidebar entries) |
| `docs/site` `check:links` (+selftest) | OK (60 pages, 60 routes, 616 heading anchors) |
| `docs/site` `check:redirects` (+selftest) | OK (30 redirects) |
| `docs/site` `check:style` (+selftest) | OK (100 documentation files) |
| `docs/site` `check:limitations` (+selftest) | OK (1 governed page) |
| `docs/site` `check:responsive` (+selftest) | OK (60 routes x 2 viewports) |
| `docs/site` `versions:selftest` | OK |

The new code is `internal/` plus a `cmd/` main, so it needs no `docs/public_api.md` entry; the three public-API scripts confirm that rather than my assuming it.

## What I did not do

- No ClickHouse, SQLite or SQL Server statement tables. Their rows are undecidable with the reason, not agreements.
- No Spanner row was executed — there is no Spanner server (#942), which the `SpannerPostgres` doc already concedes.
- No YugabyteDB server was run. Its version-extraction rule is pinned by a unit test against the banner shape, not against a live server.
- The `foreign_keys_create_backing_index` row was only ever decided *negatively*; deciding it positively needs a target that accepts a foreign key to an unindexed column, and no such server was available.
- No CI wiring (#1341).