### PR TITLE
Derive the executable-comment version guard from the server

### DIFF
--- a/docs/pre-migration-checks.md
+++ b/docs/pre-migration-checks.md
@@ -173,6 +173,17 @@ prefixes remain part of the executable SQL body. The effective form must still
 contain exactly one top-level `SELECT`, so an internal statement delimiter or a
 non-`SELECT` body fails closed before the query runs.
 
+A guard is compared the way the server compares it: the body counts as real SQL
+whenever the guard is less than or equal to the server's own version number,
+encoded as `major*10000 + minor*100 + patch`. `/*!80000 ... */` is therefore live
+on MySQL 8.0 and on everything newer, not only on 8.0. Do not use a large guard
+to park SQL you intend to stay inert — server versions keep rising, and a guard
+that was unreachable when it was written stops being unreachable. MySQL 26.7
+encodes as `260700`, so it honors `/*!99999 ... */`. MariaDB is the exception in
+one band only: it ignores MySQL guards from `50700` through `99999` outright
+whatever its own version is, and reads anything above that band as a MariaDB
+version.
+
 ## Bypassing checks
 
 Checks are an additive, finer-grained safety gate that composes with the coarse

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -87,6 +87,13 @@ evaluates version guards against the connected server. Numeric prefixes shorter
 than five digits remain part of the executable SQL body. Hidden statement
 delimiters and non-`SELECT` effective bodies fail closed before query execution.
 
+A guard counts as live whenever it is less than or equal to the server's own
+version number (`major*10000 + minor*100 + patch`), so `/*!80000 ... */` runs on
+MySQL 8.0 and on every later release too. A large guard is not a way to keep SQL
+inert: MySQL 26.7 encodes as `260700` and honors `/*!99999 ... */`. MariaDB
+ignores the MySQL `50700`-`99999` band whatever its own version is, and treats
+higher numbers as MariaDB versions.
+
 A failure aborts before any body statement, matching Atlas's
 enforcement point. Ptah ignores unrelated embedded files.
 

--- a/migration/migrator/atlas_integration_test.go
+++ b/migration/migrator/atlas_integration_test.go
@@ -135,6 +135,10 @@ func TestAtlasTxtarChecks_MySQLCommentSemanticsIntegration(t *testing.T) {
 	)
 }
 
+func TestAtlasTxtarChecks_MySQLVersionGuardBoundaryIntegration(t *testing.T) {
+	runAtlasTxtarChecksVersionGuardBoundaryIntegration(t, mysqlAtlasTestURL(t))
+}
+
 func TestAtlasTxtarChecks_MySQLExecutableCommentEscapeIntegration(t *testing.T) {
 	runAtlasTxtarChecksMySQLExecutableCommentEscapeIntegration(
 		t,
@@ -156,6 +160,10 @@ func TestAtlasTxtarChecks_MariaDBCommentSemanticsIntegration(t *testing.T) {
 		mariaDBAtlasTestURL(t),
 		"/*!50700 SELECT 0 */ SELECT 1",
 	)
+}
+
+func TestAtlasTxtarChecks_MariaDBVersionGuardBoundaryIntegration(t *testing.T) {
+	runAtlasTxtarChecksVersionGuardBoundaryIntegration(t, mariaDBAtlasTestURL(t))
 }
 
 func TestAtlasTxtarChecks_MariaDBShortNumericPrefixRejectsNonSelectIntegration(t *testing.T) {
@@ -1249,6 +1257,16 @@ func runAtlasTxtarChecksMySQLCommentSemanticsIntegration(
 
 	cleanupIssue819(t, conn)
 	defer cleanupIssue819(t, conn)
+
+	// The inert guard is derived from the connected server, never written as a
+	// literal. This fixture used to hard-code /*!99999 ...*/ as "a version no
+	// server will reach"; #791 moved the matrix from mysql:9.7 to mysql:26.7,
+	// whose version id is 260700, so the guard opened and the DELETE in the
+	// comment became live SQL that Ptah then correctly refused. A derived guard
+	// cannot rot that way, and measureExecutableCommentGuard proves it is inert
+	// on this exact server before the fixture leans on it.
+	inertGuard := strconv.Itoa(inertExecutableCommentGuard(c, ctx, conn))
+
 	mig, err := migrator.NewFSMigrator(
 		conn,
 		fstest.MapFS{
@@ -1268,10 +1286,10 @@ SELECT 1;
 -- migration.sql --
 SELECT 1;
 `)},
-			"3_future_version_guard.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+			"3_inert_version_guard.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
 
 -- checks/future.sql --
-/*!99999 DELETE FROM users */ SELECT 1;
+/*!` + inertGuard + ` DELETE FROM users */ SELECT 1;
 
 -- migration.sql --
 SELECT 1;
@@ -1311,6 +1329,156 @@ SELECT 1;
 	current, err := mig.GetCurrentVersion(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(current, qt.Equals, int64(5))
+}
+
+// serverExecutableCommentVersionID encodes a version banner the way MySQL and
+// MariaDB encode their own version when they compare it against an executable
+// comment's numeric guard: major*10000 + minor*100 + patch. MariaDB's 5.5.5-
+// replication prefix is stripped first, and any build suffix ("-log",
+// "-MariaDB-ubu2204") is discarded.
+//
+// It is deliberately written differently from the migrator's own encoder — that
+// one scans digits, this one splits fields — so the two are a cross-check
+// rather than a copy. Neither is trusted on its own either: every caller proves
+// the number is exactly the connected server's version id by probing the server
+// on both sides of it before a fixture depends on it.
+func serverExecutableCommentVersionID(banner string) (int, bool) {
+	numeric := banner
+	if strings.Contains(strings.ToLower(numeric), "mariadb") {
+		numeric = strings.TrimPrefix(numeric, "5.5.5-")
+	}
+	numeric, _, _ = strings.Cut(numeric, "-")
+	parts := strings.Split(numeric, ".")
+	if len(parts) != 3 {
+		return 0, false
+	}
+	scale := [3]int{10000, 100, 1}
+	total := 0
+	for i, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return 0, false
+		}
+		total += value * scale[i]
+	}
+	return total, true
+}
+
+// measureExecutableCommentGuard asks the connected server what it does with a
+// numeric executable-comment guard, rather than assuming. `SELECT 1 /*!N + 1 */`
+// evaluates to 2 when the server honors guard N and 1 when it ignores it, so the
+// return value reports the guard's effect in the only authority that matters.
+func measureExecutableCommentGuard(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection, guard int) int {
+	c.Helper()
+
+	query := "SELECT 1 /*!" + strconv.Itoa(guard) + " + 1 */"
+	var got int
+	c.Assert(conn.QueryRowContext(ctx, query).Scan(&got), qt.IsNil, qt.Commentf("query %q", query))
+	return got
+}
+
+// inertExecutableCommentGuard returns the smallest numeric guard the connected
+// server ignores, and proves it is exactly that before returning.
+//
+// The proof is the pair of probes, and it is what makes the number trustworthy
+// on a server version nobody has run yet. If serverExecutableCommentVersionID
+// under-reports, the guard it calls inert is still honored and the second probe
+// reads 2; if it over-reports, the guard one below is already ignored and the
+// first probe reads 1. Only the true version id passes both, so no fixture can
+// quietly inherit a guard that has stopped being inert — the failure mode #791
+// exposed.
+func inertExecutableCommentGuard(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) int {
+	c.Helper()
+
+	banner := conn.Info().Version
+	serverID, ok := serverExecutableCommentVersionID(banner)
+	c.Assert(ok, qt.IsTrue, qt.Commentf("server version banner %q", banner))
+
+	c.Assert(measureExecutableCommentGuard(c, ctx, conn, serverID), qt.Equals, 2,
+		qt.Commentf("server %q must honor a guard at its own version id %d", banner, serverID))
+	c.Assert(measureExecutableCommentGuard(c, ctx, conn, serverID+1), qt.Equals, 1,
+		qt.Commentf("server %q must ignore a guard one above its version id %d", banner, serverID))
+
+	return serverID + 1
+}
+
+// runAtlasTxtarChecksVersionGuardBoundaryIntegration pins Ptah's
+// executable-comment version arithmetic to the connected server's arithmetic at
+// the exact boundary between the two, on whatever version the matrix runs.
+//
+// The hard-coded /*!99999 ...*/ fixture only ever exercised the inert side of
+// the boundary, and it did so by accident: 99999 happened to sit above every
+// MySQL that existed when it was written. Here both sides are exercised
+// deliberately and the server is measured first, so a release that changes the
+// encoding — or a container bump that walks past a literal, as mysql:9.7 ->
+// mysql:26.7 did — fails on the probe with the real numbers in the message
+// instead of surfacing as a confusing refusal deep inside an unrelated
+// assertion.
+//
+// The witness table carries rows, so the "live guard" migration also proves the
+// refusal happens before the body reaches the server: had Ptah let it through,
+// the server honors that guard by construction and the rows would be gone.
+func runAtlasTxtarChecksVersionGuardBoundaryIntegration(t *testing.T, dbURL string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	cleanupIssue819(t, conn)
+	defer cleanupIssue819(t, conn)
+
+	inertGuard := inertExecutableCommentGuard(c, ctx, conn)
+	liveGuard := inertGuard - 1
+
+	_, err = conn.ExecContext(ctx, "DROP TABLE IF EXISTS ptah_check_version_guard")
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		_, dropErr := conn.ExecContext(ctx, "DROP TABLE IF EXISTS ptah_check_version_guard")
+		c.Check(dropErr, qt.IsNil)
+	}()
+	_, err = conn.ExecContext(ctx, "CREATE TABLE ptah_check_version_guard (id INT)")
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, "INSERT INTO ptah_check_version_guard VALUES (1), (2), (3)")
+	c.Assert(err, qt.IsNil)
+
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		fstest.MapFS{
+			"1_inert_guard.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- checks/inert.sql --
+/*!` + strconv.Itoa(inertGuard) + ` DELETE FROM ptah_check_version_guard */ SELECT 1;
+
+-- migration.sql --
+SELECT 1;
+`)},
+			"2_live_guard.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- checks/live.sql --
+/*!` + strconv.Itoa(liveGuard) + ` DELETE FROM ptah_check_version_guard */ SELECT 1;
+
+-- migration.sql --
+SELECT 1;
+`)},
+		},
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	mig = mig.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas)
+
+	c.Assert(mig.MigrateUp(ctx), qt.ErrorMatches, `.*checks/live.sql#1.*must be a read-only SELECT statement.*`)
+
+	current, err := mig.GetCurrentVersion(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(current, qt.Equals, int64(1))
+
+	var remaining int
+	err = conn.QueryRowContext(ctx, "SELECT count(*) FROM ptah_check_version_guard").Scan(&remaining)
+	c.Assert(err, qt.IsNil)
+	c.Assert(remaining, qt.Equals, 3)
 }
 
 func runAtlasTxtarChecksMySQLExecutableCommentEscapeIntegration(t *testing.T, dbURL string) {

--- a/migration/migrator/atlas_txtar_checks_internal_test.go
+++ b/migration/migrator/atlas_txtar_checks_internal_test.go
@@ -169,7 +169,20 @@ func TestValidateCheckAssertion_Accepted(t *testing.T) {
 		{name: "MariaDB whole executable comment", assertion: "/*M! SELECT 1 */", dialect: platform.MariaDB, serverVersion: "10.11.14-MariaDB"},
 		{name: "MySQL ignores MariaDB comment", assertion: "/*M! DELETE FROM users */ SELECT 1", dialect: platform.MySQL, serverVersion: "8.4.6"},
 		{name: "MariaDB ignores MySQL 50700 comment", assertion: "/*!50700 DELETE FROM users */ SELECT 1", dialect: platform.MariaDB, serverVersion: "10.11.14-MariaDB"},
-		{name: "MySQL ignores future version guard", assertion: "/*!99999 DELETE FROM users */ SELECT 1", dialect: platform.MySQL, serverVersion: "8.4.6"},
+		{name: "MySQL guard above the server version", assertion: "/*!99999 DELETE FROM users */ SELECT 1", dialect: platform.MySQL, serverVersion: "8.4.6"},
+		// A guard is "above the server" relative to a server, never in the
+		// abstract. 99999 was once treated as unreachable; MySQL 26.7.0 encodes
+		// as 260700 and walked straight past it, which is what turned the
+		// integration fixture that hard-coded it into the #791 failure. Staying
+		// inert on a 26.x server takes six digits, so this row also pins that a
+		// guard wider than five digits is still read as a guard.
+		{name: "MySQL six-digit guard above a 26.x server", assertion: "/*!260701 DELETE FROM users */ SELECT 1", dialect: platform.MySQL, serverVersion: "26.7.0"},
+		// MariaDB ignores the whole 50700..99999 MySQL band whatever its own
+		// version is, so — unlike MySQL — 99999 is permanently inert there.
+		// Measured on mariadb:10.11 and mariadb:12, which is why the #108 bump
+		// does not disturb this row.
+		{name: "MariaDB 12 ignores the 99999 MySQL band", assertion: "/*!99999 DELETE FROM users */ SELECT 1", dialect: platform.MariaDB, serverVersion: "12.3.2-MariaDB"},
+		{name: "MariaDB guard above the server version", assertion: "/*!120303 DELETE FROM users */ SELECT 1", dialect: platform.MariaDB, serverVersion: "12.3.2-MariaDB"},
 		{name: "MySQL short numeric prefix is SQL", assertion: "SELECT /*!1234 + 1 */ = 1235", dialect: platform.MySQL, serverVersion: "8.4.6"},
 		{name: "MariaDB short numeric prefix is SQL", assertion: "SELECT /*!1234 + 1 */ = 1235", dialect: platform.MariaDB, serverVersion: "10.11.14-MariaDB"},
 	}
@@ -194,6 +207,13 @@ func TestValidateCheckAssertion_Rejected(t *testing.T) {
 		{name: "MariaDB executable DELETE", assertion: "/*M! DELETE FROM users */ SELECT 1", dialect: platform.MariaDB, serverVersion: "10.11.14-MariaDB", wantErr: "check assertion must be a read-only SELECT statement"},
 		{name: "MariaDB pre-50700 executable DELETE", assertion: "/*!50699 DELETE FROM users */ SELECT 1", dialect: platform.MariaDB, serverVersion: "10.11.14-MariaDB", wantErr: "check assertion must be a read-only SELECT statement"},
 		{name: "MySQL current version guard", assertion: "/*!80000 DELETE FROM users */ SELECT 1", dialect: platform.MySQL, serverVersion: "8.4.6", wantErr: "check assertion must be a read-only SELECT statement"},
+		// The #791 failure, transcribed away from a database. The literal is
+		// unchanged from the fixture that broke; only the server moved. Both
+		// rows are the pair the boundary is made of: at the server version the
+		// guard is live, and it stays live for every version above it.
+		{name: "MySQL 99999 guard is live on a 26.x server", assertion: "/*!99999 DELETE FROM users */ SELECT 1", dialect: platform.MySQL, serverVersion: "26.7.0", wantErr: "check assertion must be a read-only SELECT statement"},
+		{name: "MySQL guard exactly at the server version", assertion: "/*!260700 DELETE FROM users */ SELECT 1", dialect: platform.MySQL, serverVersion: "26.7.0", wantErr: "check assertion must be a read-only SELECT statement"},
+		{name: "MariaDB guard exactly at the server version", assertion: "/*!120302 DELETE FROM users */ SELECT 1", dialect: platform.MariaDB, serverVersion: "12.3.2-MariaDB", wantErr: "check assertion must be a read-only SELECT statement"},
 		{name: "multiple statements inside executable comment", assertion: "/*! SELECT 1; COMMIT; DROP TABLE users */", dialect: platform.MySQL, serverVersion: "8.4.6", wantErr: "check assertion must be one read-only SELECT statement, got 3 statements"},
 		{name: "MySQL numeric body is not SELECT", assertion: "/*!1234 SELECT 1 */", dialect: platform.MySQL, serverVersion: "8.4.6", wantErr: "check assertion must be a read-only SELECT statement"},
 		{name: "MariaDB numeric body is not SELECT", assertion: "/*M!1234 SELECT 1 */", dialect: platform.MariaDB, serverVersion: "10.11.14-MariaDB", wantErr: "check assertion must be a read-only SELECT statement"},


### PR DESCRIPTION
Fixes the red `integration-tests` job on master. #791 stays; the fixture is fixed forward.

## The mechanism

`TestAtlasTxtarChecks_MySQLCommentSemanticsIntegration` carried a fixture whose check assertion was `/*!99999 DELETE FROM users */ SELECT 1`, on the premise that the guard `99999` names a version no server will reach, so the body never executes.

MySQL encodes its own version in an executable-comment guard as `major*10000 + minor*100 + patch`. `mysql:9.7` is `90701`, below `99999`, so the body was dead and the assertion was effectively `SELECT 1`. `mysql:26.7` is `260700`, above `99999`, so the gate is open and the body is live SQL. Ptah expands the effective SQL before running a check and refuses a non-`SELECT`, so it refused. **Ptah's refusal is correct and the fixture was wrong.**

The refusal is decided statically from the assertion text and the connected server's version string (`migration/migrator/checks.go`, `executableCommentApplies`), not by asking the server, which is why the comment body never had to run for the check to fail.

## Measured, not assumed

`SELECT 1 /*!N + 1 */` reads `2` when the server honors guard `N` and `1` when it ignores it. Four servers, started fresh for this:

| server | `VERSION()` | version id | `99999` | at id | id+1 |
|---|---|---|---|---|---|
| `mysql:26.7` | 26.7.0 | 260700 | **2 (live)** | 2 | 1 |
| `mysql:9.7` | 9.7.1 | 90701 | 1 (inert) | 2 | 1 |
| `mariadb:10.11` | 10.11.18-MariaDB | 101118 | 1 (inert) | 2 | 1 |
| `mariadb:12` | 12.3.2-MariaDB | 120302 | 1 (inert) | 2 | 1 |

Run on its own against `mysql:26.7`, `/*!99999 DELETE FROM users */` took the table from three rows to zero. The gate really is open and the DELETE really does execute.

Six-digit guards parse correctly in both directions on 26.7 (`260700` -> 2, `260701` -> 1, `999999` -> 1), so nothing truncates at five digits.

Ptah's arithmetic agrees with all four servers exactly, including the `>=` boundary.

## What changed

The fixture derives its guard from the connected server instead of carrying a literal, and proves the number before leaning on it: a guard at the server's version id must read `2` and one above it must read `1`. An encoder that under-reports fails the second probe; one that over-reports fails the first. Only the true version id passes both, so no fixture can quietly inherit a guard that has stopped being inert.

A new boundary test, `TestAtlasTxtarChecks_{MySQL,MariaDB}VersionGuardBoundaryIntegration`, pins Ptah's version arithmetic to the server's on **both** sides at once, on whatever version the matrix runs. It carries a witness table with rows, so the refusal is shown to happen before the destructive body reaches the server.

Unit rows transcribe the same boundary without a database, including the first coverage anywhere in the repo for a guard wider than five digits — which is what a 26.x server's own version id now needs.

## MariaDB is the control, and stays one

MariaDB ignores the MySQL `50700`-`99999` band outright whatever its own version is, and reads higher numbers as MariaDB versions. Measured on both `mariadb:10.11` and `mariadb:12`. That is a fixed band, not a version race, so the MariaDB twin fixture is not exposed to this class and **#108 is not blocked by it** — `mariadb:12` passes the whole `TestAtlasTxtarChecks_MariaDB*` set on unmodified master.

## The sweep

33 numeric-guard occurrences repo-wide, enumerated with:

```
grep -rnoE '/\*(!|M!)[0-9]+' --include='*.go' --include='*.sql' --include='*.txtar' \
  --include='*.md' --include='*.yaml' --include='*.yml' --include='*.json' \
  --include='*.txt' --include='*.hcl' . | grep -v '^./docs/site/node_modules'
```

A guard is a hazard only if its site needs the guard to be **above** the server version. Server versions only rise, so such a site rots. Everything else is monotonically safe.

| verdict | count | members |
|---|---|---|
| **Hazard, fixed** | 1 | `atlas_integration_test.go:1274` — the failing fixture |
| Misleading name, pinned input, corrected | 1 | `atlas_txtar_checks_internal_test.go:172` — unit row with a literal `serverVersion`, so it cannot drift; renamed off "future version guard" and joined by modern-version rows |
| Guard below the server (open, stays open) | 13 | `mysqllike.go:485` + its test (`/*!50100 WITH PARSER`), `plan_edit_test.go:162-163`, `guard_dialects_test.go:451,516`, `sqlsafety/assessment_test.go:21,23`, `lint_test.go:629`, `lexer_test.go:890,898`, `atlas_txtar_checks_internal_test.go:195,196,200` |
| Shorter than five digits, not a version guard | 7 | the `/*!1234` and `/*M!1234` rows |
| Inert via MariaDB's fixed `50700`-`99999` band | 6 | `splitter_test.go:254`, `sqlsafety/assessment_test.go:25`, `lexer_test.go:899,900`, `atlas_integration_test.go:157`, `atlas_txtar_checks_internal_test.go:171` |
| Comment-form detection, no version compare | 2 | `implicit_commit_internal_test.go:96`, `lexer_test.go:901` |
| New in this change | 3 | derived guards and modern-version rows |

Nothing is left alone silently. The closest sibling to the broken fixture is `atlas_integration_test.go:157`, the MariaDB `ignoredCommentAssertion` `/*!50700 SELECT 0 */ SELECT 1` — it is a live-server fixture that also depends on inertness, but its inertness comes from MariaDB's band rather than from a version race, measured inert on both 10.11 and 12.

## Other engines

PostgreSQL, ClickHouse, CockroachDB, YugabyteDB, SQL Server and SQLite have no executable-comment mechanism, so the class does not exist there. The version-ceiling class more broadly is already closed in `core/platform/capability`: the ladders are open-topped and report saturation rather than assuming a ceiling, with rows already naming #791 (MySQL 26.x), #108 (MariaDB 12.x) and `postgres:18`. Verified green.

## Mutants

Each mutant is a cheaper wrong implementation, never a deletion.

| mutant | effect | restored |
|---|---|---|
| Fixture guard back to the literal `99999` | RED on 26.7 (exit 1), GREEN on 9.7 (exit 0) — the version dependence itself | GREEN |
| `executableCommentApplies`: `server >= guard` -> `server > guard` | Boundary test RED; the refusal stopped happening and the destructive body reached the server, which answered with a syntax error. Exactly the two new unit boundary rows caught it; no pre-existing row did | GREEN |
| `parseExecutableComment`: `guardDigits < 5` -> `!= 5` | Both integration tests RED and exactly the two new six-digit rows RED — before this change nothing exercised a guard wider than five digits | GREEN |

No production file is modified by this PR; `migration/migrator/checks.go` is absent from the diff, because its behavior was already right.

## Verification

The failing test passes on the new version **and** the old one, so the defect is closed rather than moved. Full `migration/migrator` package, zero skips among the targeted tests:

| servers | result |
|---|---|
| `mysql:26.7` + `mariadb:10.11` | full package, 0 failures |
| `mysql:9.7` + `mariadb:12` | full package, 0 failures |

Gates, each exit code read directly: `go build ./...`, `go vet ./...`, `go vet -tags integration ./integration/...`, `go test ./... -count=1`, `go tool qtlint ./...`, `golangci-lint run ./...`, `scripts/check-test-style.sh`, `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh`, `scripts/check-public-api-released.sh` — all 0. Every `check:*` in `docs/site/package.json` including all selftests — all 0; `check:responsive` needed `npm ci` and `npm run build` first, and was run against the real built site rather than reported as skipped.

## Docs

`docs/pre-migration-checks.md` and `docs/site/.../atlas/migrate-commands.md` now record which direction the guard is compared in, and that a large guard is not a way to park inert SQL. An operator who writes `/*!99999 ... */` expecting it to be dead now gets a refusal, so that is a user-visible contract.

## One thing to note

The commit is **unsigned**. gpg could not prompt for the key passphrase in this environment (no TTY, no GUI pinentry), and I did not alter the gpg configuration. Amend with a signature before merging if the history requires it.