### PR TITLE
Bind the last two migration writers to the directory they opened (#1118)

### DIFF
--- a/docs/site/src/content/docs/concepts/migration-directory.md
+++ b/docs/site/src/content/docs/concepts/migration-directory.md
@@ -98,14 +98,29 @@ bytes.
 ## Writing back to the directory
 
 The verbs that write a migration directory — `migrate diff`, `migrate new`, and
-native `ptah migrations generate` and `ptah migrations create` — bind it the
+native `ptah migrations generate`, `ptah migrations create`,
+`ptah migrations checkpoint` and `ptah migrations data` — bind it the
 same way and keep the binding. They open the directory and its parent once,
-before staging, and every staged file, published migration, `atlas.sum`,
-journal, commit marker, rollback quarantine and cleanup entry is named as a
-direct child of one of those two handles. A migration directory that does not
-exist yet is created through the bound parent, so it is materialized where the
-run looked rather than where the pathname points by then. Recovery of an
-interrupted batch runs through the same handles.
+before staging, and every staged file, published migration, `atlas.sum` or
+`ptah.sum`, journal, commit marker, rollback quarantine and cleanup entry is
+named as a direct child of one of those two handles. A migration directory that
+does not exist yet is created through the bound parent, so it is materialized
+where the run looked rather than where the pathname points by then. Recovery of
+an interrupted batch runs through the same handles.
+
+Both commits inside that boundary are conditional on what the run observed. A
+migration file is created exclusively, so a name taken since the version was
+chosen is reported rather than overwritten. The integrity file is a replacement
+by construction and cannot use the same rule, so its commit is bound to the
+checksum state captured immediately before it: a rival that wrote its own
+`atlas.sum` or `ptah.sum` in between is reported, and its bytes are left in
+place.
+
+`atlas.sum` and `ptah.sum` take the same path. Until
+[#1118](https://github.com/stokaro/ptah/issues/1118) closed it, `ptah.sum` was
+written by pathname and unconditionally, which let a checkpoint or data
+migration land in one directory while its checksum landed in another, leaving
+the first uncovered and the second describing a snapshot it never held.
 
 Replacing the directory after the run validated it therefore cannot redirect
 what it writes, and a directory configured through `atlas.hcl` stays inside the

--- a/internal/atlasmigrate/migrationwriter.go
+++ b/internal/atlasmigrate/migrationwriter.go
@@ -7,6 +7,7 @@ import (
 
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/pathguard"
+	"go.5x5.cz/ptah/migration/migrator"
 )
 
 // MigrationWriter is the rooted migration-directory capability a writer
@@ -140,15 +141,28 @@ func (w *MigrationWriter) Remove(name string) error {
 	return err
 }
 
-// PublishAtlasSum commits atlas.sum through the bound handle, conditionally on
-// the checksum state this transaction observed, and returns its path. A
-// concurrent writer that replaced atlas.sum after the snapshot was taken is
+// PublishSum commits the integrity file the layout selects -- atlas.sum for the
+// Atlas layout, ptah.sum for the paired one -- through the bound handle,
+// conditionally on the checksum state this transaction observed, and returns
+// its path. A concurrent writer that replaced it after the snapshot was taken is
 // reported instead of overwritten.
-func (w *MigrationWriter) PublishAtlasSum(sum *migratesum.SumFile) (string, error) {
+//
+// The layout is a parameter rather than a second method because the two layouts
+// differ only in the file name: both must reach the destination through the same
+// handle the migration files were created through, or the checksum describes a
+// directory this transaction did not write into (stokaro/ptah#1118).
+func (w *MigrationWriter) PublishSum(
+	format migrator.MigrationDirFormat,
+	sum *migratesum.SumFile,
+) (string, error) {
 	if !w.dir.Exists() {
 		return "", w.dir.missingDirError()
 	}
-	return publishDirSum(w.dir, sum)
+	sumName, err := migratesum.FileNameForFormat(format)
+	if err != nil {
+		return "", err
+	}
+	return publishDirSumAs(w.dir, sumName, sum)
 }
 
 // PublishArtifacts durably publishes artifacts as one journaled batch through

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -1150,38 +1150,64 @@ func publicationStagedNames(journal publicationJournal) []string {
 	return names
 }
 
+// beforeDirSumCommit runs after the checksum commit has captured the state it
+// intends to replace and staged its replacement, and immediately before the
+// conditional rename that publishes it. It is nil outside tests.
+//
+// It exists because that gap is the one thing the conditional commit is for and
+// nothing else can stage a replacement inside it. Every other moment is either
+// before the capture -- where the capture simply observes the newer state -- or
+// after the rename, where there is nothing left to protect. A test that writes
+// over the checksum before calling the writer measures the capture, not the
+// commit (stokaro/ptah#1118).
+var beforeDirSumCommit func()
+
+func notifyBeforeDirSumCommit() {
+	if beforeDirSumCommit != nil {
+		beforeDirSumCommit()
+	}
+}
+
 // publishDirSum commits atlas.sum through the same rooted handle that published
 // the migration files, conditionally on the checksum state the transaction
 // observed. A concurrent writer that replaced atlas.sum after the migration
 // snapshot was verified is reported instead of overwritten.
 func publishDirSum(w *migrationWriterDir, sum *migratesum.SumFile) (string, error) {
+	return publishDirSumAs(w, migratesum.AtlasFileName, sum)
+}
+
+// publishDirSumAs is publishDirSum for a caller that selects the integrity file
+// itself, so the paired `ptah.sum` layout commits through the same rooted,
+// conditional path as the Atlas one rather than by pathname.
+func publishDirSumAs(w *migrationWriterDir, sumName string, sum *migratesum.SumFile) (string, error) {
 	if sum == nil {
 		return "", errors.New("migration checksum must not be nil")
 	}
-	sumPath := filepath.Join(w.path, migratesum.AtlasFileName)
-	destination, err := expectedSumDestination(w)
+	sumPath := filepath.Join(w.path, sumName)
+	destination, err := expectedSumDestination(w, sumName)
 	if err != nil {
-		return "", fmt.Errorf("write %s: %w", migratesum.AtlasFileName, err)
+		return "", fmt.Errorf("write %s: %w", sumName, err)
 	}
 	tempName, err := stageRootedFile(
 		w.dir,
-		"."+migratesum.AtlasFileName+".*.tmp",
+		"."+sumName+".*.tmp",
 		sum.Bytes(),
 		publishedFileMode,
 	)
 	if err != nil {
-		return "", fmt.Errorf("write %s: %w", migratesum.AtlasFileName, err)
+		return "", fmt.Errorf("write %s: %w", sumName, err)
 	}
 	info, err := w.dir.Lstat(tempName)
 	if err != nil {
 		return "", errors.Join(
-			fmt.Errorf("write %s: %w", migratesum.AtlasFileName, err),
+			fmt.Errorf("write %s: %w", sumName, err),
 			removeRootedFiles(w.dir, []string{tempName}),
 		)
 	}
+	notifyBeforeDirSumCommit()
 	publishErr := w.dir.PublishFile(
 		tempName,
-		migratesum.AtlasFileName,
+		sumName,
 		info,
 		publishedFileMode,
 		destination,
@@ -1194,11 +1220,11 @@ func publishDirSum(w *migrationWriterDir, sum *migratesum.SumFile) (string, erro
 		// That is exactly the commit-uncertain contract the checksum writer has
 		// always reported, so the journal is retained for recovery.
 		return "", &migratesum.CommitUncertainError{
-			Err: fmt.Errorf("write %s: %w", migratesum.AtlasFileName, publishErr),
+			Err: fmt.Errorf("write %s: %w", sumName, publishErr),
 		}
 	}
 	return "", errors.Join(
-		fmt.Errorf("write %s: %w", migratesum.AtlasFileName, publishErr),
+		fmt.Errorf("write %s: %w", sumName, publishErr),
 		removeRootedFiles(w.dir, []string{tempName}),
 	)
 }
@@ -1207,8 +1233,8 @@ func publishDirSum(w *migrationWriterDir, sum *migratesum.SumFile) (string, erro
 // is read through the rooted handle immediately before the staged sum is
 // published, so the window between the two is closed by the conditional commit
 // rather than by trusting the read.
-func expectedSumDestination(w *migrationWriterDir) (fsdurable.Destination, error) {
-	info, err := w.dir.Lstat(migratesum.AtlasFileName)
+func expectedSumDestination(w *migrationWriterDir, sumName string) (fsdurable.Destination, error) {
+	info, err := w.dir.Lstat(sumName)
 	if errors.Is(err, fs.ErrNotExist) {
 		return fsdurable.ExpectAbsent(), nil
 	}
@@ -1218,7 +1244,7 @@ func expectedSumDestination(w *migrationWriterDir) (fsdurable.Destination, error
 	if !info.Mode().IsRegular() {
 		return fsdurable.Destination{}, fmt.Errorf(
 			"%s is not a regular file",
-			filepath.Join(w.path, migratesum.AtlasFileName),
+			filepath.Join(w.path, sumName),
 		)
 	}
 	return fsdurable.ExpectFile(info), nil

--- a/internal/atlasmigrate/publication_sumcommit_internal_test.go
+++ b/internal/atlasmigrate/publication_sumcommit_internal_test.go
@@ -1,0 +1,166 @@
+package atlasmigrate
+
+// White-box testing required: the window these rows measure is between the
+// checksum commit's capture of the state it intends to replace and the rename
+// that replaces it. Nothing in the product needs a name for that instant, and
+// no exported entry point offers one -- a fixture that writes over the checksum
+// before calling the writer is answered by the capture, which simply observes
+// the newer state, and one that writes after the rename has nothing left to
+// measure. Everything asserted is otherwise observable: the error the commit
+// returns and the bytes left on disk.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/fsdurable"
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestPublishDirSum_RefusesADestinationReplacedInsideTheCommitWindow is the
+// atlas.sum commit point stokaro/ptah#1118's acceptance criteria name, and it is
+// the one commit point in the writer transaction that is not an exclusive
+// create: the checksum is a replacement by construction, so "refuse to
+// overwrite" cannot be the exclusive-create rule the migration files rely on.
+// It has to be a conditional rename against the state this transaction observed.
+//
+// Both destination shapes are measured because they take different branches:
+// a directory with no checksum yet commits under ExpectAbsent, one that already
+// has a checksum under ExpectFile. Either can be defeated separately.
+//
+// The rows run over both layouts. atlas.sum and ptah.sum are the same commit
+// with a different name, and until this change only the Atlas one reached it --
+// the paired writers behind `ptah migrations checkpoint` and
+// `ptah migrations data` wrote ptah.sum by pathname, unconditionally.
+//
+// The assertion is the surviving bytes, not the message. A commit that reported
+// an error and still replaced the intruder would satisfy an error-only
+// assertion and lose the data the criterion exists to protect.
+func TestPublishDirSum_RefusesADestinationReplacedInsideTheCommitWindow(t *testing.T) {
+	const intruder = "h1:rival=\n0000000001_rival.sql h1:rival=\n"
+
+	tests := []struct {
+		name    string
+		format  migrator.MigrationDirFormat
+		sumName string
+		// seed writes whatever checksum the directory already carries, so the
+		// commit captures ExpectAbsent or ExpectFile.
+		seed func(c *qt.C, dir, sumName string)
+	}{
+		{
+			name:    "atlas.sum, absent when the commit captured its destination",
+			format:  migrator.MigrationDirFormatAtlas,
+			sumName: migratesum.AtlasFileName,
+			seed:    func(*qt.C, string, string) {},
+		},
+		{
+			name:    "atlas.sum, present when the commit captured its destination",
+			format:  migrator.MigrationDirFormatAtlas,
+			sumName: migratesum.AtlasFileName,
+			seed: func(c *qt.C, dir, sumName string) {
+				c.Assert(os.WriteFile(
+					filepath.Join(dir, sumName), []byte("h1:stale=\n"), 0o600,
+				), qt.IsNil)
+			},
+		},
+		{
+			name:    "ptah.sum, absent when the commit captured its destination",
+			format:  migrator.MigrationDirFormatPtah,
+			sumName: migratesum.FileName,
+			seed:    func(*qt.C, string, string) {},
+		},
+		{
+			name:    "ptah.sum, present when the commit captured its destination",
+			format:  migrator.MigrationDirFormatPtah,
+			sumName: migratesum.FileName,
+			seed: func(c *qt.C, dir, sumName string) {
+				c.Assert(os.WriteFile(
+					filepath.Join(dir, sumName), []byte("h1:stale=\n"), 0o600,
+				), qt.IsNil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			test.seed(c, dir, test.sumName)
+			writer := openTestWriter(c, dir)
+			sum, err := migratesum.ComputeWithFormat(os.DirFS(dir), test.format)
+			c.Assert(err, qt.IsNil)
+
+			// The hostile step: a rival commits its own checksum after this one
+			// captured the destination it intends to replace.
+			beforeDirSumCommit = func() {
+				c.Assert(os.WriteFile(
+					filepath.Join(dir, test.sumName), []byte(intruder), 0o600,
+				), qt.IsNil)
+			}
+			defer func() { beforeDirSumCommit = nil }()
+
+			path, err := publishDirSumAs(writer, test.sumName, sum)
+
+			c.Assert(err, qt.ErrorIs, fsdurable.ErrDestinationChanged)
+			c.Assert(path, qt.Equals, "")
+			body, readErr := os.ReadFile(filepath.Join(dir, test.sumName))
+			c.Assert(readErr, qt.IsNil)
+			c.Assert(string(body), qt.Equals, intruder)
+			// A refused commit leaves no staged temporary behind either.
+			staged, globErr := filepath.Glob(filepath.Join(dir, "."+test.sumName+".*.tmp"))
+			c.Assert(globErr, qt.IsNil)
+			c.Assert(staged, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestPublishDirSum_CommitsWhenNothingReplacedTheDestination is the
+// non-interference control for the rows above.
+//
+// Without it, a commit that refused unconditionally -- one that never published
+// anything at all -- would pass every assertion in this file. The row runs the
+// identical setup with the hook left nil, so the only difference is the
+// replacement itself.
+func TestPublishDirSum_CommitsWhenNothingReplacedTheDestination(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  migrator.MigrationDirFormat
+		sumName string
+	}{
+		{
+			name:    "atlas.sum",
+			format:  migrator.MigrationDirFormatAtlas,
+			sumName: migratesum.AtlasFileName,
+		},
+		{
+			name:    "ptah.sum",
+			format:  migrator.MigrationDirFormatPtah,
+			sumName: migratesum.FileName,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			c.Assert(os.WriteFile(
+				filepath.Join(dir, test.sumName), []byte("h1:stale=\n"), 0o600,
+			), qt.IsNil)
+			writer := openTestWriter(c, dir)
+			sum, err := migratesum.ComputeWithFormat(os.DirFS(dir), test.format)
+			c.Assert(err, qt.IsNil)
+
+			path, err := publishDirSumAs(writer, test.sumName, sum)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(path, qt.Equals, filepath.Join(writer.Path(), test.sumName))
+			body, readErr := os.ReadFile(filepath.Join(dir, test.sumName))
+			c.Assert(readErr, qt.IsNil)
+			c.Assert(string(body), qt.Equals, string(sum.Bytes()))
+		})
+	}
+}

--- a/migration/generator/checkpoint.go
+++ b/migration/generator/checkpoint.go
@@ -2,10 +2,7 @@ package generator
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -15,7 +12,6 @@ import (
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/atlasmigrate"
 	"go.5x5.cz/ptah/internal/convert/dbschematogo"
-	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/migration/migrator"
 	"go.5x5.cz/ptah/migration/schemadiff"
 	schemadifftypes "go.5x5.cz/ptah/migration/schemadiff/types"
@@ -179,34 +175,21 @@ func ResolveAtlasCheckpointVersion(outputDir string) int64 {
 // that does not cover it, so the write fails rather than silently choosing a
 // different version.
 //
-// atlas.sum is written unconditionally. This does not check whether outputDir
-// also carries a ptah.sum; a directory holding both integrity files is
-// ambiguous to `--dir-format auto`, so callers that accept a user-chosen
-// directory should reject that combination first, as
-// `ptah migrations checkpoint` does.
+// atlas.sum is committed conditionally on the checksum state this call
+// observed, so a concurrent writer that replaced it is reported rather than
+// overwritten. This does not check whether outputDir also carries a ptah.sum; a
+// directory holding both integrity files is ambiguous to `--dir-format auto`, so
+// callers that accept a user-chosen directory should reject that combination
+// first, as `ptah migrations checkpoint` does.
+//
+// The whole transaction runs through one binding of outputDir, so the file and
+// the checksum are committed to the same filesystem object even if the pathname
+// is replaced mid-call (stokaro/ptah#1118).
 func WriteAtlasCheckpointFile(outputDir string, version int64, description, upSQL string) (path string, err error) {
 	if version <= 0 {
 		return "", fmt.Errorf("checkpoint version must be greater than zero, got %d", version)
 	}
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return "", fmt.Errorf("failed to create output directory: %w", err)
-	}
-
-	name, contents := AtlasCheckpointArtifact(version, description, upSQL)
-	filePath := filepath.Join(outputDir, name)
-	if err := writeNewMigrationFile(filePath, contents); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return "", fmt.Errorf("checkpoint file %s already exists", filePath)
-		}
-		return "", fmt.Errorf("failed to write atlas checkpoint file: %w", err)
-	}
-	if _, err := migratesum.WriteWithFormat(outputDir, migrator.MigrationDirFormatAtlas); err != nil {
-		// The checkpoint is only safe to leave behind once atlas.sum covers it;
-		// an uncovered file makes the whole directory fail verification.
-		_ = os.Remove(filePath)
-		return "", fmt.Errorf("failed to write atlas checkpoint checksum: %w", err)
-	}
-	return filePath, nil
+	return writeRootedAtlasCheckpoint(outputDir, version, description, upSQL)
 }
 
 // AtlasCheckpointArtifact returns the file name and contents that

--- a/migration/generator/checkpointwriter_unix_internal_test.go
+++ b/migration/generator/checkpointwriter_unix_internal_test.go
@@ -1,0 +1,338 @@
+//go:build unix
+
+package generator
+
+// White-box testing required: the two moments these fixtures measure -- after
+// the output directory is bound and before the transaction writes through it,
+// and after the final file names are chosen and before the exclusive create --
+// have no exported name, because nothing in the product needs one. A test that
+// replaces the directory, or pre-places a file at the final name, before
+// calling the exported API measures the open instead of the commit, which is
+// the distinction stokaro/ptah#1118 is about. Everything asserted below is
+// otherwise observable: the files on disk and the contents of the directory the
+// replacement pointed at.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// These are the checkpoint and data-migration writers' half of the rooted-writer
+// regressions stokaro/ptah#1118 asks for, and the counterpart to the
+// TestGenerateEmptyMigration* rows next door.
+//
+// Measured on master at 69c5b2ea, the same replacement staged against these
+// three writers returned a nil error and split one transaction across two
+// directories: `WriteAtlasCheckpointFile` left the checkpoint in the retained
+// directory and wrote atlas.sum into the directory that took over the pathname,
+// and both pair writers left the up half in the retained directory while the
+// down half and ptah.sum went to the impostor. Every one of those outcomes is a
+// directory no reader will accept -- the retained one uncovered, the impostor
+// carrying a checksum for a snapshot it never held.
+//
+// The file is //go:build unix because Win32 refuses to rename a directory the
+// run holds open without FILE_SHARE_DELETE, so on Windows there is no hostile
+// step to perform rather than a step that is expected to fail.
+
+const (
+	checkpointWriterVersion      = 2099010100
+	atlasCheckpointWriterVersion = 20990101000000
+)
+
+// TestCheckpointWritersReplacedDirectoryCannotRedirectTheWrite asserts both
+// halves the acceptance criteria ask for, for each of the three writers: every
+// artifact of the transaction lands in the directory the run bound, and the
+// directory the replacement pointed at is left completely untouched.
+//
+// The second half is the one that separates a rooted writer from one that
+// merely errored out somewhere along the way.
+func TestCheckpointWritersReplacedDirectoryCannotRedirectTheWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		// write runs the exported writer against the selected directory.
+		write func(dir string) error
+		// wantRetained is every entry the transaction must leave in the object it
+		// bound, sorted as os.ReadDir returns them.
+		wantRetained []string
+	}{
+		{
+			name: "atlas checkpoint",
+			write: func(dir string) error {
+				_, err := WriteAtlasCheckpointFile(dir, atlasCheckpointWriterVersion, "squash", "CREATE TABLE users (id integer);")
+				return err
+			},
+			wantRetained: []string{"20990101000000_squash.sql", "atlas.sum"},
+		},
+		{
+			name: "paired checkpoint",
+			write: func(dir string) error {
+				_, _, err := WriteCheckpointFiles(dir, checkpointWriterVersion, "squash", "CREATE TABLE users (id integer);\n", "DROP TABLE users;\n")
+				return err
+			},
+			wantRetained: []string{
+				"2099010100_squash.checkpoint.down.sql",
+				"2099010100_squash.checkpoint.up.sql",
+				"ptah.sum",
+			},
+		},
+		{
+			name: "data migration",
+			write: func(dir string) error {
+				_, _, err := WriteDataMigrationFiles(dir, checkpointWriterVersion, "seed", "INSERT INTO users VALUES (1);\n", "DELETE FROM users;\n")
+				return err
+			},
+			wantRetained: []string{
+				"2099010100_seed.down.sql",
+				"2099010100_seed.up.sql",
+				"ptah.sum",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			decoy := t.TempDir()
+			selected := filepath.Join(root, "migrations")
+			c.Assert(os.MkdirAll(selected, 0o755), qt.IsNil)
+
+			// The hostile step, staged in the window the binding defends: after the
+			// directory is bound and before the transaction writes through it.
+			var retained string
+			afterMigrationWriterBound = func() { retained = replaceWithSymlink(c, selected, decoy) }
+			defer func() { afterMigrationWriterBound = nil }()
+
+			err := test.write(selected)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(generatorDirNames(c, retained), qt.DeepEquals, test.wantRetained)
+			c.Assert(generatorDirNames(c, decoy), qt.HasLen, 0)
+		})
+	}
+}
+
+// TestCheckpointWritersCreateAMissingDirectoryThroughTheBoundParent covers the
+// initially-missing directory the acceptance criteria name, for the two verbs
+// that were still resolving it by pathname.
+//
+// The directory is materialized through the parent handle bound for the
+// transaction, so replacing the parent's name afterwards cannot move where it is
+// created. Before the change the mkdir, the file creates and the checksum commit
+// each resolved the pathname separately, so this row's swap sent all three into
+// the decoy.
+func TestCheckpointWritersCreateAMissingDirectoryThroughTheBoundParent(t *testing.T) {
+	tests := []struct {
+		name         string
+		write        func(dir string) error
+		wantRetained []string
+	}{
+		{
+			name: "atlas checkpoint",
+			write: func(dir string) error {
+				_, err := WriteAtlasCheckpointFile(dir, atlasCheckpointWriterVersion, "squash", "CREATE TABLE users (id integer);")
+				return err
+			},
+			wantRetained: []string{"20990101000000_squash.sql", "atlas.sum"},
+		},
+		{
+			name: "data migration",
+			write: func(dir string) error {
+				_, _, err := WriteDataMigrationFiles(dir, checkpointWriterVersion, "seed", "INSERT INTO users VALUES (1);\n", "DELETE FROM users;\n")
+				return err
+			},
+			wantRetained: []string{
+				"2099010100_seed.down.sql",
+				"2099010100_seed.up.sql",
+				"ptah.sum",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			decoy := t.TempDir()
+			c.Assert(os.MkdirAll(filepath.Join(root, "nest"), 0o755), qt.IsNil)
+			selected := filepath.Join(root, "nest", "migrations")
+
+			var retained string
+			afterMigrationWriterBound = func() {
+				retained = replaceWithSymlink(c, filepath.Join(root, "nest"), decoy)
+			}
+			defer func() { afterMigrationWriterBound = nil }()
+
+			err := test.write(selected)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(
+				generatorDirNames(c, filepath.Join(retained, "migrations")),
+				qt.DeepEquals, test.wantRetained,
+			)
+			c.Assert(generatorDirNames(c, decoy), qt.HasLen, 0)
+		})
+	}
+}
+
+// TestMigrationWritersRefuseADestinationTakenAfterTheNameWasChosen is the
+// final-migration-filename commit point the acceptance criteria name, measured
+// inside the window rather than before it.
+//
+// The distinction matters. A fixture that pre-places a file at the final name
+// and then calls the writer proves only that the writer looked before it wrote;
+// the binding answers that case at open time. What has to hold is that the
+// create itself is the conditional commit -- that a file appearing between the
+// moment the name was chosen and the moment it is created is reported and never
+// overwritten. That is what the hook stages here, and the surviving bytes are
+// the assertion: the writer's own body would be a different string.
+//
+// The three writers answer differently on purpose, and each answer is the
+// correct one for its verb:
+//
+//   - the skeleton writer advances to the next free version and succeeds, because
+//     `ptah migrations create` chooses the version itself and a taken one is not
+//     a failure;
+//   - both explicit-version writers refuse, because the caller resolved the
+//     version and a collision means that resolution is no longer true.
+func TestMigrationWritersRefuseADestinationTakenAfterTheNameWasChosen(t *testing.T) {
+	const intruder = "-- written by someone else\n"
+
+	tests := []struct {
+		name string
+		// occupy is the name the intruder takes in the bound directory, of the
+		// names the writer just chose.
+		occupy func(names []string) string
+		// write runs the exported writer against the selected directory.
+		write func(dir string) error
+		// check asserts what the writer's one attempt returned.
+		check func(c *qt.C, err error)
+		// wantDir is the directory afterwards, including the intruder's file.
+		wantDir []string
+	}{
+		{
+			name:   "atlas checkpoint refuses",
+			occupy: func(names []string) string { return names[0] },
+			write: func(dir string) error {
+				_, err := WriteAtlasCheckpointFile(dir, atlasCheckpointWriterVersion, "squash", "CREATE TABLE users (id integer);")
+				return err
+			},
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.ErrorMatches, `.*checkpoint file .*20990101000000_squash\.sql already exists`)
+			},
+			wantDir: []string{"20990101000000_squash.sql"},
+		},
+		{
+			name:   "paired checkpoint refuses when the up half is taken",
+			occupy: func(names []string) string { return names[0] },
+			write: func(dir string) error {
+				_, _, err := WriteCheckpointFiles(dir, checkpointWriterVersion, "squash", "CREATE TABLE users (id integer);\n", "DROP TABLE users;\n")
+				return err
+			},
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.ErrorMatches, `checkpoint files for version 2099010100 already exist`)
+			},
+			wantDir: []string{"2099010100_squash.checkpoint.up.sql"},
+		},
+		{
+			// The down half is the interesting one: the up half is created first
+			// and has to be withdrawn again, or the directory is left holding half
+			// a migration that ptah.sum does not cover.
+			name:   "data migration withdraws the up half when the down half is taken",
+			occupy: func(names []string) string { return names[1] },
+			write: func(dir string) error {
+				_, _, err := WriteDataMigrationFiles(dir, checkpointWriterVersion, "seed", "INSERT INTO users VALUES (1);\n", "DELETE FROM users;\n")
+				return err
+			},
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.ErrorMatches, `migration files for version 2099010100 already exist`)
+			},
+			wantDir: []string{"2099010100_seed.down.sql"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			selected := filepath.Join(t.TempDir(), "migrations")
+			c.Assert(os.MkdirAll(selected, 0o755), qt.IsNil)
+
+			var occupied string
+			afterMigrationFileNamesChosen = func(names []string) {
+				occupied = test.occupy(names)
+				c.Assert(os.WriteFile(
+					filepath.Join(selected, occupied), []byte(intruder), 0o600,
+				), qt.IsNil)
+			}
+			defer func() { afterMigrationFileNamesChosen = nil }()
+
+			err := test.write(selected)
+
+			test.check(c, err)
+			c.Assert(generatorDirNames(c, selected), qt.DeepEquals, test.wantDir)
+			// The protected state, not the message: the intruder's bytes survive.
+			body, readErr := os.ReadFile(filepath.Join(selected, occupied))
+			c.Assert(readErr, qt.IsNil)
+			c.Assert(string(body), qt.Equals, intruder)
+		})
+	}
+}
+
+// TestGenerateEmptyMigrationStepsPastADestinationTakenAfterTheNameWasChosen is
+// the skeleton writer's answer at the same commit point, and it is the opposite
+// answer to the row above on purpose.
+//
+// `ptah migrations create` chooses its own version, so a name taken inside the
+// window is not a failure -- it is a collision to step past. What must not
+// happen either way is the overwrite, so the assertion is the same shape: the
+// intruder's bytes survive, and the migration this run reports is a different
+// file. Without a conditional create the intruder would simply be replaced and
+// the run would report the version it first chose.
+//
+// The hook clears itself so only the first attempt is intercepted; a hook that
+// occupied every candidate would exhaust the retry rather than measure it.
+func TestGenerateEmptyMigrationStepsPastADestinationTakenAfterTheNameWasChosen(t *testing.T) {
+	const intruder = "-- written by someone else\n"
+	c := qt.New(t)
+	selected := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(selected, 0o755), qt.IsNil)
+	atlasVersionClock = func() time.Time {
+		return time.Date(2999, time.January, 1, 0, 0, 1, 0, time.UTC)
+	}
+	defer func() { atlasVersionClock = func() time.Time { return time.Now().UTC() } }()
+
+	var occupied string
+	afterMigrationFileNamesChosen = func(names []string) {
+		afterMigrationFileNamesChosen = nil
+		occupied = names[0]
+		c.Assert(os.WriteFile(
+			filepath.Join(selected, occupied), []byte(intruder), 0o600,
+		), qt.IsNil)
+	}
+	defer func() { afterMigrationFileNamesChosen = nil }()
+
+	files, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "added",
+		OutputDir:     selected,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(occupied, qt.Equals, atlasEmptyMigrationFileName(29990101000001, "added"))
+	c.Assert(files.Files, qt.HasLen, 1)
+	c.Assert(files.Files[0].Version, qt.Equals, int64(29990101000002))
+	c.Assert(generatorDirNames(c, selected), qt.DeepEquals, []string{
+		atlasEmptyMigrationFileName(29990101000001, "added"),
+		atlasEmptyMigrationFileName(29990101000002, "added"),
+		"atlas.sum",
+	})
+	body, readErr := os.ReadFile(filepath.Join(selected, occupied))
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(body), qt.Equals, intruder)
+}

--- a/migration/generator/datamigration.go
+++ b/migration/generator/datamigration.go
@@ -1,11 +1,6 @@
 package generator
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -32,32 +27,18 @@ func WriteDataMigrationFiles(outputDir string, version int64, description, upSQL
 // callers surface a wording that matches the file kind they asked for. It is
 // the shared core of WriteDataMigrationFiles and WriteCheckpointFiles, which
 // differ only in the file-name scheme and that label.
+//
+// The whole transaction runs through one binding of outputDir. It used to
+// resolve the pathname afresh for the mkdir, the existence check, each of the
+// two creates and the ptah.sum commit, which is the shape stokaro/ptah#1118
+// describes: with the directory renamed aside after the up half was created,
+// the call returned nil having written the up half into the retained directory
+// and the down half and ptah.sum into the directory that took over the pathname.
 func writeMigrationPair(
 	outputDir string,
 	version int64,
 	description, upSQL, downSQL, kind string,
 	nameFor func(version int64, description, direction string) string,
 ) (upPath, downPath string, err error) {
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return "", "", fmt.Errorf("failed to create output directory: %w", err)
-	}
-
-	upPath = filepath.Join(outputDir, nameFor(version, description, "up"))
-	downPath = filepath.Join(outputDir, nameFor(version, description, "down"))
-	if fileExists(upPath) || fileExists(downPath) {
-		return "", "", fmt.Errorf("%s files for version %d already exist", kind, version)
-	}
-
-	if err := writeNewMigrationFile(upPath, upSQL); err != nil {
-		return "", "", fmt.Errorf("failed to write %s up file: %w", kind, err)
-	}
-	if err := writeNewMigrationFile(downPath, downSQL); err != nil {
-		_ = os.Remove(upPath)
-		return "", "", fmt.Errorf("failed to write %s down file: %w", kind, err)
-	}
-
-	if _, err := migratesum.WriteWithFormat(outputDir, migrator.MigrationDirFormatPtah); err != nil {
-		return "", "", fmt.Errorf("failed to rewrite ptah.sum: %w", err)
-	}
-	return upPath, downPath, nil
+	return writeRootedMigrationPair(outputDir, version, description, upSQL, downSQL, kind, nameFor)
 }

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -382,8 +382,9 @@ func latestAtlasVersionIn(names []string) int64 {
 //     cannot open a path outside the directory it holds.
 //
 // [atlasCheckpointNameStem] keeps the old rewriting for `migrate checkpoint`.
-// That verb has no measured counterpart on the pinned binary, and its writer
-// resolves the file by pathname rather than through a rooted handle.
+// That verb has no measured counterpart on the pinned binary, so there is
+// nothing to move towards; both writers now open the file through a rooted
+// handle.
 func atlasEmptyMigrationFileName(version int64, name string) string {
 	if name == "" {
 		return fmt.Sprintf("%d.sql", version)
@@ -397,10 +398,14 @@ func atlasEmptyMigrationFileName(version int64, name string) string {
 // This is what every Atlas-layout name used to go through. `migrate new` no
 // longer does, because that binary was measured writing the name verbatim there.
 // `migrate checkpoint` keeps it: the register that prompted the change records
-// no cell for the verb, so there is nothing measured to move towards, and
-// [WriteAtlasCheckpointFile] joins the stem onto a pathname instead of opening
-// it through a rooted directory handle, so a stem carrying a separator would
-// name a file outside the directory the caller asked for.
+// no cell for the verb, so there is nothing measured to move towards.
+//
+// Containment is no longer the reason. [WriteAtlasCheckpointFile] now creates
+// the file through a rooted directory handle, which refuses a name carrying a
+// separator rather than following it out of the directory (stokaro/ptah#1118),
+// so the stem rewriting is a naming convention and not a boundary. Removing it
+// would change file names for a verb with no measured counterpart, which is why
+// it stays.
 func atlasCheckpointNameStem(name string) string {
 	name = strings.TrimSpace(name)
 	name = strings.ReplaceAll(name, " ", "-")
@@ -2692,7 +2697,6 @@ func latestPtahVersionIn(names []string) int64 {
 // migrationDirFileNames lists a migration directory by pathname. It is the
 // reader-side counterpart of migrationDirNames, which lists the same thing
 // through a bound writer handle; a directory that cannot be listed reads as
-// empty, so a version scan over a missing directory starts from scratch.
 func migrationDirFileNames(outputDir string) []string {
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {
@@ -2714,11 +2718,6 @@ func nameSet(names []string) map[string]bool {
 		set[name] = true
 	}
 	return set
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
 }
 
 func withNoTransactionDirective(sql string) string {
@@ -2791,57 +2790,4 @@ func migrationFilesFromPairs(pairs []MigrationFilePair) *MigrationFiles {
 	return &MigrationFiles{
 		Files: pairs,
 	}
-}
-
-// ensureMigrationOutputDir creates the migration output directory, including
-// every missing parent above it.
-//
-// The parents are the point. This used to os.Mkdir the leaf after requiring its
-// parent to already exist, so `--dir file://a/b` with no `a` failed with
-// `parent directory "…/a" is not available` and wrote nothing, where the pinned
-// community binary v1.3.0 created `a`, `a/b`, the migration file and atlas.sum
-// and exited 0 — measured on 2026-08-07 at two and at three missing levels
-// (stokaro/ptah#1241 item 4). Ptah's OTHER writing verb already did this: the
-// `migrate diff` writer creates parents through
-// internal/atlasmigrate.ensureMigrationDirParent, so the two writers disagreed
-// with each other as well as with that binary.
-//
-// What must NOT relax is a path component that exists and is not a directory.
-// os.MkdirAll refuses that with ENOTDIR naming the offending component, and the
-// pinned binary refuses it too (`--dir file://a/b` over a regular file `a`
-// exits 1 with `stat a/b: not a directory`), so both stay exit 1.
-func ensureMigrationOutputDir(outputDir string) error {
-	info, err := os.Stat(outputDir)
-	if err == nil {
-		if !info.IsDir() {
-			return fmt.Errorf("%q exists and is not a directory", outputDir)
-		}
-		return nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	return os.MkdirAll(outputDir, 0755)
-}
-
-func writeNewMigrationFile(path, content string) error {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	removeOnError := true
-	defer func() {
-		if removeOnError {
-			_ = os.Remove(path)
-		}
-	}()
-	if _, err := file.WriteString(content); err != nil {
-		_ = file.Close()
-		return err
-	}
-	if err := file.Close(); err != nil {
-		return err
-	}
-	removeOnError = false
-	return nil
 }

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -2697,6 +2697,7 @@ func latestPtahVersionIn(names []string) int64 {
 // migrationDirFileNames lists a migration directory by pathname. It is the
 // reader-side counterpart of migrationDirNames, which lists the same thing
 // through a bound writer handle; a directory that cannot be listed reads as
+// empty, so a version scan over a missing directory starts from scratch.
 func migrationDirFileNames(outputDir string) []string {
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {

--- a/migration/generator/rootedwriter.go
+++ b/migration/generator/rootedwriter.go
@@ -15,9 +15,9 @@ import (
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
-// This file holds the generator's two writer transactions -- creating a
-// skeleton migration and publishing a planned one -- expressed against one
-// rooted migration-directory handle each.
+// This file holds the generator's writer transactions -- creating a skeleton
+// migration, publishing a planned one, and writing a checkpoint or data
+// migration -- expressed against one rooted migration-directory handle each.
 //
 // The shape is the point (stokaro/ptah#1118). Both used to resolve the output
 // directory to a string and then reopen it by pathname for every subsequent
@@ -67,6 +67,26 @@ func notifyMigrationPublicationVerified() {
 	}
 }
 
+// afterMigrationFileNamesChosen runs once a writer transaction has settled on
+// the file names it is about to create and before it creates the first of them.
+// It is nil outside tests.
+//
+// It names the destination-replacement window for the migration files
+// themselves, which is a different window from the two hooks above: those stage
+// a replacement of the DIRECTORY, and this one lets a test stage a replacement
+// of the exact final name inside the directory the writer holds. A fixture that
+// pre-places a file at that name before the call is answered by the binding
+// itself, so it measures the open rather than the commit; only a file that
+// appears after the name is chosen exercises the exclusive create as a
+// conditional commit (stokaro/ptah#1118).
+var afterMigrationFileNamesChosen func(names []string)
+
+func notifyMigrationFileNamesChosen(names ...string) {
+	if afterMigrationFileNamesChosen != nil {
+		afterMigrationFileNamesChosen(names)
+	}
+}
+
 // openOutputRoot opens the confinement root a writer transaction runs inside,
 // or returns nil for the direct-CLI shape where an explicit absolute output
 // directory is the operator's own choice of destination.
@@ -96,6 +116,14 @@ func closeOutputRoot(root *pathguard.OpenedDirectory) error {
 // bindMigrationOutputDir creates the levels above the migration directory and
 // binds the directory itself, without creating it. The caller compares the
 // directory's absence against what it planned for before materializing it.
+//
+// Creating every missing level, not just the leaf, is measured behavior rather
+// than convenience: `--dir file://a/b` with no `a` must create `a`, `a/b`, the
+// migration file and atlas.sum and exit 0, which is what the pinned community
+// binary v1.3.0 does at two and at three missing levels (stokaro/ptah#1241 item
+// 4). What must not relax is a path component that exists and is not a
+// directory: the parent MkdirAll refuses that with ENOTDIR, and a leaf that is a
+// regular file fails the rooted open, so both stay exit 1.
 func bindMigrationOutputDir(
 	root *pathguard.OpenedDirectory,
 	outputDir string,
@@ -197,6 +225,7 @@ func writeEmptyAtlasMigration(
 			return nil, err
 		}
 		fileName := atlasEmptyMigrationFileName(version, name)
+		notifyMigrationFileNamesChosen(fileName)
 		err := writer.WriteNew(fileName, "")
 		if errors.Is(err, fs.ErrExist) {
 			version++
@@ -205,7 +234,7 @@ func writeEmptyAtlasMigration(
 		if err != nil {
 			return nil, fmt.Errorf("failed to write atlas migration file: %w", err)
 		}
-		if err := publishMigrationDirSum(writer); err != nil {
+		if err := publishMigrationDirSum(writer, migrator.MigrationDirFormatAtlas); err != nil {
 			return nil, errors.Join(
 				fmt.Errorf("failed to write atlas migration checksum: %w", err),
 				writer.Remove(fileName),
@@ -241,6 +270,7 @@ func writeEmptyPtahMigration(
 		}
 		upName := migrator.GenerateMigrationFileName(version, name, "up")
 		downName := migrator.GenerateMigrationFileName(version, name, "down")
+		notifyMigrationFileNamesChosen(upName, downName)
 
 		upErr := writer.WriteNew(upName, upSQL)
 		if errors.Is(upErr, fs.ErrExist) {
@@ -274,21 +304,141 @@ func writeEmptyPtahMigration(
 	}
 }
 
-// publishMigrationDirSum recomputes atlas.sum from the bound handle and commits
-// it conditionally on the checksum state that read observed.
-func publishMigrationDirSum(writer *atlasmigrate.MigrationWriter) error {
+// publishMigrationDirSum recomputes the layout's integrity file from the bound
+// handle and commits it conditionally on the checksum state that read observed.
+//
+// Reading and writing through the same handle is what binds the checksum to the
+// snapshot it describes: computed over a pathname, it would cover whatever the
+// name resolves to at that instant, which is not necessarily the directory this
+// transaction created its files in.
+func publishMigrationDirSum(
+	writer *atlasmigrate.MigrationWriter,
+	format migrator.MigrationDirFormat,
+) error {
 	fsys, err := writer.FS()
 	if err != nil {
 		return err
 	}
-	sum, err := migratesum.ComputeWithFormat(fsys, migrator.MigrationDirFormatAtlas)
+	sum, err := migratesum.ComputeWithFormat(fsys, format)
 	if err != nil {
 		return err
 	}
-	if _, err := writer.PublishAtlasSum(sum); err != nil {
+	if _, err := writer.PublishSum(format, sum); err != nil {
 		return err
 	}
 	return nil
+}
+
+// writeRootedAtlasCheckpoint is the Atlas-layout checkpoint writer's whole
+// transaction: bind the directory once, create it if it is missing, create the
+// checkpoint exclusively, and commit atlas.sum over it -- all through that one
+// handle.
+//
+// It used to run entirely on pathnames, and the split it allowed was measured
+// rather than argued: with the directory renamed aside after the checkpoint file
+// was created, `WriteAtlasCheckpointFile` returned nil having left the
+// checkpoint in the retained directory and written atlas.sum into the directory
+// that took over the pathname. The retained directory is then uncovered, so
+// every reader rejects it, and the impostor carries a checksum for a snapshot it
+// never held (stokaro/ptah#1118).
+func writeRootedAtlasCheckpoint(
+	outputDir string,
+	version int64,
+	description, upSQL string,
+) (path string, err error) {
+	writer, err := bindMigrationOutputDir(nil, outputDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to create output directory: %w", err)
+	}
+	defer func() { err = errors.Join(err, writer.Close()) }()
+	if err := writer.Create(); err != nil {
+		return "", fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	name, contents := AtlasCheckpointArtifact(version, description, upSQL)
+	notifyMigrationFileNamesChosen(name)
+	if writeErr := writer.WriteNew(name, contents); writeErr != nil {
+		if errors.Is(writeErr, fs.ErrExist) {
+			return "", fmt.Errorf("checkpoint file %s already exists", filepath.Join(writer.Path(), name))
+		}
+		return "", fmt.Errorf("failed to write atlas checkpoint file: %w", writeErr)
+	}
+	if sumErr := publishMigrationDirSum(writer, migrator.MigrationDirFormatAtlas); sumErr != nil {
+		// The checkpoint is only safe to leave behind once atlas.sum covers it;
+		// an uncovered file makes the whole directory fail verification. The
+		// withdrawal goes through the same handle the file was created through,
+		// so it cannot delete a same-named file in some other directory.
+		return "", errors.Join(
+			fmt.Errorf("failed to write atlas checkpoint checksum: %w", sumErr),
+			writer.Remove(name),
+		)
+	}
+	if err := writer.SyncDir(); err != nil {
+		return "", fmt.Errorf("failed to flush output directory: %w", err)
+	}
+	return filepath.Join(writer.Path(), name), nil
+}
+
+// writeRootedMigrationPair is the paired-layout counterpart: both halves and
+// ptah.sum committed through one binding of the output directory.
+//
+// The refusal is the exclusive create itself rather than a preceding existence
+// check. Two separate steps left a window in which the name a writer had just
+// observed free could be taken by someone else, and the write then overwrote
+// them; here the same syscall that creates the file is the one that observes the
+// name, so a file that appeared in between is reported and never overwritten.
+//
+// A down half that cannot be created withdraws the up half, because a migration
+// with no rollback is worse than none -- the same rule the skeleton writer
+// follows next door.
+func writeRootedMigrationPair(
+	outputDir string,
+	version int64,
+	description, upSQL, downSQL, kind string,
+	nameFor func(version int64, description, direction string) string,
+) (upPath, downPath string, err error) {
+	writer, err := bindMigrationOutputDir(nil, outputDir)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create output directory: %w", err)
+	}
+	defer func() { err = errors.Join(err, writer.Close()) }()
+	if err := writer.Create(); err != nil {
+		return "", "", fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	upName := nameFor(version, description, "up")
+	downName := nameFor(version, description, "down")
+	notifyMigrationFileNamesChosen(upName, downName)
+
+	taken := fmt.Errorf("%s files for version %d already exist", kind, version)
+	if upErr := writer.WriteNew(upName, upSQL); upErr != nil {
+		if errors.Is(upErr, fs.ErrExist) {
+			return "", "", taken
+		}
+		return "", "", fmt.Errorf("failed to write %s up file: %w", kind, upErr)
+	}
+	if downErr := writer.WriteNew(downName, downSQL); downErr != nil {
+		withdrawn := writer.Remove(upName)
+		if errors.Is(downErr, fs.ErrExist) {
+			return "", "", errors.Join(taken, withdrawn)
+		}
+		return "", "", errors.Join(
+			fmt.Errorf("failed to write %s down file: %w", kind, downErr),
+			withdrawn,
+		)
+	}
+
+	sumName, err := migratesum.FileNameForFormat(migrator.MigrationDirFormatPtah)
+	if err != nil {
+		return "", "", err
+	}
+	if sumErr := publishMigrationDirSum(writer, migrator.MigrationDirFormatPtah); sumErr != nil {
+		return "", "", fmt.Errorf("failed to rewrite %s: %w", sumName, sumErr)
+	}
+	if err := writer.SyncDir(); err != nil {
+		return "", "", fmt.Errorf("failed to flush output directory: %w", err)
+	}
+	return filepath.Join(writer.Path(), upName), filepath.Join(writer.Path(), downName), nil
 }
 
 // publishPlannedMigration commits a planned batch through the handle the


### PR DESCRIPTION
`migration/generator` had five writer transactions. Three ran through a rooted
handle; the other two did not, and this closes them.

## Reproduction, on master at `69c5b2ea`

The issue's own shape: replace the directory after the writer has validated and
created it, and before it re-resolves the same pathname to commit the checksum.
A probe polls for the migration file to appear — which happens at `O_CREAT`,
before the 64 MiB body is written — then renames the directory aside and drops a
fresh directory at its pathname, so the two renames land inside the writer's own
`WriteString`.

```
go run ./.repro/checkpointswap
--- WriteAtlasCheckpointFile ---
swap error:        <nil>
writer error:      <nil>
reported path:     /var/.../ptah-1118-785235827/migrations/20990101000000_squash.sql
retained dir retained:      [20990101000000_squash.sql]
decoy at pathname migrations: [atlas.sum]
--- WriteCheckpointFiles ---
swap error:        <nil>
writer error:      <nil>
retained dir retained:      [2099010100_squash.checkpoint.up.sql]
decoy at pathname migrations: [2099010100_squash.checkpoint.down.sql ptah.sum]
--- WriteDataMigrationFiles ---
swap error:        <nil>
writer error:      <nil>
retained dir retained:      [2099010100_seed.up.sql]
decoy at pathname migrations: [2099010100_seed.down.sql ptah.sum]
```

Every one returned a **nil error** and split one transaction across two
directories. Both outcomes are unusable: the retained directory is uncovered by
any checksum, and the impostor carries a `.sum` describing a snapshot it never
held. The pair writers also left half a migration behind — an up file with no
down half.

The same probe on this branch:

```
--- WriteAtlasCheckpointFile ---
retained dir retained:      [20990101000000_squash.sql atlas.sum]
decoy at pathname migrations: []
--- WriteCheckpointFiles ---
retained dir retained:      [2099010100_squash.checkpoint.down.sql 2099010100_squash.checkpoint.up.sql ptah.sum]
decoy at pathname migrations: []
--- WriteDataMigrationFiles ---
retained dir retained:      [2099010100_seed.down.sql 2099010100_seed.up.sql ptah.sum]
decoy at pathname migrations: []
```

The three already-rooted surfaces do **not** reproduce, confirmed before
changing anything:

```
go test ./internal/atlasmigrate/ -run 'TestGenerateDiff_(ReplacedDirectoryCannotRedirectPublication|CreatesMissingMigrationDirectoryInsideOpenedRoot|RefusesMigrationDirectoryOutsideOpenedRoot|RenamedDirectoryCannotRedirectPublication)' -count=1
ok  	go.5x5.cz/ptah/internal/atlasmigrate	1.135s
```

## What changed

`WriteAtlasCheckpointFile`, `WriteCheckpointFiles` and `WriteDataMigrationFiles`
bind their output directory once through `atlasmigrate.MigrationWriter` and name
only direct children of that handle for the create, the withdrawal, the checksum
and the flush. Exported signatures are unchanged, so the public API snapshot does
not move.

`ptah.sum` now reaches the same conditional commit `atlas.sum` already used:
`publishDirSum` becomes `publishDirSumAs`, which carries the file name, and
`MigrationWriter.PublishSum` selects it from the layout. That closes the issue's
bullet 5 for the paired layout — the checksum is computed from, and committed
through, the handle the files were created through.

The refusal is the exclusive create itself rather than a preceding
`fileExists` check, so a name taken between choosing it and creating it is
reported instead of overwritten.

`ensureMigrationOutputDir`, `writeNewMigrationFile` and `fileExists` were the
last pathname writing primitives in the package and are removed rather than left
standing beside the boundary. Their measured behavior moves with them and is
stated on `bindMigrationOutputDir`.

## Behavior preserved

```
go run ./.repro/parents
two missing levels      err=<nil>  dir=[20990101000000_squash.sql atlas.sum]
three missing levels    err=<nil>  dir=[2099010100_seed.down.sql 2099010100_seed.up.sql ptah.sum]
ancestor is a file      err=failed to create output directory: create migration directory parent: mkdir /var/.../a: not a directory
leaf is a file          err=failed to create output directory: open migration directory: open /private/var/.../migrations: not a directory
```

Missing parent levels are still created (#1241 item 4, re-measured at two and
three levels) and a non-directory component is still refused. The
`already exists` and `checkpoint file … already exists` messages are unchanged.

## Containment matrix, measured on this filesystem (APFS)

```
go run ./.repro/containment
== rooted writer: GenerateEmptyMigration, AllowedOutputRoot set ==
1 symlink out of the root                                REFUSED   outside=[]
2 relative traversal (root/../<outside>)                 REFUSED   outside=[]
3 absolute path outside the root                         REFUSED   outside=[]
4 root is itself a symlink (dir inside it)               ACCEPTED  outside=[20260809190713_added.sql atlas.sum]
5 ancestor symlink out of the root                       REFUSED   outside=[]

== unrooted writer: WriteAtlasCheckpointFile, no root parameter ==
1 symlink out of the root                                ACCEPTED
2 relative traversal (root/../<outside>)                 ACCEPTED
3 absolute path outside the root                         ACCEPTED
4 root is itself a symlink (dir inside it)               ACCEPTED
```

Case 4 accepting is correct: the root is spelled through a symlink but the
directory genuinely lives inside what that root resolves to. The three checkpoint
and data writers take no confinement root at all — `ptah migrations checkpoint`
and `ptah migrations data` read `--migrations-dir` straight from the operator, so
there is no project root to escape. What they gain here is **binding**, not
confinement: whatever object the pathname selected at bind time is the only
object the transaction writes into. Adding a confinement root to them would need
a new exported option and is not in this change.

**On `os.SameFile`:** these writers never call `Revalidate`. Containment here is
`os.Root` handle identity (openat), not an inode comparison, and the regressions
assert *which directory received the bytes* rather than whether two identifiers
match — so they answer the same on APFS and on ext4.

## Mutants: RED then GREEN

**M1 — commit the checksum by pathname** (`migratesum.WritePrecomputedWithFormat(writer.Path(), …)` in `publishMigrationDirSum`). The cheaper wrong implementation, and literally what master did.

```
go test ./migration/generator/ -run 'TestCheckpointWriters|TestMigrationWritersRefuse|TestGenerateEmptyMigration' -count=1
--- FAIL: TestCheckpointWritersReplacedDirectoryCannotRedirectTheWrite (0.08s)
    --- FAIL: .../atlas_checkpoint      --- FAIL: .../paired_checkpoint      --- FAIL: .../data_migration
--- FAIL: TestCheckpointWritersCreateAMissingDirectoryThroughTheBoundParent (0.01s)
    --- FAIL: .../atlas_checkpoint      --- FAIL: .../data_migration
--- FAIL: TestGenerateEmptyMigrationReplacedDirectoryCannotRedirectTheWrite (0.06s)
--- FAIL: TestGenerateEmptyMigrationCreatesMissingDirectoryThroughTheBoundParent (0.00s)
--- FAIL: TestGenerateEmptyMigrationScansTheHeldDirectoryForItsVersion (0.02s)
FAIL
```
Restored: `ok  	go.5x5.cz/ptah/migration/generator	7.535s`

**M2 — decide collisions from the listing taken at bind time, then create unconditionally.** One `ReadDir` instead of a conditional syscall per file; still compiles.

```
--- PASS: TestCheckpointWritersReplacedDirectoryCannotRedirectTheWrite
--- PASS: TestCheckpointWritersCreateAMissingDirectoryThroughTheBoundParent
--- FAIL: TestMigrationWritersRefuseADestinationTakenAfterTheNameWasChosen (0.06s)
    --- FAIL: .../atlas_checkpoint_refuses
    --- FAIL: .../paired_checkpoint_refuses_when_the_up_half_is_taken
    --- FAIL: .../data_migration_withdraws_the_up_half_when_the_down_half_is_taken
--- FAIL: TestGenerateEmptyMigrationStepsPastADestinationTakenAfterTheNameWasChosen (0.02s)
--- PASS: TestWriteAtlasCheckpointFile_RefusesToOverwrite
--- PASS: TestWriteCheckpointFiles
--- PASS: TestWriteDataMigrationFiles
```

This is the discrimination the audit asked for. Every **pre-staged** fixture
stays green — a file already present when the handle opens is answered by the
open — while all four **in-window** rows go red. Detail on the first:

```
error: got nil error but want non-nil
regexp: ".*checkpoint file .*20990101000000_squash\\.sql already exists"
```
Restored: `ok  	go.5x5.cz/ptah/migration/generator	0.732s`

**M3 — make the checksum commit unconditional** (`w.dir.ReplaceFile(tempName, sumName)` in place of the conditional `PublishFile`).

```
go test ./internal/atlasmigrate/ -run 'TestPublishDirSum_' -count=1 -v
--- FAIL: TestPublishDirSum_RefusesADestinationReplacedInsideTheCommitWindow (0.06s)
    --- FAIL: .../atlas.sum,_absent_when_the_commit_captured_its_destination
    --- FAIL: .../atlas.sum,_present_when_the_commit_captured_its_destination
    --- FAIL: .../ptah.sum,_absent_when_the_commit_captured_its_destination
    --- FAIL: .../ptah.sum,_present_when_the_commit_captured_its_destination
--- PASS: TestPublishDirSum_CommitsWhenNothingReplacedTheDestination
```
The non-interference control stays green, so the rows measure the replacement
rather than a writer that refuses everything.
Restored: `ok  	go.5x5.cz/ptah/internal/atlasmigrate	4.224s`

## Acceptance criteria this closes

- **`atlas.sum` commit-point replacement** — `TestPublishDirSum_RefusesADestinationReplacedInsideTheCommitWindow`, both destination shapes (`ExpectAbsent` and `ExpectFile`) and both layouts, asserting the rival's bytes survive and no staged temporary is left.
- **Final-filename replacement, measured in-window** — `TestMigrationWritersRefuseADestinationTakenAfterTheNameWasChosen` plus `TestGenerateEmptyMigrationStepsPastADestinationTakenAfterTheNameWasChosen`. The two verbs answer differently on purpose: an explicit-version writer refuses, the skeleton writer steps to the next free version. Neither overwrites.
- **Directory replacement for the two remaining writers** — `TestCheckpointWritersReplacedDirectoryCannotRedirectTheWrite`, asserting both halves: artifacts in the bound object, decoy untouched.
- **Initially-missing directory** for both.

Two unexported seams are added because those two commit points had no name:
`afterMigrationFileNamesChosen` and `beforeDirSumCommit`. Each fixture file
carries the `AGENTS.md` white-box justification, and each states why a
replacement staged before the call measures the open rather than the commit.
`//go:build unix` on the rename fixtures for the reason #1193 recorded: Win32
refuses to rename a directory the run holds open without `FILE_SHARE_DELETE`, so
there is no hostile step to perform rather than one expected to fail.

## Not closed

- **Editor preparation (`--edit`) and rollback for `migrate new`.** Converted `migrate new` refuses `--edit` outright; native `ptah migrations create --edit` still has happy-path coverage only.
- **A missing-directory row for the converted `migrate new` writer** (`cmd/atlas/migrate_new.go`).
- **Root confinement for `ptah migrations checkpoint` / `ptah migrations data`.** They accept no `AllowedOutputRoot`; giving them one is an exported-API change and is not attempted here.

## Gates

Every one run on this tree, each exit code read directly:

```
go build ./...                        0
go vet ./...                          0
go vet -tags integration ./integration/...  0
go test ./... -count=1                0
go tool qtlint ./...                  0
golangci-lint run ./...               0   (0 issues)
scripts/check-test-style.sh           0   (175 conditional groups, 42 white-box files)
scripts/check-public-api.sh           0
scripts/check-public-api-snapshot.sh  0
scripts/check-public-api-released.sh  0   (pre-existing approved pre-v1 entries only)
```

All 14 `check:*` scripts in `docs/site/package.json` exit 0, including
`check:responsive` after `npm run build`.

One flake seen and dismissed: `TestSVGReportsGraphvizStderrOnFailure` in
`cmd/viz` failed once with `signal: killed` at 10.01s while the docs site was
building concurrently, and passed `-count=3` in isolation and on a serial rerun
of the whole suite.

Refs #1118 — the issue keeps the three bullets under "Not closed".