### PR TITLE
Ask one owner which schemas a comparison side is read at (#1276)

### DIFF
--- a/cmd/internal/dbcli/dbcli.go
+++ b/cmd/internal/dbcli/dbcli.go
@@ -42,9 +42,28 @@ func RegisterConnectTimeoutFlag(flags *pflag.FlagSet, target *string) {
 	flags.StringVar(target, ConnectTimeoutFlagName, DefaultConnectTimeout.String(), "Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.")
 }
 
-// RegisterSchemasFlag registers a comma-separated schema allow-list flag.
+// RegisterSchemasFlag registers a comma-separated schema allow-list flag for a
+// verb whose empty value leaves the read at the schema the connection landed
+// in.
 func RegisterSchemasFlag(flags *pflag.FlagSet, target *string) {
 	flags.StringVar(target, SchemasFlagName, "", "Comma-separated database schemas to introspect (PostgreSQL-family only). Empty uses the connection default schema.")
+}
+
+// RegisterURLScopedSchemasFlag registers the same flag for the verbs whose
+// empty value lets the database URL decide, through
+// [go.5x5.cz/ptah/internal/schemascope.ReadNames]: a PostgreSQL-family URL that
+// pins a schema with `search_path` is read at that schema, and one that pins
+// none is read across every schema of the connected database.
+//
+// The two spellings exist because the two groups of verbs really do differ, and
+// one help string covering both would be false for one of them. `schema
+// inspect`, `schema diff` and `schema apply` compare against a description that
+// may name any schema of the database, so a read narrower than the URL turns
+// silence into intent (stokaro/ptah#1264, stokaro/ptah#1276); `introspect`,
+// `compare`, `migrate` and the rest keep the narrower default they document.
+func RegisterURLScopedSchemasFlag(flags *pflag.FlagSet, target *string) {
+	flags.StringVar(target, SchemasFlagName, "", "Comma-separated database schemas to introspect (PostgreSQL-family only). "+
+		"Empty lets the URL decide: a URL pinning search_path is read at that schema, one pinning none across every schema.")
 }
 
 // RegisterMigrationsSchemaFlag registers the migration tracking table schema flag.

--- a/cmd/schema/apply.go
+++ b/cmd/schema/apply.go
@@ -106,7 +106,7 @@ apply rather than reporting a synced schema for work that did not happen.`,
 	flags.BoolVar(&opts.edit, applyEditFlag, false, "Open the planned SQL in $VISUAL or $EDITOR before confirmation")
 	flags.StringVar(&opts.txMode, applyTxModeFlag, "", "Transaction mode: all, file, or none (default file)")
 	flags.StringVar(&opts.lockTimeout, applyLockTimeoutFlag, "", "Timeout for acquiring the schema apply lock, such as 10s (empty waits indefinitely)")
-	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
+	dbcli.RegisterURLScopedSchemasFlag(flags, &opts.schemas)
 	flags.StringArrayVar(&opts.include, applyIncludeFlag, nil, "Schema objects to include in the apply (Atlas-style selectors)")
 	flags.StringArrayVar(&opts.exclude, applyExcludeFlag, nil, "Schema objects to exclude from the apply (Atlas-style selectors)")
 	flags.StringVar(&opts.planPath, applyPlanFlag, "", "Pre-approved plan file saved by `ptah schema plan`; executed after fingerprint verification")

--- a/cmd/schema/diff.go
+++ b/cmd/schema/diff.go
@@ -69,7 +69,7 @@ selection on standard error.`,
 	flags.StringArrayVar(&opts.fromURLs, diffFromFlag, nil, "Current schema state: file path, database URL, or migration directory (repeatable)")
 	flags.StringArrayVar(&opts.toURLs, diffToFlag, nil, "Desired schema state: file path, database URL, or migration directory (repeatable)")
 	flags.StringVar(&opts.devURL, diffDevURLFlag, "", "Dev database URL used to choose the SQL dialect and replay migration-directory sources")
-	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
+	dbcli.RegisterURLScopedSchemasFlag(flags, &opts.schemas)
 	flags.StringArrayVar(&opts.include, diffIncludeFlag, nil, "Schema objects to include in diffing (Atlas-style selectors)")
 	flags.StringArrayVar(&opts.exclude, diffExcludeFlag, nil, "Schema objects to exclude from diffing (Atlas-style selectors)")
 	flags.StringVar(&opts.format, diffFormatFlag, "sql", "Output format: sql or json")

--- a/cmd/schema/inspect.go
+++ b/cmd/schema/inspect.go
@@ -83,7 +83,7 @@ inspected output never references an object it omitted.`,
 	flags.StringVar(&opts.schemaFile, inspectSchemaFileFlag, "", "Local schema file to inspect (.hcl, .yaml, .yml, or .sql); requires --dev-url")
 	flags.StringVar(&opts.migrationsDir, inspectMigrationsDirFlag, "", "Atlas-format migration directory to inspect; requires --dev-url")
 	flags.StringVar(&opts.devURL, inspectDevURLFlag, "", "Dev database URL used to evaluate non-database inspection sources; it is reset destructively")
-	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
+	dbcli.RegisterURLScopedSchemasFlag(flags, &opts.schemas)
 	flags.StringArrayVar(&opts.include, inspectIncludeFlag, nil, "Schema objects to include in inspection (Atlas-style selectors)")
 	flags.StringArrayVar(&opts.exclude, inspectExcludeFlag, nil, "Schema objects to exclude from inspection (Atlas-style selectors)")
 	flags.StringVar(&opts.format, inspectFormatFlag, "hcl", "Output format: hcl, sql, or json")

--- a/integration/gonative/schema_read_scope_postgres_test.go
+++ b/integration/gonative/schema_read_scope_postgres_test.go
@@ -1,0 +1,226 @@
+//go:build integration
+
+// Read-scope guard for stokaro/ptah#1276.
+//
+// The issue's thesis is that Ptah's READ path and its COMPARE path set scope
+// independently, and that the comparator then reads whatever the reader failed
+// to look at as intent. The boundary guard beside this file crosses that
+// boundary for one verb, `schema apply`, in one direction. This file crosses it
+// for `schema diff` in BOTH directions, because the two directions fail
+// differently and only one of them is destructive:
+//
+//   - a document as the DESIRED state against a database read too narrowly
+//     plans a creation for an object that already exists, and the migration
+//     fails;
+//   - the same document as the CURRENT state plans a REMOVAL of an object
+//     nothing asked to remove, and the migration succeeds.
+//
+// Measured on PostgreSQL 17.10 before internal/schemascope.ReadNames existed,
+// against a database holding `public.a` and `extra.b` reached by a plain URL,
+// compared against its own `ptah-compat schema inspect` output:
+//
+//	schema diff --from <plain URL> --to file://<document>
+//	  CREATE SCHEMA IF NOT EXISTS extra;
+//	  CREATE TABLE "extra"."b" ( "id" integer PRIMARY KEY NOT NULL );
+//	schema diff --from file://<document> --to <plain URL>
+//	  ALTER TABLE "extra"."b" DROP CONSTRAINT IF EXISTS "b_pkey";
+//	  DROP TABLE IF EXISTS "extra"."b" CASCADE;
+//
+// The pinned Atlas community binary v1.3.0 answers `Schemas are synced, no
+// changes to be made.` to both, at exit 0.
+//
+// The plain URL is the fixture and not a default: it is the URL form that hid
+// #1257 and #1275, and a suite that always pins a schema cannot fail on it.
+//
+// The last row is the control that keeps the fix from becoming a worse defect.
+// A desired state that genuinely describes one schema of a two-schema database
+// still removes what it does not describe -- the goal is to stop UNOWNED
+// silence from becoming a removal, not to stop removals -- and a fix that made
+// an unnamed schema globally unmanaged would turn that row red while leaving
+// the two above it green.
+
+package gonative_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"go.5x5.cz/ptah/internal/atlasreport"
+	"go.5x5.cz/ptah/internal/atlasschema"
+)
+
+// readScopeSeed is the two-schema database every row below is measured on.
+var readScopeSeed = []string{
+	"CREATE SCHEMA extra",
+	"CREATE TABLE public.a (id integer PRIMARY KEY)",
+	"CREATE TABLE extra.b (id integer PRIMARY KEY)",
+}
+
+// readScopePublicOnly is a hand-authored desired state describing exactly one
+// schema of that database. It carries no `ptah:not-described` record, so its
+// silence about `extra` is authoritative and the removal it implies is intent.
+const readScopePublicOnly = `schema "public" {
+}
+
+table "a" {
+  schema = schema.public
+  column "id" {
+    null = false
+    type = integer
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`
+
+func TestPostgreSQLDiffReadScopeMatchesTheDescribedScopeIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+
+	tests := []struct {
+		name string
+		// document produces the desired-state file this row compares against.
+		document func(c *qt.C, sourceURL string) string
+		// sides orders the two states: which one is --from and which is --to.
+		sides func(sourceURL, documentURL string) (from, to []string)
+		want  []string
+	}{
+		{
+			name:     "the database's own description as the desired state plans nothing",
+			document: readScopeInspected,
+			sides: func(sourceURL, documentURL string) ([]string, []string) {
+				return []string{sourceURL}, []string{documentURL}
+			},
+			want: nil,
+		},
+		{
+			name:     "the database's own description as the current state plans nothing",
+			document: readScopeInspected,
+			sides: func(sourceURL, documentURL string) ([]string, []string) {
+				return []string{documentURL}, []string{sourceURL}
+			},
+			want: nil,
+		},
+		{
+			name:     "a document describing one schema still removes what it does not describe",
+			document: readScopeLiteral(readScopePublicOnly),
+			sides: func(sourceURL, documentURL string) ([]string, []string) {
+				return []string{sourceURL}, []string{documentURL}
+			},
+			want: []string{
+				`ALTER TABLE "extra"."b" DROP CONSTRAINT IF EXISTS "b_pkey"`,
+				`DROP TABLE IF EXISTS "extra"."b" CASCADE`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			sourceURL := newReadScopeDatabase(c, dsn, "src", readScopeSeed)
+			devURL := newReadScopeDatabase(c, dsn, "dev", nil)
+			documentURL := "file://" + readScopeDocumentFile(c, test.document(c, sourceURL))
+
+			from, to := test.sides(sourceURL, documentURL)
+			diff, err := atlasschema.Diff(c.Context(), atlasschema.DiffOptions{
+				FromURLs: from,
+				ToURLs:   to,
+				DevURL:   devURL,
+				// The document is a compatibility projection in two of the
+				// three rows, so the loader has to accept the same names
+				// `ptah-compat` accepts. The comparison is the measurement, not
+				// the parse.
+				IgnoreUnknownHCLNames: true,
+				Diagnostics:           io.Discard,
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(boundaryStripComments(readScopeStatements(diff.Changes)), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// readScopeInspected is the database's own description, rendered by the
+// compatibility surface. That surface is the one whose document declares
+// coverage limits, so a row using it exercises the record as well as the scope.
+func readScopeInspected(c *qt.C, sourceURL string) string {
+	c.Helper()
+
+	rendered, err := atlasschema.InspectSource(c.Context(), atlasschema.InspectSourceOptions{
+		URL:                    sourceURL,
+		Format:                 "hcl",
+		Diagnostics:            io.Discard,
+		OmitAtlasRefusedBlocks: true,
+		IgnoreUnknownHCLNames:  true,
+	})
+	c.Assert(err, qt.IsNil)
+	return rendered
+}
+
+// readScopeLiteral is a desired state written by hand rather than inspected.
+func readScopeLiteral(document string) func(*qt.C, string) string {
+	return func(*qt.C, string) string { return document }
+}
+
+func readScopeStatements(changes []atlasreport.SchemaDiffChange) []string {
+	statements := make([]string, 0, len(changes))
+	for _, change := range changes {
+		statements = append(statements, change.Cmd)
+	}
+	return statements
+}
+
+func readScopeDocumentFile(c *qt.C, document string) string {
+	c.Helper()
+
+	path := filepath.Join(c.TempDir(), "desired.hcl")
+	c.Assert(os.WriteFile(path, []byte(document), 0o600), qt.IsNil)
+	return path
+}
+
+// newReadScopeDatabase creates and seeds a throwaway database and returns its
+// plain URL: the DSN's own parameters and nothing else, because the parameter
+// this suite is about is the one that is absent.
+//
+// The server is shared with other suites and other agents, so nothing here
+// touches the database POSTGRES_TEST_DSN names.
+func newReadScopeDatabase(c *qt.C, dsn, role string, seed []string) string {
+	c.Helper()
+
+	admin, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Assert(admin.PingContext(c.Context()), qt.IsNil)
+
+	name := fmt.Sprintf("ptah_readscope_%s_%d", role, time.Now().UnixNano())
+	ident := pgx.Identifier{name}.Sanitize()
+	_, err = admin.ExecContext(c.Context(), "CREATE DATABASE "+ident)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		_, dropErr := admin.ExecContext(
+			context.WithoutCancel(c.Context()),
+			"DROP DATABASE IF EXISTS "+ident+" WITH (FORCE)",
+		)
+		c.Check(dropErr, qt.IsNil)
+		c.Check(admin.Close(), qt.IsNil)
+	})
+
+	parsed, err := url.Parse(dsn)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + name
+	parsed.RawPath = ""
+	dbURL := parsed.String()
+	boundarySeed(c, dbURL, seed)
+	return dbURL
+}

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -128,9 +128,13 @@ type DiffResult struct {
 	SumPath        string
 }
 
+// devSchemaReader reads the replayed dev database at an ALREADY RESOLVED read
+// scope. The names come from [schemascope.ReadNames] at the call site, not from
+// here, so this verb reads the same schemas `schema diff`, `schema inspect` and
+// `schema apply` read (stokaro/ptah#1276).
 type devSchemaReader func(
 	conn *dbschema.DatabaseConnection,
-	schemas []string,
+	readNames []string,
 	defaultSchema string,
 ) (*dbschematypes.DBSchema, error)
 
@@ -238,15 +242,13 @@ func generateDiff(
 		replaySource,
 		migrator.MigrationDirFormatAtlas,
 		func(replayConn *dbschema.DatabaseConnection) error {
-			replayed, err := runtime.readDevSchema(replayConn, schemas, devDefaultSchema)
+			replayed, compared, err := compareReplayedState(
+				ctx, replayConn, runtime, schemas, devDefaultSchema, desired,
+			)
 			if err != nil {
 				return err
 			}
-			current = replayed
-			diff, err = schemadiff.CompareWithDatabase(ctx, replayConn, desired, replayed, nil)
-			if err != nil {
-				return fmt.Errorf("compare dev database schema: %w", err)
-			}
+			current, diff = replayed, compared
 			return nil
 		},
 	); err != nil {
@@ -510,18 +512,60 @@ func normalizeDiffOptions(opts DiffOptions) DiffOptions {
 	return opts
 }
 
-func readScopedDevSchema(
-	conn *dbschema.DatabaseConnection,
+// compareReplayedState reads the state the migration directory just replayed
+// on the dev database and compares the desired state against it.
+//
+// Which schemas that read covers is resolved here, by the one owner every other
+// read consumes. A directory that creates `extra.b`, replayed and then read at
+// the dev connection's own schema, reported the replay as having created
+// nothing there, and `migrate diff` re-emitted `CREATE TABLE "extra"."b"` into a
+// new migration file on every run: two runs, two files, and applying the
+// directory failed at SQLSTATE 42P07. Measured on PostgreSQL 17.10
+// (stokaro/ptah#1276).
+func compareReplayedState(
+	ctx context.Context,
+	replayConn *dbschema.DatabaseConnection,
+	runtime diffRuntime,
 	schemas []string,
 	defaultSchema string,
+	desired *goschema.Database,
+) (*dbschematypes.DBSchema, *difftypes.SchemaDiff, error) {
+	readNames, err := schemascope.ReadNames(ctx, replayConn.Info(), schemas, replayConn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read dev database schema: %w", err)
+	}
+	replayed, err := runtime.readDevSchema(replayConn, readNames, defaultSchema)
+	if err != nil {
+		return nil, nil, err
+	}
+	diff, err := schemadiff.CompareWithDatabase(ctx, replayConn, desired, replayed, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("compare dev database schema: %w", err)
+	}
+	return replayed, diff, nil
+}
+
+// readScopedDevSchema reads the state the migration directory replayed, which
+// is the CURRENT side of `migrate diff`.
+//
+// readNames is the resolved read scope, and it is also what the result is
+// filtered by. The two were separate when the filter carried an explicit
+// `--schema` selection and the read carried nothing, and that gap is the
+// defect: filtering by the names actually read is a no-op for every object the
+// read could have returned, and it is exactly the selection when one was made
+// (stokaro/ptah#1276).
+func readScopedDevSchema(
+	conn *dbschema.DatabaseConnection,
+	readNames []string,
+	defaultSchema string,
 ) (*dbschematypes.DBSchema, error) {
-	current, err := dbschema.ReadSchemaWithSchemas(conn, schemas)
+	current, err := dbschema.ReadSchemaWithSchemas(conn, readNames)
 	if err != nil {
 		return nil, fmt.Errorf("read dev database schema: %w", err)
 	}
 	return schemascope.FilterDatabaseWithDefaultSchema(
 		withoutRevisionTable(current),
-		schemas,
+		readNames,
 		defaultSchema,
 	), nil
 }

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -16,6 +16,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlassource"
 	"go.5x5.cz/ptah/internal/atlasurl"
 	"go.5x5.cz/ptah/internal/schemafile"
+	"go.5x5.cz/ptah/internal/schemascope"
 	"go.5x5.cz/ptah/migration/migrator"
 	"go.5x5.cz/ptah/migration/planner"
 	"go.5x5.cz/ptah/migration/schemadiff"
@@ -138,11 +139,12 @@ type applyComputation struct {
 	statements []string
 	current    *types.DBSchema
 	desired    *goschema.Database
-	// readScope is the schema allow-list current was read at, nil when the read
-	// was the connection's own default. A saved plan records no schema scope, so
-	// [VerifyPlanTarget] re-reads at that default; a caller fingerprinting
-	// current has to know whether the two would be the same read.
-	readScope []string
+	// readWidened reports that current was read at a wider or narrower scope
+	// than [VerifyPlanTarget] will re-read the same database at. A saved plan
+	// records no schema scope, so the verifier asks [schemascope.ReadNames] with
+	// no selection; a caller fingerprinting current has to know whether the two
+	// would be the same read.
+	readWidened bool
 }
 
 func computeApplyPlan(
@@ -181,10 +183,9 @@ func computeApplyPlan(
 	if err != nil {
 		return applyComputation{}, fmt.Errorf("load --to schema: %w", err)
 	}
-	readScope := applyReadScope(opts.Schemas, conn.Info().Schema, desired)
-	current, err := dbschema.ReadSchemaWithSchemas(conn, readScope)
+	current, readWidened, err := applyCurrentState(ctx, conn, opts.Schemas, desired)
 	if err != nil {
-		return applyComputation{}, fmt.Errorf("read database schema: %w", err)
+		return applyComputation{}, err
 	}
 	current, currentReport, currentErr := scopeDatabaseSide(current, scope, "current schema")
 	if currentErr != nil && !emptySelection(currentErr) {
@@ -218,7 +219,11 @@ func computeApplyPlan(
 			currentErr)
 	}
 
-	computation := applyComputation{current: current, desired: desired, readScope: readScope}
+	computation := applyComputation{
+		current:     current,
+		desired:     desired,
+		readWidened: readWidened,
+	}
 	info := conn.Info()
 	diff, err := schemadiff.CompareWithDatabase(ctx, conn, desired, current, nil)
 	if err != nil {
@@ -240,46 +245,75 @@ func computeApplyPlan(
 	return computation, nil
 }
 
+// applyCurrentState reads the database side of an apply, and reports whether
+// that read covers something other than the one [VerifyPlanTarget] will make
+// when a plan saved from it is used later.
+//
+// The two scopes are resolved side by side, here, because a plan file records
+// no schema scope: the verifier can only ask [schemascope.ReadNames] with no
+// selection, so the planning run has to know whether its own read was the same
+// one. Deriving them in two places is how a freshly saved plan reported itself
+// stale against the database it had just been computed from (stokaro/ptah#1276).
+func applyCurrentState(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	requested []string,
+	desired *goschema.Database,
+) (current *types.DBSchema, readWidened bool, err error) {
+	verifierScope, err := schemascope.ReadNames(ctx, conn.Info(), nil, conn)
+	if err != nil {
+		return nil, false, fmt.Errorf("read database schema: %w", err)
+	}
+	readScope := applyReadScope(requested, verifierScope, desired)
+	current, err = dbschema.ReadSchemaWithSchemas(conn, readScope)
+	if err != nil {
+		return nil, false, fmt.Errorf("read database schema: %w", err)
+	}
+	return current, !slices.Equal(readScope, verifierScope), nil
+}
+
 // applyReadScope resolves the schemas the DATABASE side of an apply is read at.
 //
 // The two sides of a comparison have to be read at the same scope or silence on
 // one of them is mistaken for absence. `schema inspect` on a URL that pins no
-// schema now describes every schema of the realm (stokaro/ptah#1264); applying
-// that description back to the database it came from used to read only the
+// schema describes every schema of the realm (stokaro/ptah#1264); applying that
+// description back to the database it came from used to read only the
 // connection's own schema, find no `extra` there, and plan `CREATE SCHEMA
 // extra` and `CREATE TABLE "extra"."b"` for a schema and a table the database
 // already has. Measured on PostgreSQL 17.10: the plan never converged, and
 // executing it failed at SQLSTATE 42P07.
 //
-// The scope is taken from the DESIRED state rather than from the URL, and that
-// choice is the safety property. A URL-derived realm scope would widen the read
-// for every document, including one that describes a single schema of a
-// multi-schema database -- and a schema the database has that the document does
-// not describe is planned for removal. Measured on the same database, a
-// document declaring only `public` read at two-schema scope plans `DROP TABLE
-// IF EXISTS "extra"."b" CASCADE`. Reading exactly the schemas the document
-// names cannot reach an object no document mentions.
+// base is what the URL says this run covers, resolved once by
+// [schemascope.ReadNames] so that this verb, `schema diff`, `schema inspect`
+// and `migrate diff` cannot disagree about it. An earlier fix derived the scope
+// here from the DESIRED state instead, to keep a document describing one schema
+// of a multi-schema database from reaching the others. That is the wrong
+// protection at the wrong layer: it makes a whole schema silently unmanaged
+// rather than authoritatively absent, and it makes this verb disagree with
+// `schema diff` over the same two inputs. The pinned Atlas community binary
+// v1.3.0 plans `DROP SCHEMA "extra" CASCADE` for that document on both verbs,
+// measured on PostgreSQL 17.10, and a desired state that means to keep a schema
+// it does not describe says so with a `ptah:not-described schema` record --
+// which the comparator honors and no scope trick can express.
+//
+// The desired state's own schemas are still added on top, because a URL pinned
+// to one schema by `search_path` covers less than a document may name, and a
+// creation planned for an object that exists fails the run.
 //
 // An explicit `--schema` outranks both: it is the operator naming the scope.
-//
-// nil is returned when the desired state names nothing beyond the schema the
-// connection is already on, so the common case reads exactly what it read
-// before.
-func applyReadScope(requested []string, connectedSchema string, desired *goschema.Database) []string {
+func applyReadScope(requested []string, base []string, desired *goschema.Database) []string {
 	if names := SplitSchemaNames(requested); len(names) > 0 {
 		return names
 	}
-	connected := strings.TrimSpace(connectedSchema)
-	named := desiredSchemaNames(desired)
-	beyond := slices.DeleteFunc(named, func(name string) bool { return name == connected })
-	if len(beyond) == 0 {
+	scope := slices.Clone(base)
+	scope = append(scope, desiredSchemaNames(desired)...)
+	scope = slices.DeleteFunc(scope, func(name string) bool { return strings.TrimSpace(name) == "" })
+	slices.Sort(scope)
+	scope = slices.Compact(scope)
+	if len(scope) == 0 {
 		return nil
 	}
-	if connected != "" {
-		beyond = append(beyond, connected)
-	}
-	slices.Sort(beyond)
-	return slices.Compact(beyond)
+	return scope
 }
 
 // desiredSchemaNames is every schema a desired state names, over the

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -139,12 +139,11 @@ type applyComputation struct {
 	statements []string
 	current    *types.DBSchema
 	desired    *goschema.Database
-	// readWidened reports that current was read at a wider or narrower scope
-	// than [VerifyPlanTarget] will re-read the same database at. A saved plan
-	// records no schema scope, so the verifier asks [schemascope.ReadNames] with
-	// no selection; a caller fingerprinting current has to know whether the two
-	// would be the same read.
-	readWidened bool
+	// readScope is the schema allow-list current was read at, nil when the read
+	// was the connection's own default. A saved plan records no schema scope, so
+	// [VerifyPlanTarget] re-reads at that default; a caller fingerprinting
+	// current has to know whether the two would be the same read.
+	readScope []string
 }
 
 func computeApplyPlan(
@@ -183,7 +182,7 @@ func computeApplyPlan(
 	if err != nil {
 		return applyComputation{}, fmt.Errorf("load --to schema: %w", err)
 	}
-	current, readWidened, err := applyCurrentState(ctx, conn, opts.Schemas, desired)
+	current, readScope, err := applyCurrentState(ctx, conn, opts.Schemas, desired)
 	if err != nil {
 		return applyComputation{}, err
 	}
@@ -220,9 +219,9 @@ func computeApplyPlan(
 	}
 
 	computation := applyComputation{
-		current:     current,
-		desired:     desired,
-		readWidened: readWidened,
+		current:   current,
+		desired:   desired,
+		readScope: readScope,
 	}
 	info := conn.Info()
 	diff, err := schemadiff.CompareWithDatabase(ctx, conn, desired, current, nil)
@@ -245,31 +244,25 @@ func computeApplyPlan(
 	return computation, nil
 }
 
-// applyCurrentState reads the database side of an apply, and reports whether
-// that read covers something other than the one [VerifyPlanTarget] will make
-// when a plan saved from it is used later.
-//
-// The two scopes are resolved side by side, here, because a plan file records
-// no schema scope: the verifier can only ask [schemascope.ReadNames] with no
-// selection, so the planning run has to know whether its own read was the same
-// one. Deriving them in two places is how a freshly saved plan reported itself
-// stale against the database it had just been computed from (stokaro/ptah#1276).
+// applyCurrentState reads the database side of an apply and reports the scope
+// it was read at, which [planSourceSchema] needs in order to fingerprint a
+// state [VerifyPlanTarget] can recompute.
 func applyCurrentState(
 	ctx context.Context,
 	conn *dbschema.DatabaseConnection,
 	requested []string,
 	desired *goschema.Database,
-) (current *types.DBSchema, readWidened bool, err error) {
-	verifierScope, err := schemascope.ReadNames(ctx, conn.Info(), nil, conn)
+) (current *types.DBSchema, readScope []string, err error) {
+	urlScope, err := schemascope.ReadNames(ctx, conn.Info(), nil, conn)
 	if err != nil {
-		return nil, false, fmt.Errorf("read database schema: %w", err)
+		return nil, nil, fmt.Errorf("read database schema: %w", err)
 	}
-	readScope := applyReadScope(requested, verifierScope, desired)
+	readScope = applyReadScope(requested, urlScope, desired)
 	current, err = dbschema.ReadSchemaWithSchemas(conn, readScope)
 	if err != nil {
-		return nil, false, fmt.Errorf("read database schema: %w", err)
+		return nil, nil, fmt.Errorf("read database schema: %w", err)
 	}
-	return current, !slices.Equal(readScope, verifierScope), nil
+	return current, readScope, nil
 }
 
 // applyReadScope resolves the schemas the DATABASE side of an apply is read at.

--- a/internal/atlasschema/applyscope_internal_test.go
+++ b/internal/atlasschema/applyscope_internal_test.go
@@ -11,11 +11,14 @@ package atlasschema
 // live by TestPostgreSQLSchemaBoundaryGuardIntegration's `two_schemas_plain_url`
 // fixture.
 //
-// The nil rows are the load-bearing ones: nil means the reader keeps the scope
-// it had before stokaro/ptah#1264, so a document that names nothing beyond the
-// connected schema reads exactly what it read before. A row returning
-// []string{"public"} instead would be indistinguishable in the plan and would
-// still have widened what every apply asks the catalog for.
+// The load-bearing rows are the ones where base and the document disagree. base
+// is what schemascope.ReadNames said this URL covers, and it is the same answer
+// `schema diff`, `schema inspect` and `migrate diff` get; the document's own
+// schemas are added on top rather than replacing it, because a URL pinned by
+// search_path covers less than a document may name and a creation planned for
+// an object that exists fails the run. A row that returned only the document's
+// schemas would make a whole schema silently unmanaged, which is
+// stokaro/ptah#1276 with the sign flipped.
 
 import (
 	"testing"
@@ -31,14 +34,14 @@ func TestApplyReadScope(t *testing.T) {
 	tests := []struct {
 		name      string
 		requested []string
-		connected string
+		base      []string
 		desired   *goschema.Database
 		want      []string
 	}{
 		{
-			name:      "explicit schemas outrank the document",
+			name:      "explicit schemas outrank both the URL and the document",
 			requested: []string{"only_this"},
-			connected: "public",
+			base:      []string{"extra", "public"},
 			desired: &goschema.Database{
 				Schemas: []goschema.Schema{{Name: "public"}, {Name: "extra"}},
 			},
@@ -47,30 +50,30 @@ func TestApplyReadScope(t *testing.T) {
 		{
 			name:      "a comma-separated selection is split like the flag",
 			requested: []string{"one,two"},
-			connected: "public",
+			base:      []string{"public"},
 			desired:   &goschema.Database{},
 			want:      []string{"one", "two"},
 		},
 		{
-			name:      "a document naming only the connected schema keeps the default read",
-			connected: "public",
+			name: "the URL's realm scope is read whether or not the document names it",
+			base: []string{"extra", "public"},
 			desired: &goschema.Database{
 				Schemas: []goschema.Schema{{Name: "public"}},
 				Tables:  []goschema.Table{{Name: "a", Schema: "public"}},
 			},
-			want: nil,
+			want: []string{"extra", "public"},
 		},
 		{
-			name:      "a document qualifying nothing keeps the default read",
-			connected: "public",
+			name: "a document qualifying nothing reads exactly the URL's scope",
+			base: []string{"public"},
 			desired: &goschema.Database{
 				Tables: []goschema.Table{{Name: "a"}},
 			},
-			want: nil,
+			want: []string{"public"},
 		},
 		{
-			name:      "a schema block beyond the connected one widens the read",
-			connected: "public",
+			name: "a schema block beyond a pinned URL widens the read",
+			base: []string{"public"},
 			desired: &goschema.Database{
 				Schemas: []goschema.Schema{{Name: "extra"}, {Name: "public"}},
 				Tables:  []goschema.Table{{Name: "a", Schema: "public"}, {Name: "b", Schema: "extra"}},
@@ -78,16 +81,16 @@ func TestApplyReadScope(t *testing.T) {
 			want: []string{"extra", "public"},
 		},
 		{
-			name:      "a qualified table alone widens the read",
-			connected: "public",
+			name: "a qualified table alone widens the read",
+			base: []string{"public"},
 			desired: &goschema.Database{
 				Tables: []goschema.Table{{Name: "b", Schema: "extra"}},
 			},
 			want: []string{"extra", "public"},
 		},
 		{
-			name:      "declarations other than tables name schemas too",
-			connected: "public",
+			name: "declarations other than tables name schemas too",
+			base: []string{"public"},
 			desired: &goschema.Database{
 				Sequences:      []goschema.Sequence{{Name: "s", Schema: "seqs"}},
 				Domains:        []goschema.Domain{{Name: "d", Schema: "doms"}},
@@ -97,25 +100,25 @@ func TestApplyReadScope(t *testing.T) {
 			want: []string{"comps", "doms", "public", "rngs", "seqs"},
 		},
 		{
-			name:      "blank names are not schemas",
-			connected: "public",
+			name: "blank names are not schemas",
+			base: []string{"public"},
 			desired: &goschema.Database{
 				Schemas: []goschema.Schema{{Name: "  "}},
 				Tables:  []goschema.Table{{Name: "a", Schema: ""}},
 			},
-			want: nil,
+			want: []string{"public"},
 		},
 		{
-			name:      "no desired state reads what it read before",
-			connected: "public",
-			desired:   nil,
-			want:      nil,
+			name:    "a connection naming no schema and a document naming none reads the reader's default",
+			base:    nil,
+			desired: nil,
+			want:    nil,
 		},
 	}
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			c.Assert(applyReadScope(tt.requested, tt.connected, tt.desired), qt.DeepEquals, tt.want)
+			c.Assert(applyReadScope(tt.requested, tt.base, tt.desired), qt.DeepEquals, tt.want)
 		})
 	}
 }

--- a/internal/atlasschema/inspect_scope.go
+++ b/internal/atlasschema/inspect_scope.go
@@ -11,7 +11,7 @@ import (
 	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/dbschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
-	"go.5x5.cz/ptah/internal/schemaselection"
+	"go.5x5.cz/ptah/internal/schemascope"
 )
 
 // readInspectSchema reads the schemas one inspection describes.
@@ -52,28 +52,46 @@ func readInspectSchema(
 
 // inspectSchemaNames resolves the schema names to read.
 //
-// An explicit `--schema` wins over the URL's scope: it is the operator naming
-// what they want described, and a name that turns out not to exist stays
-// absent from the result rather than being replaced by a schema they did not
-// ask for. Measured on PostgreSQL 17, `--schema nope` renders `{}` on both
+// The decision itself belongs to [schemascope.ReadNames], which every read
+// feeding a comparison consumes; this wrapper only labels the failure. An
+// explicit `--schema` wins over the URL's scope: it is the operator naming what
+// they want described, and a name that turns out not to exist stays absent from
+// the result rather than being replaced by a schema they did not ask for.
+// Measured on PostgreSQL 17, `--schema nope` renders `{}` on both
 // implementations.
 func inspectSchemaNames(
 	ctx context.Context,
 	conn *dbschema.DatabaseConnection,
 	requested []string,
 ) ([]string, error) {
-	if names := SplitSchemaNames(requested); len(names) > 0 {
-		return names, nil
-	}
-	info := conn.Info()
-	if !schemaselection.Realm(info.Dialect, info.URL, info.Schema) {
-		return []string{info.Schema}, nil
-	}
-	names, err := schemaselection.RealmSchemas(ctx, info.Dialect, conn)
+	names, err := schemascope.ReadNames(ctx, conn.Info(), requested, conn)
 	if err != nil {
 		return nil, fmt.Errorf("read database schema: %w", err)
 	}
 	return names, nil
+}
+
+// readVerifierScopedSchema reads a target database at the scope a plan file
+// cannot record: [schemascope.ReadNames] with no selection.
+//
+// Three callers need exactly this one read -- the fingerprint a plan is saved
+// with, the fingerprint it is verified against, and the baseline a rehearsal
+// rebuilds on the dev database -- and a plan is stale the moment any two of
+// them answer differently, whatever the database did. It is one function so
+// they cannot (stokaro/ptah#1276).
+func readVerifierScopedSchema(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+) (*dbschematypes.DBSchema, error) {
+	names, err := schemascope.ReadNames(ctx, conn.Info(), nil, conn)
+	if err != nil {
+		return nil, fmt.Errorf("read database schema: %w", err)
+	}
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, names)
+	if err != nil {
+		return nil, fmt.Errorf("read database schema: %w", err)
+	}
+	return schema, nil
 }
 
 // withConnectedSchemaRow makes sure a run that named no schema describes the

--- a/internal/atlasschema/inspect_scope.go
+++ b/internal/atlasschema/inspect_scope.go
@@ -71,29 +71,6 @@ func inspectSchemaNames(
 	return names, nil
 }
 
-// readVerifierScopedSchema reads a target database at the scope a plan file
-// cannot record: [schemascope.ReadNames] with no selection.
-//
-// Three callers need exactly this one read -- the fingerprint a plan is saved
-// with, the fingerprint it is verified against, and the baseline a rehearsal
-// rebuilds on the dev database -- and a plan is stale the moment any two of
-// them answer differently, whatever the database did. It is one function so
-// they cannot (stokaro/ptah#1276).
-func readVerifierScopedSchema(
-	ctx context.Context,
-	conn *dbschema.DatabaseConnection,
-) (*dbschematypes.DBSchema, error) {
-	names, err := schemascope.ReadNames(ctx, conn.Info(), nil, conn)
-	if err != nil {
-		return nil, fmt.Errorf("read database schema: %w", err)
-	}
-	schema, err := dbschema.ReadSchemaWithSchemas(conn, names)
-	if err != nil {
-		return nil, fmt.Errorf("read database schema: %w", err)
-	}
-	return schema, nil
-}
-
 // withConnectedSchemaRow makes sure a run that named no schema describes the
 // one it is connected to, even on a dialect whose reader reports no schema rows
 // of its own.

--- a/internal/atlassource/resolve.go
+++ b/internal/atlassource/resolve.go
@@ -158,7 +158,17 @@ func (s Set) resolveDatabase(ctx context.Context, opts ResolveOptions) (State, e
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	schema, err := dbschema.ReadSchemaWithSchemas(conn, schemascope.SplitNames(opts.Schemas))
+	// Which schemas this read covers is [schemascope.ReadNames]'s decision, not
+	// this function's. Deriving it here is what made a database URL describe the
+	// connected schema alone while `schema inspect` described the whole realm,
+	// and the comparator -- which cannot tell a schema nobody read from a schema
+	// nobody wants -- planned `DROP TABLE "extra"."b" CASCADE` off the
+	// difference (stokaro/ptah#1276).
+	names, err := schemascope.ReadNames(ctx, conn.Info(), opts.Schemas, conn)
+	if err != nil {
+		return State{}, fmt.Errorf("read %s database schema: %w", s.Flag, err)
+	}
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, names)
 	if err != nil {
 		return State{}, fmt.Errorf("read %s database schema: %w", s.Flag, err)
 	}
@@ -221,7 +231,15 @@ func (s Set) resolveMigrationDir(ctx context.Context, opts ResolveOptions) (Stat
 		snapshot,
 		migrator.MigrationDirFormatAtlas,
 		func(replayConn *dbschema.DatabaseConnection) error {
-			schema, err := dbschema.ReadSchemaWithSchemas(replayConn, schemascope.SplitNames(opts.Schemas))
+			// Same decision, same owner: a migration directory that creates a
+			// second schema describes it, and a read scoped to the dev
+			// connection's own schema would report the replay as having created
+			// nothing there (stokaro/ptah#1276).
+			names, err := schemascope.ReadNames(ctx, replayConn.Info(), opts.Schemas, replayConn)
+			if err != nil {
+				return fmt.Errorf("read dev database schema: %w", err)
+			}
+			schema, err := dbschema.ReadSchemaWithSchemas(replayConn, names)
 			if err != nil {
 				return fmt.Errorf("read dev database schema: %w", err)
 			}

--- a/internal/schemascope/readnames.go
+++ b/internal/schemascope/readnames.go
@@ -1,0 +1,76 @@
+package schemascope
+
+import (
+	"context"
+
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/schemaselection"
+)
+
+// ReadNames resolves the schemas one live database read covers, for every read
+// whose result becomes a side of a schema comparison.
+//
+// It exists because the answer was being derived independently at each read,
+// and the comparator was never told which one it got. `schema inspect` asked
+// [schemaselection.Realm] and described a whole multi-schema database
+// (stokaro/ptah#1264); the read behind every `--from`/`--to` database URL asked
+// nothing and described the connected schema alone. The two disagreeing is not
+// a cosmetic difference, because the comparator reads absence as intent, and
+// the absence is then produced by whichever reader was asked. Measured on
+// PostgreSQL 17.10 against a database holding `public.a` and `extra.b`,
+// inspected on the compatibility surface and compared back against itself:
+//
+//	schema diff --from file://<that document> --to <plain URL>
+//	  -> DROP TABLE IF EXISTS "extra"."b" CASCADE;
+//	schema diff --from <plain URL> --to file://<that document>
+//	  -> CREATE TABLE "extra"."b" ( ... );
+//
+// The first drops a table nothing asked to drop, the second creates one that
+// already exists, and the pinned Atlas community binary v1.3.0 reports
+// `Schemas are synced` for both. stokaro/ptah#1276.
+//
+// The three answers, in the order they are asked:
+//
+//   - an explicit `--schema`/`--schemas` selection wins. It is the operator
+//     naming what they want, and a name that turns out not to exist stays
+//     absent from the result rather than being replaced by a schema they did
+//     not ask for.
+//   - otherwise the URL decides, through [schemaselection.Realm]: a URL that
+//     pins no schema puts the whole realm under the read.
+//   - a URL that pins one leaves the read at the connected schema.
+//
+// The names are always returned explicitly, even when they resolve to the one
+// schema the reader would have defaulted to, so the read reports the schemas
+// themselves and not only their contents.
+//
+// q is the connection the realm probe runs on; it is the narrow interface
+// [schemaselection.RealmSchemas] takes, so this package stays off the
+// connection layer.
+func ReadNames(
+	ctx context.Context,
+	info dbschematypes.DBInfo,
+	requested []string,
+	q schemaselection.RowsQuerier,
+) ([]string, error) {
+	if names := SplitNames(requested); len(names) > 0 {
+		return names, nil
+	}
+	if !schemaselection.Realm(info.Dialect, info.URL, info.Schema) {
+		return connectedSchemaNames(info), nil
+	}
+	return schemaselection.RealmSchemas(ctx, info.Dialect, q)
+}
+
+// connectedSchemaNames is the read scope of a connection whose URL pinned a
+// schema: the one it landed in.
+//
+// An empty answer is returned as no names rather than as one empty name, which
+// leaves the dialect reader on its own default. Only a connection whose dialect
+// reports no schema at all reaches that, and inventing a name for it here would
+// describe a schema the server never confirmed.
+func connectedSchemaNames(info dbschematypes.DBInfo) []string {
+	if names := SplitNames([]string{info.Schema}); len(names) > 0 {
+		return names
+	}
+	return nil
+}

--- a/internal/schemascope/readnames_test.go
+++ b/internal/schemascope/readnames_test.go
@@ -1,0 +1,180 @@
+package schemascope_test
+
+import (
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+	"go.5x5.cz/ptah/internal/schemascope"
+)
+
+// TestReadNames pins the one decision every comparison-side database read
+// consumes (stokaro/ptah#1276).
+//
+// The load-bearing rows are the two PostgreSQL URL forms. A plain URL puts the
+// whole realm under the read, because the document the read will be compared
+// against describes the whole realm; a `search_path` URL leaves it at the one
+// schema the operator pinned. Collapsing the first into the second is the
+// cheaper implementation the tree had, and it is what made `schema diff` plan
+// `DROP TABLE "extra"."b" CASCADE` against a database whose own description it
+// had just been handed.
+//
+// The probe-call assertions are half the property: an explicit selection and a
+// pinned URL must not query the server at all, so a fix that always probed
+// would be a different behavior wearing the same answers.
+func TestReadNames(t *testing.T) {
+	realmProbeErr := errors.New("realm probe exploded")
+
+	tests := []struct {
+		name       string
+		info       dbschematypes.DBInfo
+		requested  []string
+		probe      func(query string, args []driver.NamedValue) (dbtest.QueryResult, error)
+		want       []string
+		wantErr    string
+		wantProbes int
+	}{
+		{
+			name: "an explicit selection wins and asks the server nothing",
+			info: dbschematypes.DBInfo{
+				Dialect: "postgres",
+				URL:     "postgres://localhost/db?sslmode=disable",
+				Schema:  "public",
+			},
+			requested:  []string{"only_this"},
+			probe:      realmProbeRows("public", "extra"),
+			want:       []string{"only_this"},
+			wantProbes: 0,
+		},
+		{
+			name: "a comma-separated selection is split like the flag",
+			info: dbschematypes.DBInfo{
+				Dialect: "postgres",
+				URL:     "postgres://localhost/db",
+				Schema:  "public",
+			},
+			requested:  []string{"one,two"},
+			probe:      realmProbeRows("public", "extra"),
+			want:       []string{"one", "two"},
+			wantProbes: 0,
+		},
+		{
+			name: "a plain PostgreSQL URL covers the whole realm",
+			info: dbschematypes.DBInfo{
+				Dialect: "postgres",
+				URL:     "postgres://localhost/db?sslmode=disable",
+				Schema:  "public",
+			},
+			probe:      realmProbeRows("public", "extra"),
+			want:       []string{"extra", "public"},
+			wantProbes: 1,
+		},
+		{
+			name: "a search_path URL covers the schema it pinned",
+			info: dbschematypes.DBInfo{
+				Dialect: "postgres",
+				URL:     "postgres://localhost/db?search_path=public",
+				Schema:  "public",
+			},
+			probe:      realmProbeRows("public", "extra"),
+			want:       []string{"public"},
+			wantProbes: 0,
+		},
+		{
+			name: "a comma-carrying search_path pins nothing and covers the realm",
+			info: dbschematypes.DBInfo{
+				Dialect: "postgres",
+				URL:     "postgres://localhost/db?search_path=public,extra",
+				Schema:  "public",
+			},
+			probe:      realmProbeRows("public", "extra"),
+			want:       []string{"extra", "public"},
+			wantProbes: 1,
+		},
+		{
+			name: "a MySQL connection covers the database it named",
+			info: dbschematypes.DBInfo{
+				Dialect: "mysql",
+				URL:     "mysql://root@tcp(127.0.0.1:3306)/app",
+				Schema:  "app",
+			},
+			probe:      realmProbeRows("app"),
+			want:       []string{"app"},
+			wantProbes: 0,
+		},
+		{
+			name: "SQLite has one namespace and covers it",
+			info: dbschematypes.DBInfo{
+				Dialect: "sqlite",
+				URL:     "sqlite://file?mode=memory",
+				Schema:  "main",
+			},
+			probe:      realmProbeRows("main"),
+			want:       []string{"main"},
+			wantProbes: 0,
+		},
+		{
+			name: "a connection reporting no schema leaves the reader its own default",
+			info: dbschematypes.DBInfo{
+				Dialect: "sqlite",
+				URL:     "sqlite://file?mode=memory",
+				Schema:  "   ",
+			},
+			probe:      realmProbeRows("main"),
+			want:       nil,
+			wantProbes: 0,
+		},
+		{
+			name: "a failing realm probe is an error, not an empty realm",
+			info: dbschematypes.DBInfo{
+				Dialect: "postgres",
+				URL:     "postgres://localhost/db",
+				Schema:  "public",
+			},
+			probe: func(string, []driver.NamedValue) (dbtest.QueryResult, error) {
+				return dbtest.QueryResult{}, realmProbeErr
+			},
+			wantErr:    "failed to list realm schemas: realm probe exploded",
+			wantProbes: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := dbtest.Open(t, test.probe)
+
+			got, err := schemascope.ReadNames(t.Context(), test.info, test.requested, db.SQL)
+
+			c.Assert(errString(err), qt.Equals, test.wantErr)
+			c.Assert(got, qt.DeepEquals, test.want)
+			c.Assert(db.QueryCount(), qt.Equals, test.wantProbes)
+		})
+	}
+}
+
+// realmProbeRows answers the realm probe with a fixed schema list.
+func realmProbeRows(names ...string) func(string, []driver.NamedValue) (dbtest.QueryResult, error) {
+	return func(string, []driver.NamedValue) (dbtest.QueryResult, error) {
+		rows := make([][]driver.Value, 0, len(names))
+		for _, name := range names {
+			rows = append(rows, []driver.Value{name})
+		}
+		return dbtest.QueryResult{Columns: []string{"nspname"}, Rows: rows}, nil
+	}
+}
+
+// errString renders an error for comparison, so the table can carry the wanted
+// message as one field instead of a nil check plus a match in every row.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/schemaselection/schemaselection.go
+++ b/internal/schemaselection/schemaselection.go
@@ -37,6 +37,10 @@ const searchPathParam = "search_path"
 // PostgresNonSystemSchemas is the WHERE predicate that keeps the schemas a
 // realm describes and drops the server's own, over a `pg_namespace n`.
 //
+// CockroachDB exposes crdb_internal through the PostgreSQL catalog surface, but
+// its virtual relations are not ordinary user tables and PostgreSQL readers
+// cannot inspect them as comparison input.
+//
 // The ESCAPE clause matters: in LIKE, `_` matches any single character, so an
 // unescaped 'pg\_%' would also hide a user schema named `pgapp` and describe
 // less of the database than is there.
@@ -46,6 +50,7 @@ const searchPathParam = "search_path"
 // go.5x5.cz/ptah/internal/migrateclean, which needs each schema's tables as
 // well. Those two questions differ; "which schemas is the realm" does not.
 const PostgresNonSystemSchemas = `n.nspname <> 'information_schema'
+			  AND n.nspname <> 'crdb_internal'
 			  AND n.nspname NOT LIKE 'pg\_%' ESCAPE '\'`
 
 // RowQuerier is the part of *sql.DB and *sql.Tx [Selection.Resolve] needs.

--- a/internal/schemaselection/schemaselection_test.go
+++ b/internal/schemaselection/schemaselection_test.go
@@ -224,6 +224,30 @@ func TestResolveAsksTheServer(t *testing.T) {
 	}
 }
 
+func TestRealmSchemas_PostgresFamilyQueryExcludesSystemSchemas(t *testing.T) {
+	c := qt.New(t)
+	var queries []string
+	db := dbtest.Open(t, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		queries = append(queries, query)
+		return dbtest.QueryResult{
+			Columns: []string{"nspname"},
+			Rows: [][]driver.Value{
+				{"public"},
+				{"extra"},
+			},
+		}, nil
+	})
+
+	got, err := schemaselection.RealmSchemas(t.Context(), "cockroachdb", db.SQL)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, []string{"extra", "public"})
+	c.Assert(queries, qt.HasLen, 1)
+	c.Assert(queries[0], qt.Contains, "n.nspname <> 'information_schema'")
+	c.Assert(queries[0], qt.Contains, "n.nspname <> 'crdb_internal'")
+	c.Assert(queries[0], qt.Contains, "n.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'")
+}
+
 // errString renders an error for comparison, so the table can carry the wanted
 // message as one field instead of a nil check plus a match in every row.
 func errString(err error) string {


### PR DESCRIPTION
Item 1 of #1276, measured. `schema inspect` resolves realm scope from the URL (#1264); every other database read derived the answer for itself and covered the connected schema alone. The comparator cannot tell a schema nobody read from a schema nobody wants, so the gap between the two readers became intent — in both directions, and one of them destructive.

## Reproduced first, on master (69c5b2ea)

PostgreSQL 17.10, a database holding `public.a` and `extra.b`, reached by a **plain URL** with no `search_path` — the URL form that hid #1257 and #1275 — compared against its own `ptah-compat schema inspect` output.

```
$ ptah-compat schema diff --from file://ptah2.hcl --to 'postgres://…/src2?sslmode=disable' --dev-url …
-- ALTER statements: --
ALTER TABLE "extra"."b" DROP CONSTRAINT IF EXISTS "b_pkey";
-- WARNING: This will delete all data!
DROP TABLE IF EXISTS "extra"."b" CASCADE;
EXIT=0

$ ptah-compat schema diff --from 'postgres://…/src2?sslmode=disable' --to file://ptah2.hcl --dev-url …
CREATE SCHEMA IF NOT EXISTS extra;
-- POSTGRES TABLE: extra.b --
CREATE TABLE "extra"."b" (
  "id" integer PRIMARY KEY NOT NULL
);
EXIT=0
```

The pinned Atlas community binary v1.3.0 answers `Schemas are synced, no changes to be made.` to both, at exit 0. Native `ptah schema diff` reproduces the first one identically.

`migrate diff` never converged, and that one reaches a file a pipeline applies:

```
$ ptah-compat migrate diff first  --dir file://mb --to file://doc.hcl --dev-url …   EXIT=0
$ ptah-compat migrate diff second --dir file://mb --to file://doc.hcl --dev-url …   EXIT=0
$ ls mb | grep -c '\.sql$'
2
$ ptah-compat migrate apply --dir file://mb --url 'postgres://…/t1'
Error: … failed to apply migration 20260809194632: … ERROR: relation "b" already exists (SQLSTATE 42P07)
EXIT=1
```

The oracle writes one file and reports `The migration directory is synced with the desired state` on the second run.

## The fix

`internal/schemascope.ReadNames` is now the one answer to "which schemas does this read cover": an explicit `--schema`/`--schemas` selection wins, otherwise `schemaselection.Realm` decides, and a URL pinning no schema puts the whole realm under the read. Its consumers are `schema inspect` (which stops deriving its own), every `--from`/`--to` database URL in `internal/atlassource`, the migration-directory replay read, `migrate diff`'s current side, and `schema apply`.

`schema apply` previously took its read scope from the DESIRED state, to keep a document describing one schema of a multi-schema database from reaching the others. That is the wrong protection at the wrong layer: it makes a whole schema silently unmanaged rather than authoritatively absent, and it made that verb disagree with `schema diff` over the same two inputs. It now starts from the URL's answer and adds the desired state's own schemas on top, which a `search_path`-pinned URL still needs.

The contract is unchanged and is the one #1276 states: unowned silence must not become a removal, not that removals stop. A document carrying no `ptah:not-described schema` record is authoritative, and its silence is intent.

## After

Same database, same documents, same commands:

| surface | before | after |
| --- | --- | --- |
| compat `schema diff`, document as current | `DROP TABLE "extra"."b" CASCADE` | synced |
| compat `schema diff`, document as desired | `CREATE TABLE "extra"."b"` | synced |
| native `schema diff`, document as current | `DROP TABLE "extra"."b" CASCADE` | synced |
| compat `migrate diff`, run twice | 2 files, never converges | 1 file, `synced` |
| compat `schema apply --dry-run`, document | synced | synced |

Applying the one-file directory to a fresh database exits 0 and leaves `public.a` and `extra.b` in `pg_class`. Applying the inspected document of a rich fixture (three schemas, `isn`/`pgcrypto`/`citext`, two sequences, an RLS policy, a view, a trigger, a role grant, two indexes) back to the database it came from with `--auto-approve` reports synced and leaves the catalog byte-identical: `schemas=3 tables=3 ext=4 seq=2 pol=1` before and after.

The intentional-removal direction still works, and matches the oracle: a hand-written document describing only `public`, against the same two-schema database, plans `DROP TABLE IF EXISTS "extra"."b" CASCADE` on `schema diff` and on `schema apply --dry-run` alike. The oracle plans `DROP SCHEMA "extra" CASCADE` for the same input; before this change Ptah reported `Schemas are synced` and silently left a whole schema unmanaged.

## Tests, and the mutants they were watched under

`TestReadNames` (`internal/schemascope`) pins the decision over nine rows, including which of them may query the server at all — an explicit selection and a pinned URL must not probe.

```
# mutant: `if !schemaselection.Realm(...)` -> `if true`, i.e. always the connected schema
$ go test ./internal/schemascope/ -run TestReadNames -count=1 ; echo $?
1     (3 rows red: plain URL, comma-carrying search_path, failing probe)
# restored
$ go test ./internal/schemascope/ -count=1 ; echo $?
0
```

`TestPostgreSQLDiffReadScopeMatchesTheDescribedScopeIntegration` (`integration/gonative`, build tag `integration`, run by the `integration-tests` job's "Run executor integration tests with live databases" step, which sets `POSTGRES_TEST_DSN`) crosses the boundary live in both directions plus the genuine-removal control. Two mutants separate the rows:

```
# mutant A: revert internal/atlassource to `schemascope.SplitNames(opts.Schemas)`
$ POSTGRES_TEST_DSN=… go test -tags=integration ./integration/gonative -run '^TestPostgreSQLDiffReadScope' -count=1 ; echo $?
1     --- FAIL: …/the_database's_own_description_as_the_desired_state_plans_nothing
      --- FAIL: …/the_database's_own_description_as_the_current_state_plans_nothing
      --- FAIL: …/a_document_describing_one_schema_still_removes_what_it_does_not_describe

# mutant B: scope the --from read to the schemas the desired state names
#           (the alternative fix, in internal/atlasschema/diff.go)
$ POSTGRES_TEST_DSN=… go test -tags=integration ./integration/gonative -run '^TestPostgreSQLDiffReadScope' -count=1 ; echo $?
1     --- PASS: …/the_database's_own_description_as_the_desired_state_plans_nothing
      --- PASS: …/the_database's_own_description_as_the_current_state_plans_nothing
      --- FAIL: …/a_document_describing_one_schema_still_removes_what_it_does_not_describe

# restored
$ POSTGRES_TEST_DSN=… go test -tags=integration ./integration/gonative -run '^TestPostgreSQLDiffReadScope' -count=1 ; echo $?
0
```

Mutant B is the discriminating one: it is the fix this change replaces, and only the control row can see it.

## Gates

Each run on the pushed tree, exit code read directly: `go build ./...` 0; `go vet ./...` 0; `go vet -tags integration ./integration/...` 0; `go test ./... -count=1` 0; `go tool qtlint ./...` 0; `golangci-lint run ./...` 0 issues; `scripts/check-test-style.sh` 0; `scripts/check-public-api.sh` 0; `scripts/check-public-api-snapshot.sh` 0; `scripts/check-public-api-released.sh` 0; every `check:*` in `docs/site/package.json` 0, including `check:responsive` after `npm run build`. The whole `./integration/gonative -tags=integration` suite is green against PostgreSQL 17.10.

## What this does NOT close

#1276 is an umbrella. This closes its item 1 and the destructive instance above; it does not close the issue.

- The `schema plan` fingerprint pair (`planSourceSchema`, `VerifyPlanTarget`, the rehearsal baseline in `planverify.go` and `simulate.go`) still reads at the connection's own scope, not the owner's. It is self-consistent and unchanged from master — drift outside the connected schema was already invisible there, because the read never saw it — but it is the same class and should be routed through `schemascope.ReadNames` with a `ctx` threaded to `VerifyPlanTarget`.
- `integration/gonative/schema_boundary_guard_postgres_test.go` still observes the live side through `dbschema.ReadSchemaWithSchemas(conn, nil)`, which is a reader no comparison uses any more. It passes unchanged on this branch (verified), but its header paragraph beginning "One row still records a difference" and `two_schemas_plain_url`'s `wantReadSchemas`/`wantDocumentOnly` now describe an instrument rather than a defect; the row's stated target is `wantReadSchemas: {"extra","public"}` and `wantDocumentOnly: nil`, which is what it reads when the observation goes through the owner.
- `docs/site/src/content/docs/direct/inspect.md` still says only that an empty `--schemas` reads the connection's default schema. The flag help on `schema inspect|diff|apply` now states the real rule; the page should repeat it.
- The reader does not yet RECORD what it skipped. A `search_path`-pinned URL reads one schema and says nothing about the rest, and the multi-schema-HCL refusal (#1231) is what stops that from becoming a removal today. Item 2's `coverage.Set` should be populated on the read side too.