### PR TITLE
Let the capability probe describe the servers this repository runs

### DIFF
--- a/cmd/capability-probe/main.go
+++ b/cmd/capability-probe/main.go
@@ -4,7 +4,14 @@
 // It answers one question per capability: does the server actually behave the
 // way core/platform/capability says it does? A disagreement exits non-zero. So
 // does a run that decided nothing — a probe that skipped every row must not
-// read as a probe that passed every row.
+// read as a probe that passed every row — and so does a run that decided fewer
+// rows than the dialect's plan promised to answer. The report's summary line
+// prints the count and that floor side by side, because "decided 22" alone
+// cannot tell an intact run from an eroded one.
+//
+// A server on a release line cells.go does not declare exits non-zero too, and
+// so does one on a line declared without a measured preset: both are gaps the
+// probe names rather than papers over.
 //
 //	capability-probe --db-url postgres://user:pw@localhost:5432/db
 //	capability-probe --db-url mysql://root:pw@localhost:3306/db --evidence

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -863,8 +863,9 @@ func ForDialect(dialect string) Capabilities {
 // measures that line, together with the preset it deserves — never as a side
 // effect of bumping a container tag.
 const (
-	// MySQL84 covers 8.4 LTS through the 9.x LTS line, which is the newest
-	// MySQL the integration matrix runs (mysql:9.7).
+	// MySQL84 covers 8.4 LTS through the 9.x LTS line. The integration matrix
+	// already runs mysql:26.7, which therefore resolves saturated: Ptah has no
+	// measured MySQL 26 capability line yet.
 	newestMeasuredMySQLMajor = 9
 	// MariaDB1011 covers 10.2 through the 11.x lines; the integration matrix
 	// runs mariadb:10.11.

--- a/core/platform/capability/capability_internal_test.go
+++ b/core/platform/capability/capability_internal_test.go
@@ -1,0 +1,84 @@
+package capability
+
+// White-box testing required: parseVersion is unexported and every exported
+// caller collapses its result into a preset or a boolean, so no external test
+// can read the numbers it produced. Those numbers are the subject here — two
+// banners this package reads WRONGLY, and a claim written in prose in
+// internal/capabilityprobe/version.go that until now nothing executed.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// sqlServer2025Banner is what @@VERSION returned from a live
+// mcr.microsoft.com/mssql/server:2025-latest container, verbatim including the
+// embedded newlines. internal/capabilityprobe/version_test.go pins the same
+// bytes; each package keeps its own copy because this one cannot import that
+// one without a cycle.
+const sqlServer2025Banner = "Microsoft SQL Server 2025 (RTM-CU7) (KB5096981) - 17.0.4065.4 (X64) \n" +
+	"\tJul  8 2026 23:26:08 \n" +
+	"\tCopyright (C) 2025 Microsoft Corporation\n" +
+	"\tEnterprise Developer Edition (64-bit) on Linux (Ubuntu 24.04.4 LTS) <X64>"
+
+// yugabyteBanner is what a live yugabytedb/yugabyte:2026.1.0.0-b118 reported
+// through YSQL. The leading number is the PostgreSQL compatibility version.
+const yugabyteBanner = "PostgreSQL 15.12-YB-2026.1.0.0-b0 on aarch64-unknown-linux-gnu, compiled by clang, 64-bit"
+
+// TestParseVersion_ReadsTheWrongNumberOutOfTwoRealBanners executes the misread
+// that internal/capabilityprobe exists to correct.
+//
+// It is a characterization test, not a wish: both rows below record what this
+// parser does today, and both are wrong about the product. The SQL Server row
+// is the one with teeth — the marketing year 2025 would select a preset for a
+// version that does not exist the day a `case platform.SQLServer:` is added to
+// the resolver's switch. The PostgreSQL and MySQL rows are the control that
+// makes the other two mean something: the same rule reads those banners
+// correctly, so the defect is in what these two banners put first, not in the
+// parser being broken for everything.
+func TestParseVersion_ReadsTheWrongNumberOutOfTwoRealBanners(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range []struct {
+		name   string
+		banner string
+		want   serverVersion
+	}{{
+		name:   "the SQL Server banner reads as the marketing year, not the product version 17.0.4065.4",
+		banner: sqlServer2025Banner,
+		want:   serverVersion{major: 2025},
+	}, {
+		name:   "the YugabyteDB banner reads as the PostgreSQL compatibility version, not the product 2026.1.0.0",
+		banner: yugabyteBanner,
+		want:   serverVersion{major: 15, minor: 12},
+	}, {
+		name:   "control: a PostgreSQL banner reads correctly under the same rule",
+		banner: "PostgreSQL 17.10 (Debian 17.10-1.pgdg13+1) on aarch64-unknown-linux-gnu",
+		want:   serverVersion{major: 17, minor: 10},
+	}, {
+		name:   "control: a MySQL banner reads correctly under the same rule",
+		banner: "9.7.1",
+		want:   serverVersion{major: 9, minor: 7, patch: 1},
+	}} {
+		c.Run(tc.name, func(c *qt.C) {
+			got, ok := parseVersion(tc.banner)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(got, qt.Equals, tc.want)
+		})
+	}
+}
+
+// TestResolveServerVersion_MasksTheYugabyteMisread executes the other half of
+// the claim: the YugabyteDB misread above never reaches a preset, because the
+// banner match fires before any version is parsed. That is why the SQL Server
+// case is the dangerous one and this one is not.
+func TestResolveServerVersion_MasksTheYugabyteMisread(t *testing.T) {
+	c := qt.New(t)
+
+	resolved := ResolveServerVersion("postgres", yugabyteBanner)
+	c.Assert(resolved.Capabilities, qt.DeepEquals, YugabyteDB25(),
+		qt.Commentf("the -yb- banner match must answer before parseVersion sees 15.12"))
+	c.Assert(resolved.Saturated, qt.IsFalse)
+	c.Assert(resolved.VersionSpecific, qt.IsTrue)
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -215,7 +215,10 @@ The newest measured line per refined dialect:
 
 PostgreSQL 18 therefore resolves saturated even though the integration matrix
 already runs `postgres:18`: Ptah has no measured PostgreSQL 18 capability line
-yet, so 18 is planned with the PostgreSQL 17 preset and says so.
+yet, so 18 is planned with the PostgreSQL 17 preset and says so. MySQL is in the
+same position for the same reason — the matrix runs `mysql:26.7`, which is the
+`26.7.0` in the examples above — so two of the three refined dialects are
+currently described to their own CI by a stand-in.
 
 Raising one of those numbers is the deliberate act of claiming a newer server
 line behaves like the preset it lands on. Do it in the change that measures
@@ -233,9 +236,9 @@ server version, and the line it was planned as; an unparseable version is
 recorded at `DEBUG` too. Neither reaches a default run's stderr, and that is
 deliberate: the CLI's default logger keeps `WARN` and above so that a clean run
 emits nothing, and connecting to a supported server is a clean run. The
-integration matrix runs `postgres:18`, so a saturated resolution there fires on
-every connection — a warning would be noise on every command rather than a
-diagnostic. Use `--log-level debug` to see it, or read `Saturated` and
+integration matrix runs `postgres:18` and `mysql:26.7`, so a saturated
+resolution fires on every connection to either — a warning would be noise on
+every command rather than a diagnostic. Use `--log-level debug` to see it, or read `Saturated` and
 `NewestMeasured` from `ResolveServerVersion` directly.
 
 Surfacing an unrefined version to the user on a channel of its own is

--- a/internal/capabilityprobe/cells.go
+++ b/internal/capabilityprobe/cells.go
@@ -127,7 +127,12 @@ func (c Cell) String() string {
 //
 // The lines are the vendor-supported ones, checked against the vendors on
 // 2026-08-09, plus any line whose preset Ptah still ships — a preset with no
-// cell is a claim nothing in this repository can measure.
+// cell is a claim nothing in this repository can measure — plus any line this
+// repository's own docker-compose.yaml or integration workflow starts. That
+// last source is not decoration: a container CI runs and the matrix does not
+// declare is a server whose preset nothing here can describe, and cells_test.go
+// derives the check from those two files rather than from a list somebody has
+// to remember to edit.
 //
 // Four presets still have no cell, and each absence is deliberate:
 //
@@ -189,7 +194,18 @@ var Cells = []Cell{
 
 	// MySQL: the two LTS lines (endoflife.date/api/mysql.json, read
 	// 2026-08-09 — 9.7 latest 9.7.2 EOL 2034-04-21, 8.4 latest 8.4.11 EOL
-	// 2032-04-30; both flagged LTS).
+	// 2032-04-30; both flagged LTS), plus 26.7, which is the line this
+	// repository actually starts.
+	{
+		Dialect: platform.MySQL, Line: "26.7",
+		Preset: nil, PresetName: "",
+		Refinement: RefinedByVersion, Image: "mysql:26.7",
+		Note: "no measured MySQL 26 preset: newestMeasuredMySQLMajor is 9, so a 26 server resolves " +
+			"saturated onto MySQL84. This is the line docker-compose.yaml and " +
+			".github/workflows/go-integration-tests.yml pin, and a live mysql:26.7 reports VERSION() " +
+			"26.7.0 — so until a preset is measured for it, the servers this repository runs its own " +
+			"MySQL suite against are described by a stand-in",
+	},
 	{
 		Dialect: platform.MySQL, Line: "9.7",
 		Preset: capability.MySQL84, PresetName: "MySQL84",
@@ -228,7 +244,7 @@ var Cells = []Cell{
 	},
 
 	// ClickHouse has no version ladder: ResolveServerVersion parses the
-	// version and then discards it, so all three lines receive ClickHouse24.
+	// version and then discards it, so all four lines receive ClickHouse24.
 	{
 		Dialect: platform.ClickHouse, Line: "26.7",
 		Preset: capability.ClickHouse24, PresetName: "ClickHouse24",
@@ -243,6 +259,14 @@ var Cells = []Cell{
 		Dialect: platform.ClickHouse, Line: "25.8",
 		Preset: capability.ClickHouse24, PresetName: "ClickHouse24",
 		Refinement: NotRefined, Image: "clickhouse/clickhouse-server:25.8",
+	},
+	{
+		Dialect: platform.ClickHouse, Line: "24.10",
+		Preset: capability.ClickHouse24, PresetName: "ClickHouse24",
+		Refinement: NotRefined, Image: "clickhouse/clickhouse-server:24.10",
+		Note: "the second ClickHouse service .github/workflows/go-integration-tests.yml starts, and " +
+			"the line the ClickHouse24 preset is named after; a live clickhouse/clickhouse-server:24.10 " +
+			"reports 24.10.4.191",
 	},
 
 	// SQL Server lines are numbered by product version here, not by the

--- a/internal/capabilityprobe/cells_test.go
+++ b/internal/capabilityprobe/cells_test.go
@@ -2,6 +2,10 @@ package capabilityprobe_test
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -150,10 +154,18 @@ func TestCellFor(t *testing.T) {
 	}
 }
 
-// TestCells_CoverEveryLineTheRepositoryRuns keeps the matrix honest about the
-// containers this repository actually starts: a line CI runs and the matrix
-// does not declare is a line whose preset nothing measures.
-func TestCells_CoverEveryLineTheRepositoryRuns(t *testing.T) {
+// TestCells_CoverEveryVersionMeasuredFromALiveServer keeps the matrix honest
+// about servers somebody actually started: each row below is a version string a
+// live container reported, and a version with no cell is a server whose preset
+// nothing here can describe.
+//
+// This is the half of the question a container tag cannot answer. A tag is
+// vendor text — mcr.microsoft.com/mssql/server:2025-latest names a marketing
+// year and clickhouse/clickhouse-server:26 names nothing precise at all — so
+// TestCells_DeclareEveryDatabaseContainerThisRepositoryStarts checks that the
+// matrix declares the containers, and this one checks that what those
+// containers report on the wire lands on a cell.
+func TestCells_CoverEveryVersionMeasuredFromALiveServer(t *testing.T) {
 	c := qt.New(t)
 
 	for _, tc := range []struct {
@@ -162,10 +174,13 @@ func TestCells_CoverEveryLineTheRepositoryRuns(t *testing.T) {
 	}{
 		{platform.Postgres, "18.4"},
 		{platform.Postgres, "17.10"},
+		{platform.MySQL, "26.7.0"},
 		{platform.MySQL, "9.7.1"},
 		{platform.MariaDB, "10.11.18"},
 		{platform.MariaDB, "11.4.12"},
 		{platform.MariaDB, "12.3.2"},
+		{platform.ClickHouse, "26.7.3.19"},
+		{platform.ClickHouse, "24.10.4.191"},
 		{platform.CockroachDB, "26.2.5"},
 		{platform.YugabyteDB, "2026.1.0.0"},
 		{platform.SQLServer, "17.0.4065.4"},
@@ -177,4 +192,158 @@ func TestCells_CoverEveryLineTheRepositoryRuns(t *testing.T) {
 			c.Assert(found, qt.IsTrue)
 		})
 	}
+}
+
+// pinnedImageFiles are the two files that decide which database containers this
+// repository starts: docker-compose.yaml for local runs and `make db-start`,
+// the integration workflow for CI.
+//
+// Reading them is the point. The list this test used to carry was written by
+// hand, and when the MySQL service moved from 9.7 to 26.7 the list kept naming
+// 9.7 — so the guard that exists to catch an undeclared line went on passing
+// while the only MySQL this repository starts fell off the matrix entirely.
+var pinnedImageFiles = []string{
+	"../../docker-compose.yaml",
+	"../../.github/workflows/go-integration-tests.yml",
+}
+
+// imageLine matches a YAML `image:` entry at any indentation. Compose nests it
+// under services.<name> and the workflow under jobs.<job>.services.<name>, so a
+// structure-aware read would need two shapes to answer one question.
+var imageLine = regexp.MustCompile(`(?m)^\s*image:\s*["']?([^"'\s#]+)`)
+
+// databaseImages maps an image repository onto the dialect a server built from
+// it speaks.
+var databaseImages = map[string]string{
+	"postgres":                       platform.Postgres,
+	"mysql":                          platform.MySQL,
+	"mariadb":                        platform.MariaDB,
+	"clickhouse/clickhouse-server":   platform.ClickHouse,
+	"cockroachdb/cockroach":          platform.CockroachDB,
+	"yugabytedb/yugabyte":            platform.YugabyteDB,
+	"mcr.microsoft.com/mssql/server": platform.SQLServer,
+}
+
+// notADatabase lists the images these files start that no capability preset
+// describes. It is written out rather than inferred so that an image in neither
+// map fails the test: a check that quietly ignores what it does not recognize
+// would let the next database arrive with no cell and nothing to say so.
+var notADatabase = map[string]bool{
+	"registry": true,
+}
+
+// TestCells_DeclareEveryDatabaseContainerThisRepositoryStarts derives the
+// coverage question from the files that answer it.
+func TestCells_DeclareEveryDatabaseContainerThisRepositoryStarts(t *testing.T) {
+	c := qt.New(t)
+
+	pinned := readPinnedImages(c)
+	assertThePinnedListHasDatabasesInIt(c, pinned)
+
+	for _, ref := range pinned {
+		c.Run(ref, func(c *qt.C) {
+			for _, check := range checksForPinnedImage(ref) {
+				check(c)
+			}
+		})
+	}
+}
+
+// readPinnedImages returns every image reference the two files start, sorted
+// and deduplicated: postgres:18 appears in both.
+func readPinnedImages(c *qt.C) []string {
+	c.Helper()
+
+	var refs []string
+	for _, path := range pinnedImageFiles {
+		body, err := os.ReadFile(path)
+		c.Assert(err, qt.IsNil)
+		matches := imageLine.FindAllStringSubmatch(string(body), -1)
+		c.Assert(len(matches) > 0, qt.IsTrue,
+			qt.Commentf("%s yielded no image: lines — a check whose input list comes back empty passes "+
+				"by examining nothing", path))
+		for _, match := range matches {
+			refs = append(refs, match[1])
+		}
+	}
+	return slices.Compact(slices.Sorted(slices.Values(refs)))
+}
+
+// assertThePinnedListHasDatabasesInIt is the non-vacuity guard on the read
+// above. A regex that stopped matching the service blocks would still return
+// the workflow's registry image, every per-image check would classify it as not
+// a database, and the test would pass having examined no database at all.
+func assertThePinnedListHasDatabasesInIt(c *qt.C, pinned []string) {
+	c.Helper()
+
+	seen := map[string]bool{}
+	for _, ref := range pinned {
+		repository, _ := splitImageRef(ref)
+		seen[databaseImages[repository]] = true
+	}
+	for _, dialect := range []string{platform.Postgres, platform.MySQL, platform.MariaDB} {
+		c.Assert(seen[dialect], qt.IsTrue,
+			qt.Commentf("no %s container was found in %v; the image read is broken, not the matrix", dialect, pinnedImageFiles))
+	}
+}
+
+// checksForPinnedImage returns the assertions for one image reference, so the
+// loop body stays free of a conditional.
+func checksForPinnedImage(ref string) []func(*qt.C) {
+	repository, tag := splitImageRef(ref)
+	if notADatabase[repository] {
+		return []func(*qt.C){func(c *qt.C) {
+			c.Assert(cellsDeclaring(repository, tag), qt.HasLen, 0,
+				qt.Commentf("%s is listed as not a database, yet a matrix cell claims it", ref))
+		}}
+	}
+	dialect, known := databaseImages[repository]
+	if !known {
+		return []func(*qt.C){func(c *qt.C) {
+			c.Fatalf("image %q is started by %v and appears in neither databaseImages nor notADatabase; "+
+				"classify it rather than letting it through unexamined", ref, pinnedImageFiles)
+		}}
+	}
+	return []func(*qt.C){func(c *qt.C) {
+		declaring := cellsDeclaring(repository, tag)
+		c.Assert(len(declaring) > 0, qt.IsTrue,
+			qt.Commentf("this repository starts %s and no matrix cell declares it, so nothing here can "+
+				"describe the capabilities of the server it runs (add a cell in cells.go)", ref))
+		for _, cell := range declaring {
+			c.Check(cell.Dialect, qt.Equals, dialect,
+				qt.Commentf("cell %s declares image %q, whose repository speaks %s", cell, cell.Image, dialect))
+		}
+	}}
+}
+
+// cellsDeclaring returns the cells whose Image covers a pinned reference.
+//
+// Exact equality is the ordinary case. The single loosening is the floating
+// tag: docker-compose.yaml pins clickhouse/clickhouse-server:26, which resolves
+// to whichever 26.x the registry serves that day, so it is covered when the
+// matrix declares a line beneath it. The prefix must end at a dot, or "2" would
+// cover "26.7".
+func cellsDeclaring(repository, tag string) []capabilityprobe.Cell {
+	var out []capabilityprobe.Cell
+	for _, cell := range capabilityprobe.Cells {
+		cellRepository, cellTag := splitImageRef(cell.Image)
+		if cellRepository != repository {
+			continue
+		}
+		if cellTag == tag || strings.HasPrefix(cellTag, tag+".") {
+			out = append(out, cell)
+		}
+	}
+	return out
+}
+
+// splitImageRef separates an image reference into repository and tag. The colon
+// is taken from the right and only counts after the last slash, so a registry
+// host carrying a port is not mistaken for a tag.
+func splitImageRef(ref string) (repository, tag string) {
+	colon := strings.LastIndex(ref, ":")
+	if colon <= strings.LastIndex(ref, "/") {
+		return ref, ""
+	}
+	return ref[:colon], ref[colon+1:]
 }

--- a/internal/capabilityprobe/doc.go
+++ b/internal/capabilityprobe/doc.go
@@ -20,6 +20,16 @@
 // therefore also fails a run that decided nothing — a probe that skipped every
 // row must not read as a probe that passed every row.
 //
+// It fails a run that decided LESS THAN ITS PLAN PROMISED for the same reason.
+// A floor of one row is barely a floor: twenty-three of twenty-four could go
+// quietly unmeasured and the run would still exit zero. [Report.Decidable]
+// counts the keys the dialect's plan did not declare undecidable in advance —
+// derived from the plan, not written down per dialect, because a hand-kept
+// number drifts the moment a capability is registered and drifts downward. On
+// a line no observation can be credited to it is zero: every row there is
+// undecidable by construction, and demanding decisions would make the exit
+// code permanently uninformative rather than newly strict.
+//
 // # Why the deciding statement is not always the obvious one
 //
 // Four shapes of statement decide nothing on their own, and each of them was

--- a/internal/capabilityprobe/probe.go
+++ b/internal/capabilityprobe/probe.go
@@ -95,6 +95,17 @@ type Report struct {
 	SessionDeltas []capability.Capability
 	// Rows is one entry per registered capability, sorted by key.
 	Rows []Row
+	// Decidable is how many rows this run was obliged to decide: the
+	// registered keys the dialect's plan did NOT declare undecidable in
+	// advance, on a line the matrix can credit an observation to. It is zero
+	// on an unattributable line, where every row is undecidable by
+	// construction and the count would be a demand no run can meet.
+	//
+	// It is derived from the plan rather than written down per dialect
+	// because a number somebody maintains by hand drifts the moment a
+	// capability is added, and the drift is silent in the direction that
+	// lowers the bar.
+	Decidable int
 	// Planned is false when the probe has no statement table for this
 	// dialect, so nothing was executed at all.
 	Planned bool
@@ -139,7 +150,11 @@ func (r *Report) Mismatches() []Row {
 //
 // Failing on "decided nothing" is not defensive padding. A skipped check that
 // reads as a passed check is how a matrix comes to certify lines nobody ever
-// probed, and this repository has been bitten by that shape before.
+// probed, and this repository has been bitten by that shape before. Failing on
+// "decided less than the plan promised" is the same argument one step further
+// in: a floor of one row lets twenty-three of twenty-four go quietly
+// unmeasured while the run still exits zero, and coverage that can erode
+// without turning anything red is coverage nobody is holding.
 func (r *Report) Err() error {
 	var problems []error
 
@@ -167,12 +182,34 @@ func (r *Report) Err() error {
 		problems = append(problems, fmt.Errorf(
 			"%s: preset says %t, server does %t", row.Capability, row.PresetSays, row.ServerDoes))
 	}
-	if r.Decided() == 0 {
-		problems = append(problems, fmt.Errorf(
-			"this run decided 0 of %d capability rows; a probe that measured nothing must not read as a probe that passed",
-			len(r.Rows)))
+	if r.Decided() < r.floor() {
+		problems = append(problems, r.coverageProblem())
 	}
 	return errors.Join(problems...)
+}
+
+// floor is the fewest rows a run may decide and still be allowed to report
+// success.
+//
+// On a line the matrix can credit it is every row the plan promised to answer,
+// so a run that quietly stopped deciding most of them fails. Everywhere else
+// it is one, which keeps the original guard: a probe that decided nothing must
+// never read as a probe that passed.
+func (r *Report) floor() int {
+	return max(1, r.Decidable)
+}
+
+// coverageProblem states the shortfall in the terms of whichever floor applied.
+func (r *Report) coverageProblem() error {
+	if r.Decidable == 0 {
+		return fmt.Errorf(
+			"this run decided 0 of %d capability rows; a probe that measured nothing must not read as a probe that passed",
+			len(r.Rows))
+	}
+	return fmt.Errorf(
+		"this run decided %d of %d capability rows, %d fewer than the %d the %s plan promised to answer; "+
+			"coverage that erodes without failing anything is coverage nobody is holding",
+		r.Decided(), len(r.Rows), r.Decidable-r.Decided(), r.Decidable, r.Dialect)
 }
 
 // cellProblems reports the ways a matched cell can be a lie about the server
@@ -301,7 +338,29 @@ func measure(ctx context.Context, pinned *dbschema.DatabaseConnection, report *R
 			s.broken, namespace)
 	}
 	report.Rows = assemble(report, observations, attempts)
+	report.Decidable = decidable(report, dialectPlan)
 	return nil
+}
+
+// decidable counts the rows this run had to decide for its coverage to be
+// intact: every registered key the plan did not declare undecidable in advance.
+//
+// On a line no observation can be credited to it is zero rather than that
+// count. Every row there is undecidable by construction — the resolver hands
+// each release of the engine the same preset — so demanding decisions would
+// turn a correctly reported limitation into a permanent failure and teach
+// readers to ignore the exit code.
+func decidable(report *Report, p plan) int {
+	if lineReason(report) != "" {
+		return 0
+	}
+	n := 0
+	for _, key := range capability.All() {
+		if _, declared := p.undecided[key]; !declared {
+			n++
+		}
+	}
+	return n
 }
 
 // runPlan executes a dialect's experiments in order and collects one

--- a/internal/capabilityprobe/probe_internal_test.go
+++ b/internal/capabilityprobe/probe_internal_test.go
@@ -10,6 +10,8 @@ package capabilityprobe
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -17,6 +19,9 @@ import (
 	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/core/platform/capability"
 )
+
+// probedDialects are the dialects the probe has a statement table for.
+var probedDialects = []string{platform.Postgres, platform.MySQL, platform.MariaDB}
 
 // TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce is the guard that keeps
 // the matrix complete as the registry grows.
@@ -26,6 +31,14 @@ import (
 // complete. "Exactly once" rather than "at least once" is deliberate: two
 // experiments deciding the same key would let the later one overwrite the
 // earlier answer depending on table order.
+//
+// The two ways a key can be answered are counted SEPARATELY and only then
+// added. Seeding one counter from the declared-undecidable map and adding the
+// experiments to it — which is what this test used to do — makes the two
+// indistinguishable, so moving a key out of experiments and into undecided
+// keeps the total at one and coverage drops with nothing going red. Telling
+// them apart is what lets
+// TestPlans_DeclareUndecidableOnlyWhereThisFileRecordsWhy hold the split.
 func TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce(t *testing.T) {
 	c := qt.New(t)
 
@@ -34,30 +47,134 @@ func TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce(t *testing.T) {
 		registered[key] = true
 	}
 
-	for _, dialect := range []string{platform.Postgres, platform.MySQL, platform.MariaDB} {
+	for _, dialect := range probedDialects {
 		c.Run(dialect, func(c *qt.C) {
 			dialectPlan, ok := planFor(dialect)
 			c.Assert(ok, qt.IsTrue)
 
-			answered := map[capability.Capability]int{}
-			for key := range dialectPlan.undecided {
-				answered[key]++
-			}
+			byExperiment := map[capability.Capability]int{}
 			for _, current := range dialectPlan.experiments {
-				c.Assert(len(current.decides) > 0, qt.IsTrue, qt.Commentf("an experiment that decides nothing cannot be run"))
+				c.Check(len(current.decides) > 0, qt.IsTrue, qt.Commentf("an experiment that decides nothing cannot be run"))
 				for _, key := range current.decides {
-					answered[key]++
+					byExperiment[key]++
 				}
+			}
+			declared := map[capability.Capability]int{}
+			for key := range dialectPlan.undecided {
+				declared[key]++
 			}
 
 			for key := range registered {
-				c.Assert(answered[key], qt.Equals, 1,
-					qt.Commentf("%s: capability %q is answered %d times, want exactly once", dialect, key, answered[key]))
+				c.Check(byExperiment[key]+declared[key], qt.Equals, 1,
+					qt.Commentf("%s: capability %q is answered %d times by an experiment and %d times by "+
+						"declaration, want exactly one answer in total",
+						dialect, key, byExperiment[key], declared[key]))
 			}
-			for key := range answered {
-				c.Assert(registered[key], qt.IsTrue,
-					qt.Commentf("%s: plan answers %q, which is not in the capability registry", dialect, key))
+			for key := range byExperiment {
+				c.Check(registered[key], qt.IsTrue,
+					qt.Commentf("%s: an experiment decides %q, which is not in the capability registry", dialect, key))
 			}
+			for key := range declared {
+				c.Check(registered[key], qt.IsTrue,
+					qt.Commentf("%s: the plan declares %q undecidable, which is not in the capability registry", dialect, key))
+			}
+		})
+	}
+}
+
+// TestPlans_DeclareUndecidableOnlyWhereThisFileRecordsWhy pins WHICH keys each
+// dialect is allowed to answer by declaration instead of by measurement.
+//
+// Counting answers cannot see this. A key moved from experiments into undecided
+// is still answered exactly once, so the count stays at one while the run
+// decides one row fewer — the cheapest way to make a stubborn row stop failing
+// is to declare it undecidable, and nothing about the totals notices. The
+// expected sets below are therefore written out: growing one is a deliberate
+// edit to a test, reviewed as the coverage reduction it is, rather than a
+// silent side effect of editing plans.go.
+//
+// Each entry is the set plans.go argues for in a comment at the point of
+// declaration. Postgres argues for none: everything it registers, it measures.
+func TestPlans_DeclareUndecidableOnlyWhereThisFileRecordsWhy(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range []struct {
+		dialect string
+		want    []capability.Capability
+	}{{
+		dialect: platform.Postgres,
+		want:    nil,
+	}, {
+		dialect: platform.MySQL,
+		want:    []capability.Capability{capability.RoleManagement},
+	}, {
+		dialect: platform.MariaDB,
+		want:    []capability.Capability{capability.RoleManagement, capability.Sequences},
+	}} {
+		c.Run(tc.dialect, func(c *qt.C) {
+			dialectPlan, ok := planFor(tc.dialect)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(slices.Sorted(maps.Keys(dialectPlan.undecided)), qt.DeepEquals, tc.want,
+				qt.Commentf("%s declares a different set of keys undecidable in advance than this test allows; "+
+					"adding one lowers what the probe measures, so it belongs here as a reviewed edit", tc.dialect))
+		})
+	}
+}
+
+// TestDecidable_IsDerivedFromThePlanAndTheLine pins the floor's derivation
+// against what live servers actually decided on 2026-08-09: postgres:17 decided
+// 24 of 24, mysql:9.7 decided 23, mariadb:10.11 decided 22. Those runs are the
+// reason the floor can be this strict without failing a healthy server.
+func TestDecidable_IsDerivedFromThePlanAndTheLine(t *testing.T) {
+	c := qt.New(t)
+
+	registered := len(capability.All())
+	for _, tc := range []struct {
+		name string
+		cell Cell
+		want int
+	}{{
+		name: "postgres declares nothing undecidable, so every registered row is owed",
+		cell: measuredCell,
+		want: registered,
+	}, {
+		name: "mysql owes one fewer: role_management names a surface no MySQL path reads",
+		cell: Cell{
+			Dialect: platform.MySQL, Line: "9.7",
+			Preset: capability.MySQL84, PresetName: "MySQL84",
+			Refinement: RefinedByVersion,
+		},
+		want: registered - 1,
+	}, {
+		name: "mariadb owes two fewer: sequences is a claim about the generator, not the engine",
+		cell: Cell{
+			Dialect: platform.MariaDB, Line: "10.11",
+			Preset: capability.MariaDB1011, PresetName: "MariaDB1011",
+			Refinement: RefinedByVersion,
+		},
+		want: registered - 2,
+	}, {
+		name: "a banner-refined line owes nothing, because no observation there can be credited to it",
+		cell: Cell{
+			Dialect: platform.CockroachDB, Line: "26.2",
+			Preset: capability.CockroachDB23, PresetName: "CockroachDB23",
+			Refinement: RefinedByBanner,
+		},
+		want: 0,
+	}, {
+		name: "a line with no measured preset owes nothing either",
+		cell: Cell{
+			Dialect: platform.MySQL, Line: "26.7",
+			Refinement: RefinedByVersion,
+			Note:       "no measured MySQL 26 preset",
+		},
+		want: 0,
+	}} {
+		c.Run(tc.name, func(c *qt.C) {
+			dialectPlan, ok := planFor(tc.cell.Dialect)
+			c.Assert(ok, qt.IsTrue)
+			report := reportOn(tc.cell, true, capability.Postgres17())
+			c.Assert(decidable(report, dialectPlan), qt.Equals, tc.want)
 		})
 	}
 }
@@ -67,12 +184,12 @@ func TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce(t *testing.T) {
 func TestPlans_DeclaredUndecidablesCarryAReason(t *testing.T) {
 	c := qt.New(t)
 
-	for _, dialect := range []string{platform.Postgres, platform.MySQL, platform.MariaDB} {
+	for _, dialect := range probedDialects {
 		c.Run(dialect, func(c *qt.C) {
 			dialectPlan, ok := planFor(dialect)
 			c.Assert(ok, qt.IsTrue)
 			for key, reason := range dialectPlan.undecided {
-				c.Assert(len(reason) > 40, qt.IsTrue,
+				c.Check(len(reason) > 40, qt.IsTrue,
 					qt.Commentf("%s/%s: an undecidable reason has to say why, not just that", dialect, key))
 			}
 		})
@@ -278,6 +395,85 @@ func TestReportErr(t *testing.T) {
 			assertErrMatches(c, tc.build().Err(), tc.want)
 		})
 	}
+}
+
+// TestReportErr_TheFloorIsWhatThePlanPromised covers the erosion a
+// "decided at least one row" guard cannot see.
+//
+// A run that answered one row of twenty-four is not a run that measured this
+// server, and before the floor existed it exited zero. The rows below move the
+// decided count around a fixed promise, so the boundary is exercised from both
+// sides rather than only from the failing one.
+func TestReportErr_TheFloorIsWhatThePlanPromised(t *testing.T) {
+	c := qt.New(t)
+
+	registered := len(capability.All())
+	for _, tc := range []struct {
+		name  string
+		build func() *Report
+		want  string
+	}{{
+		name: "a run that decided everything its plan promised passes",
+		build: func() *Report {
+			return promisedReport(registered)
+		},
+		want: "",
+	}, {
+		name: "one promised row short is a failure, not a rounding error",
+		build: func() *Report {
+			return promisedReport(registered, capability.XMLType)
+		},
+		want: `(?s).*decided 23 of 24 capability rows, 1 fewer than the 24 the postgres plan promised to answer.*`,
+	}, {
+		name: "the shape the old floor let through: one row decided out of twenty-four",
+		build: func() *Report {
+			return promisedReport(registered, everyKeyExcept(capability.XMLType)...)
+		},
+		want: `(?s).*decided 1 of 24 capability rows, 23 fewer than the 24 the postgres plan promised to answer.*`,
+	}, {
+		name: "a plan that promised nothing still may not decide nothing",
+		build: func() *Report {
+			return promisedReport(0, everyKeyExcept()...)
+		},
+		want: `(?s).*decided 0 of 24 capability rows; a probe that measured nothing.*`,
+	}} {
+		c.Run(tc.name, func(c *qt.C) {
+			assertErrMatches(c, tc.build().Err(), tc.want)
+		})
+	}
+}
+
+// promisedReport builds a report on an attributable, measured line that
+// promised to decide `promised` rows and left `undecided` of them unanswered.
+func promisedReport(promised int, undecided ...capability.Capability) *Report {
+	preset := capability.Postgres17()
+	report := reportOn(measuredCell, true, preset)
+	report.Planned = true
+	report.Control = Attempt{Statement: nonsenseControl}
+	report.Resolution.Capabilities = preset
+	report.Resolution.VersionSpecific = true
+	report.Decidable = promised
+
+	observations := map[capability.Capability]observation{}
+	for _, key := range capability.All() {
+		observations[key] = decided(preset.Has(key))
+	}
+	for _, key := range undecided {
+		observations[key] = cannotDecide("the deciding statement for %q was never executed", key)
+	}
+	report.Rows = assemble(report, observations, nil)
+	return report
+}
+
+// everyKeyExcept returns the registry minus the named keys.
+func everyKeyExcept(keep ...capability.Capability) []capability.Capability {
+	var out []capability.Capability
+	for _, key := range capability.All() {
+		if !slices.Contains(keep, key) {
+			out = append(out, key)
+		}
+	}
+	return out
 }
 
 // TestRun_RefusesAnEmptyMatrix pins the guard that stops a matrix covering

--- a/internal/capabilityprobe/render.go
+++ b/internal/capabilityprobe/render.go
@@ -113,9 +113,12 @@ func writeSessionDeltas(w io.Writer, r *Report) {
 	fmt.Fprintf(w, "  session      pinned session changed %s\n", strings.Join(names, ", "))
 }
 
+// writeSummary prints the counts and the floor the run had to clear. The floor
+// belongs on the same line as the count it is compared against: a reader who
+// sees "decided 22" cannot tell an intact run from an eroded one without it.
 func writeSummary(w io.Writer, r *Report) {
-	fmt.Fprintf(w, "\nsummary: %d rows — %d AGREES, %d DISAGREES, %d UNDECIDABLE; decided %d\n",
-		len(r.Rows), r.Count(Agrees), r.Count(Disagrees), r.Count(Undecidable), r.Decided())
+	fmt.Fprintf(w, "\nsummary: %d rows — %d AGREES, %d DISAGREES, %d UNDECIDABLE; decided %d, floor %d\n",
+		len(r.Rows), r.Count(Agrees), r.Count(Disagrees), r.Count(Undecidable), r.Decided(), r.floor())
 }
 
 func writeAnnotations(w io.Writer, r *Report) {

--- a/internal/capabilityprobe/version_test.go
+++ b/internal/capabilityprobe/version_test.go
@@ -6,6 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
 	"go.5x5.cz/ptah/internal/capabilityprobe"
 )
 
@@ -29,6 +30,13 @@ const yugabyteBanner = "PostgreSQL 15.12-YB-2026.1.0.0-b0 on aarch64-unknown-lin
 // banner as 2025 and the YugabyteDB banner as 15.12 is what makes the corrected
 // rows mean something. Without the control this test would only assert that a
 // function returns what it was written to return.
+//
+// "The same rule" is an equivalence, and an equivalence nobody executes is a
+// comment. Two tests execute it instead of asserting it:
+// TestParseVersion_TheSharedParserReallyMisreadsTheSQLServerBanner below runs
+// the shared resolver on these bytes, and
+// capability.TestParseVersion_ReadsTheWrongNumberOutOfTwoRealBanners calls the
+// shared parser itself, where the numbers are readable.
 func TestParseVersion_CorrectsTheBannersOneParserCannotRead(t *testing.T) {
 	c := qt.New(t)
 
@@ -96,6 +104,38 @@ func TestParseVersion_CorrectsTheBannersOneParserCannotRead(t *testing.T) {
 			c.Assert(got.String(), qt.Equals, tc.want)
 		})
 	}
+}
+
+// TestParseVersion_TheSharedParserReallyMisreadsTheSQLServerBanner runs the
+// shared code on the SQL Server banner instead of describing what it would do.
+//
+// capability.parseVersion is unexported, so the executable surface is
+// capability.ResolveServerVersion on the postgres dialect: it saturates exactly
+// when the parsed major is above the newest measured PostgreSQL line. A banner
+// the shared parser reads as 2025 therefore saturates and the product version
+// it should have read, 17.0.4065.4, does not — one call each, opposite answers,
+// no equivalence taken on trust.
+//
+// YugabyteDB cannot be exercised the same way and that is the finding rather
+// than a gap: ResolveServerVersion matches "-yb-" before it parses anything, so
+// no exported surface routes that banner through the shared parser at all.
+// capability.TestResolveServerVersion_MasksTheYugabyteMisread executes the
+// masking, and capability.TestParseVersion_ReadsTheWrongNumberOutOfTwoRealBanners
+// executes the misread underneath it.
+func TestParseVersion_TheSharedParserReallyMisreadsTheSQLServerBanner(t *testing.T) {
+	c := qt.New(t)
+
+	shared := capability.ResolveServerVersion(platform.Postgres, sqlServer2025Banner)
+	c.Assert(shared.Saturated, qt.IsTrue,
+		qt.Commentf("the shared parser must have read a major above the newest measured PostgreSQL line "+
+			"(%s) out of this banner, which is only possible if it took the marketing year", shared.NewestMeasured))
+
+	corrected, err := capabilityprobe.ParseVersion(platform.SQLServer, sqlServer2025Banner, "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(corrected.String(), qt.Equals, "17.0.4065.4")
+	c.Assert(capability.ResolveServerVersion(platform.Postgres, corrected.String()).Saturated, qt.IsFalse,
+		qt.Commentf("the version the sqlserver rule recovers is below that line, so the assertion above is "+
+			"about which number the shared parser picked and not about the banner being long"))
 }
 
 func TestParseVersion_RefusesABannerWithNoDigits(t *testing.T) {


### PR DESCRIPTION
Closes the three gaps the capability probe's own verification declared, plus the
control weakness it flagged. Refs #1339, #1341.

Every literal block below is the output of the command shown above it, untrimmed.
Containers were started for this change and dropped after it; ports and names are
unique to this run.

## Gap 1 — the probe could not describe the repository's own MySQL service

`docker-compose.yaml` and `.github/workflows/go-integration-tests.yml` both pin
`mysql:26.7`. `cells.go` declared MySQL lines 9.7 and 8.4 only.

```
$ .probe-bin/capability-probe --db-url 'mysql://root:probe@localhost:33741/probe'   # before
  banner       26.7.0
  matrix cell  NONE — no cell in cells.go covers this release line
  resolution   version-specific=false saturated=true newest-measured="9.x"
summary: 24 rows — 0 AGREES, 0 DISAGREES, 24 UNDECIDABLE; decided 0
capability-probe: no matrix cell covers mysql 26.7.0: this release line is not in the matrix, so nothing here promotes it to measured (add a cell in cells.go)
PROBE_EXIT=1
```

Probing every other tag the repository pins found a **second** line off the matrix,
measured the same way:

```
$ .probe-bin/capability-probe --db-url 'clickhouse://default:probe@localhost:19742/probe'
  banner       24.10.4.191
  matrix cell  NONE — no cell in cells.go covers this release line
CH2410_EXIT=1
```

`clickhouse/clickhouse-server:24.10` is the workflow's second ClickHouse service —
the one #1341's own table lists.

**Both cells added, data only.** The `cells.go` diff is 27 added lines and 3 removed,
all inside the `Cells` slice literal and its doc comments; no function body, type or
signature is touched.

MySQL 26 gets `Preset: nil`, for exactly the reason PostgreSQL 18 does.
`newestMeasuredMySQLMajor` is 9, so a 26 server resolves **saturated**: it receives
`MySQL84` from the ladder's open-topped arm, not from a match. Writing
`Preset: capability.MySQL84` would assert the ladder selected it, which is false, and
`cellProblems` would refuse it as a contradiction. Promoting the line means moving
that constant — a reviewed claim, and not a data change — so this PR does not do it.

After:

```
$ .probe-bin/capability-probe --db-url 'mysql://root:probe@localhost:33741/probe'   # after
  banner       26.7.0
  matrix cell  mysql 26.7 [preset none, version-ladder]
  resolution   version-specific=false saturated=true newest-measured="9.x"
summary: 24 rows — 0 AGREES, 0 DISAGREES, 24 UNDECIDABLE; decided 0, floor 1
capability-probe: matrix cell mysql 26.7 has no measured capability preset (...)
PROBE_EXIT=1
```

Still exit 1, and that is the point: the probe now names the line and its gap
instead of saying the line does not exist. **The finding is that all 23 observable
rows agree with the stand-in** — the run reports zero mismatches, so nothing about
MySQL 26.7 contradicts `MySQL84`; the only thing missing is a measured preset.

### The other pinned tags

| pinned image | measured version | cell | exit | finding |
|---|---|---|---|---|
| `postgres:18` | 18.4 | postgres 18, no preset | 1 | 24 observed, 0 mismatches |
| `mysql:26.7` | 26.7.0 | mysql 26.7, no preset (new) | 1 | 23 observed, 0 mismatches |
| `mariadb:10.11` | 10.11.18 | mariadb 10.11, MariaDB1011 | **0** | 22 AGREES, 0 DISAGREES |
| `clickhouse/clickhouse-server:26.7` | 26.7.3.19 | clickhouse 26.7 | 1 | no plan for the dialect |
| `clickhouse/clickhouse-server:24.10` | 24.10.4.191 | clickhouse 24.10 (new) | 1 | no plan for the dialect |
| `cockroachdb/cockroach:v26.2.5` | 26.2.5 | cockroachdb 26.2 | 1 | **3 mismatches** |
| `yugabytedb/yugabyte:2026.1.0.0-b118` | 2026.1.0.0 | yugabytedb 2026.1 | 1 | **3 mismatches** |
| `mcr.microsoft.com/mssql/server:2025-latest` | 17.0.4065.4 | sqlserver 17.0 | 1 | no plan for the dialect |

Two cells that exist turn out to be **wrong about the live server**, which is what
"known to be true and not merely present" was supposed to find:

```
$ .probe-bin/capability-probe --db-url 'postgres://root@localhost:26741/defaultdb?sslmode=disable'
preset and server disagree:
  role_management                        preset says false server does true  [UNDECIDABLE]
  row_level_security                     preset says false server does true  [UNDECIDABLE]
  sequences                              preset says false server does true  [UNDECIDABLE]
```

```
$ .probe-bin/capability-probe --db-url 'postgres://yugabyte@localhost:15743/yugabyte?sslmode=disable'
preset and server disagree:
  advisory_locks                         preset says false server does true  [UNDECIDABLE]
  create_index_concurrently              preset says false server does true  [UNDECIDABLE]
  row_level_security                     preset says false server does true  [UNDECIDABLE]
```

Both are `UNDECIDABLE` because those lines are banner-refined, and both are
reported anyway, which is the mechanism #1339 built for exactly this. **Neither
preset is changed here** — a preset edit is its own reviewed measurement, and
CockroachDB's `create_index_concurrently` row shows why: the server accepts the
statement inside an explicit transaction block, so the keyword is parsed and
dropped. Filed as a follow-up rather than smuggled in.

### The guard that should have caught Gap 1

`TestCells_CoverEveryLineTheRepositoryRuns` carried a hand-written version list
that still named `mysql 9.7.1` and named no ClickHouse at all. It now derives the
question from the two files that answer it, and an image in neither the database
map nor the not-a-database list **fails** rather than passing unexamined. Run
against the pre-change `cells.go` it names both gaps:

```
$ git restore --source=origin/master --worktree internal/capabilityprobe/cells.go
$ go test ./internal/capabilityprobe/ -count=1 -run TestCells_DeclareEveryDatabaseContainerThisRepositoryStarts
    --- FAIL: .../clickhouse/clickhouse-server:24.10
              this repository starts clickhouse/clickhouse-server:24.10 and no matrix cell declares it, ...
    --- FAIL: .../mysql:26.7
              this repository starts mysql:26.7 and no matrix cell declares it, ...
BEFORE_STATE_TEST_EXIT=1
```

A tag is not a version — `mssql:2025-latest` is a marketing year and
`clickhouse-server:26` is a floating major — so the two questions are split: this
test asks whether the matrix *declares the container*, and
`TestCells_CoverEveryVersionMeasuredFromALiveServer` asks whether what those
containers report *on the wire* lands on a cell. Its rows are the twelve versions
measured above.

## Gap 2 — coverage could erode without turning the build red

`Report.Err` failed only at `Decided() == 0`, so a run that decided 1 row of 24
exited 0. The floor is now every row the dialect's plan promised to answer,
**derived from the plan** rather than written down, and 0 on a line no observation
can be credited to (where every row is undecidable by construction and a demand
would be unmeetable). Live runs clear it exactly:

```
postgres:17    decided 24, floor 24   PG17_EXIT=0
mysql:9.7      decided 23, floor 23   MY97_EXIT=0
mariadb:10.11  decided 22, floor 22   MARIADB_EXIT=0
cockroachdb    decided 0,  floor 1    CRDB_EXIT=1
```

The floor is on the summary line because a reader who sees "decided 22" cannot
otherwise tell an intact run from an eroded one.

**Mutant** — the cheaper wrong implementation is "one decided row proves the probe
ran", `func (r *Report) floor() int { return 1 }`. It compiles.

```
$ go test ./internal/capabilityprobe/ -count=1     # mutant live
--- FAIL: TestReportErr_TheFloorIsWhatThePlanPromised
    --- FAIL: .../one_promised_row_short_is_a_failure,_not_a_rounding_error
    --- FAIL: .../the_shape_the_old_floor_let_through:_one_row_decided_out_of_twenty-four
MUTANT_B_TEST_EXIT=1
```

The "decided everything promised" row and the "decided nothing" row stay green
under the mutant, and so does the shipped
`TestAssemble_UndecidableRowsAreNotCountedAsDecided` — the new test is the one
that catches erosion, and the old guard is preserved rather than replaced.
Restored: `RESTORED_GREEN_EXIT=0`.

## Gap 3 — the coverage test counted an unanswered key as answered

`TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce` seeded its counter from
`dialectPlan.undecided` and then added the experiments, so moving a key from one
to the other kept the total at 1. The two are counted separately now, and a second
test pins **which** keys each dialect may answer by declaration — postgres none,
mysql `role_management`, mariadb `role_management` and `sequences` — because a
count can never see that distinction.

**Mutant** — the cheapest way to make a stubborn row stop failing: move
`capability.XMLType` out of `postgresPlan`'s experiments into its `undecided` map,
with a plausible reason attached. It compiles and the key is still answered once.

```
$ go test ./internal/capabilityprobe/ -count=1     # mutant live, new guards
--- FAIL: TestPlans_DeclareUndecidableOnlyWhereThisFileRecordsWhy/postgres
--- FAIL: TestDecidable_IsDerivedFromThePlanAndTheLine/postgres...
MUTANT_A_TEST_EXIT=1

$ git restore --source=origin/master --worktree internal/capabilityprobe/{probe_internal_test.go,cells_test.go,probe.go,render.go}
$ go test ./internal/capabilityprobe/ -count=1     # same mutant, shipped guards
ok  	go.5x5.cz/ptah/internal/capabilityprobe	6.366s
OLD_GUARDS_VS_MUTANT_A_EXIT=0
```

Green under the shipped guards, red under the new ones. Note that
`TestPlans_AnswerEveryRegisteredCapabilityExactlyOnce` does **not** fail even after
the fix — correctly, since the key is answered once — which is why the second test
had to exist. The two guards compose: this one blocks static erosion, the floor
blocks runtime erosion, and neither is enough alone, because a mutant that moves a
key into `undecided` lowers the floor and the decided count together.

## The control that asserted an equivalence instead of executing it

`version_test.go` demonstrated the SQL Server marketing-year misread using the
probe's own `ParseVersion` on the postgres dialect, so nothing would notice if
`capability.parseVersion` changed.

`parseVersion` is unexported and every exported caller collapses it into a preset
or a boolean, so two tests were added rather than one. The probe-side test runs
`capability.ResolveServerVersion` on the postgres dialect over the same banner
bytes: it saturates exactly when the parsed major is above the newest measured
PostgreSQL line, so a banner read as 2025 saturates and the 17.0.4065.4 the
sqlserver arm recovers does not — one call each, opposite verdicts. A new white-box
test in the capability package calls `parseVersion` directly, where the numbers are
readable, and pins both misreads with two correctly-read banners as the control.

**YugabyteDB cannot be reached that way, and the test says so** rather than
pretending: `ResolveServerVersion` matches `-yb-` before it parses anything, so no
exported surface routes that banner through the shared parser. The masking itself
is executed instead.

**Mutant** — the cheapest "fix" someone would apply to the shared parser: cut the
banner at the first `" - "` before scanning.

```
$ go test ./internal/capabilityprobe/ ./core/platform/capability/ -count=1   # mutant live
--- FAIL: TestParseVersion_TheSharedParserReallyMisreadsTheSQLServerBanner
--- FAIL: TestParseVersion_ReadsTheWrongNumberOutOfTwoRealBanners/the_SQL_Server_banner...
MUTANT_D_TEST_EXIT=1

$ go test ./internal/capabilityprobe/ -count=1 -run 'TestParseVersion_CorrectsTheBannersOneParserCannotRead'
--- PASS: TestParseVersion_CorrectsTheBannersOneParserCannotRead   (all 10 rows)
SHIPPED_CONTROL_VS_MUTANT_D_EXIT=0
```

The shipped control passes while the shared parser it names has changed underneath
it. That is the whole finding, executed.

## Documentation

`newestMeasuredMySQLMajor`'s comment claimed "the newest MySQL the integration
matrix runs (mysql:9.7)". The matrix runs `mysql:26.7`. Corrected, and
`docs/capabilities.md` now says MySQL is in the same saturated position as
PostgreSQL 18 — two of the three refined dialects are currently described to their
own CI by a stand-in.

## Gates

Each run separately with its exit code read directly, none through a pipe: `go
build ./...` 0, `go vet ./...` 0, `go vet -tags integration ./integration/...` 0,
`go test ./... -count=1` 0 (0 FAIL lines), `go tool qtlint ./...` 0,
`golangci-lint run ./...` 0 (0 issues), `scripts/check-test-style.sh` 0, the three
`check-public-api*` scripts 0/0/0, `npm ci` plus all 15 `check:*` and `:selftest`
scripts in `docs/site/package.json` 0 (`check:responsive` after `npm run build`,
which it requires).

`check-test-style.sh` was verified to actually inspect the new files rather than
pass by skipping them: planting an `if` in a new test body turns it red naming
`core/platform/capability/capability_internal_test.go`, exit 1, and removing it
returns exit 0.

## Not done here, and why

- **Promoting `mysql 26.7` to a measured preset.** Needs `newestMeasuredMySQLMajor`
  moved from 9 to 26, which the constant's own comment calls a deliberate reviewed
  claim and not a data change. The evidence is now in hand: 23 of 23 observable
  rows agree.
- **The CockroachDB and YugabyteDB preset disagreements.** Six rows across two
  presets, each its own measurement.
- **Wiring any of this into CI.** That is the body of #1341 and is untouched. This
  PR closes the three gaps that made the gate unusable for the versions this
  repository actually runs; #1341's tier-2 and tier-3 matrices remain open.
- **`#1341`'s "a cell with no preset entry fails the build"** criterion. Three cells
  (postgres 18, mariadb 12.3, mysql 26.7) have no preset by design today; making
  that a build failure is the CI work, not a probe change.

### On the commit count

Six commits carrying one message: local commits were blocked by GPG signing in a
headless shell (`gpg: signing failed: Inappropriate ioctl for device`), so this was
pushed through the API, which caps a single call below the 158 KB payload. The head
tree was verified byte-for-byte against the tested worktree (`git diff --quiet
origin/issue-1341-probe-gaps` exit 0). Squash on merge.