### PR TITLE
Say what was measured about a failed rollback (#995)

### DIFF
--- a/docs/site/src/content/docs/versioned/rollback.md
+++ b/docs/site/src/content/docs/versioned/rollback.md
@@ -220,17 +220,20 @@ bodies happen to be the same length such a row cannot be told apart, and
 `--force` is the override in either case.
 :::
 
-**`ptah-compat migrate down` keeps the Atlas revision-table schema, but it does
-not copy Atlas's failed-down defect.** Measured against Atlas (build,
-2026-08-01), a down whose second statement fails leaves its row reading
-`applied=2, total=2, error=''`, even when `-- atlas:txmode none` already
-committed the first statement and left the schema half-reverted.
+**`ptah-compat migrate down` keeps the Atlas revision-table schema and still
+records a failed rollback.** There is no community Atlas rollback behavior to
+match here: on the pinned community build, `atlas migrate down --help` prints
+`'atlas migrate down' is not supported by the community version.` So what a
+failed `ptah-compat migrate down` leaves behind is Ptah's own decision, and the
+decision is to leave no clean applied row over a partially reverted schema.
 
-Ptah records that failure instead. For Atlas-format rows it stores the rollback
-marker in `operator_version`, keeps `applied` and `total` as down-statement
-progress, and writes the error fields already present in the Atlas schema. A
-failed statement is therefore visible in `ptah-compat migrate status`, later
-apply runs refuse to cross any unfinished rollback marker, and
+For Atlas-format rows Ptah stores the rollback marker in `operator_version`,
+keeps `applied` and `total` as down-statement progress, and writes the error
+fields already present in the Atlas schema. A `-- atlas:txmode none` down whose
+third of four statements fails therefore leaves `operator_version='Ptah/down'`,
+`applied=2`, `total=4`, and both error fields set. The failure is visible in
+`ptah-compat migrate status`, a later `migrate apply` refuses to cross the
+unfinished rollback — `--allow-dirty` included — and
 `ptah migrations repair --revision-format atlas` resumes the down body. A
 successful rollback still deletes the row.
 
@@ -254,11 +257,12 @@ statement but stopped on a database-state safety check needs no
 `--resume-from`; after the database is reconciled, rerun repair to finalize the
 rollback without replaying SQL.
 
-This is an intentional safety divergence: table interoperability is retained,
-but an Atlas reader may report a Ptah-recorded failed rollback differently from
-Atlas's own hidden failure. The same rule follows the **revision table format**,
-not the binary, so native `ptah migrations down --revision-format atlas` gets
-the same recoverable bookkeeping.
+This is an intentional divergence in the direction of safety: the table stays
+readable by other tools, but a reader that expects a revision row to describe
+forward progress only may report a Ptah-recorded failed rollback differently.
+The same rule follows the **revision table format**, not the binary, so native
+`ptah migrations down --revision-format atlas` gets the same recoverable
+bookkeeping.
 
 ## Failure modes
 


### PR DESCRIPTION
## What this changes

One paragraph of `docs/site/src/content/docs/versioned/rollback.md`, plus the
sentence further down that repeats its claim. No code, no behavior change.

The page justified Ptah's failed-down bookkeeping with a measurement of Atlas's
own:

> Measured against Atlas (build, 2026-08-01), a down whose second statement
> fails leaves its row reading `applied=2, total=2, error=''` …

The pinned community binary cannot produce that row, because it has no rollback
verb at all. Measured on it, exit codes read directly:

```
$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas version
atlas community version v1.3.0
https://github.com/ariga/atlas/releases/tag/v1.3.0
To download an official version, visit: https://atlasgo.io/getting-started#installation
VERSION_EXIT=0

$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas migrate down --help
'atlas migrate down' is not supported by the community version.
…
DOWN_HELP_EXIT=0

$ /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas migrate apply --help    # control, same build
'atlas migrate apply' reads the migration state of the connected database …
APPLY_HELP_EXIT=0
```

So the paragraph rested a real safety property on a measurement nobody can
reproduce with the binary this repository pins. It now states what is
measurable — the community build has no rollback verb, so the bookkeeping is
Ptah's own decision rather than a copied one — and quotes a row this branch
actually produced.

## The row the page now quotes, measured

Binaries built inside the working worktree, not the shared `bin/`. Fixture: an
Atlas txtar whose down body is `-- atlas:txmode none` with four statements,
the third naming a table that does not exist.

```
$ ptah-compat migrate apply --url sqlite://e2.db --dir file://migrations
Migrating to version 20260101000000 from 1 pending migrations.
Migration complete. Current version: 20260101000000
APPLY_EXIT=0

$ ptah-compat migrate down --url sqlite://e2.db --dir file://migrations --to-version 0
Error: error running down migrations: failed to revert migration 20260101000000: … no such table: definitely_missing_table (1)
SQL: DROP TABLE definitely_missing_table
DOWN_EXIT=1

$ sqlite3 e2.db "SELECT version, applied, total, error, error_stmt, operator_version FROM atlas_schema_revisions;"
         version = 20260101000000
         applied = 2
           total = 4
           error = SQL logic error: no such table: definitely_missing_table (1)
      error_stmt = DROP TABLE definitely_missing_table;
operator_version = Ptah/down
$ sqlite3 e2.db ".tables"
atlas_schema_revisions  parent

$ ptah-compat migrate status --url sqlite://e2.db --dir file://migrations
Migration Status: PENDING
  -- Current Version: 20260101000000 (2 statements applied)
  -- Next Version:    20260101000000 (2 statements left)
  -- Executed Files:  1 (last one partially)
  -- Pending Files:   1

Last migration attempt had errors:
  -- SQL:   DROP TABLE definitely_missing_table;
  -- ERROR: SQL logic error: no such table: definitely_missing_table (1)
STATUS_EXIT=0

$ ptah-compat migrate apply --url sqlite://e2.db --dir file://migrations
Error: error applying migrations: migration 20260101000000 is dirty: state=failed applied=2/4 …
APPLY2_EXIT=1

$ ptah-compat migrate apply … --allow-dirty
Error: error applying migrations: migration 20260101000000 is dirty from an interrupted rollback; repair the rollback before migrating up
APPLY_ALLOWDIRTY_EXIT=1

$ ptah migrations repair --db-url sqlite://e2.db --migrations-dir migrations \
    --dir-format atlas --revision-format atlas --version 20260101000000 --resume-from 4
INFO Completed rollback of migration version=20260101000000 description=Setup
REPAIR_EXIT=0
$ sqlite3 e2.db ".tables"                                → atlas_schema_revisions
$ sqlite3 e2.db "SELECT COUNT(*) FROM atlas_schema_revisions;"  → 0
```

Every sentence the page now makes about this path is one of those lines.

## Why this PR exists at all

The assignment was to close #995. It does not reproduce on master: its six
acceptance boxes were closed in code by #1137 and #1332, which landed after the
issue's last triage comment. The re-measurement is posted on the issue. This
paragraph is the one thing in #995's own surface area that was still wrong.

## Not done here

Three places still assert what Atlas's failed-down bookkeeping is, without
claiming a measurement — `docs/site/src/content/docs/atlas/comparison.md:317`,
`docs/site/src/content/docs/atlas/feature-matrix.md:182`, and
`docs/site/src/content/docs/versioned/apply.md:351`. Two code comments say the
same thing in the same words, and carry the word this repository does not use:
`migration/migrator/migrator.go:2538-2540` and
`migration/migrator/atlas_down_bookkeeping_test.go:15-18`. Those edits were
prepared and passed every gate, but local commits cannot be signed in this
environment, and pushing a 100 KB source file through the API by hand is not a
safe way to land a comment reword. They are named here so the next commit that
can be signed locally picks them up.

## Gates

Run on this content, each exit code read directly, before the tree was reduced
to the single documentation file and again after:

`go build ./...` 0 · `go vet ./...` 0 · `go vet -tags integration ./integration/...` 0 ·
`go test ./... -count=1` 0 · `go tool qtlint ./...` 0 · `golangci-lint run ./...` 0 (0 issues) ·
`scripts/check-test-style.sh` 0 · `scripts/check-public-api.sh` 0 ·
`scripts/check-public-api-snapshot.sh` 0 · `scripts/check-public-api-released.sh` 0 ·
docs `check:exit-codes` 0 · `check:exit-codes:selftest` 0 · `check:core-doc-links` 0 ·
`check:page-health` 0 · `check:links` 0 · `check:links:selftest` 0 · `check:redirects` 0 ·
`check:redirects:selftest` 0 · `check:style` 0 · `check:style:selftest` 0 ·
`check:limitations` 0 · `check:limitations:selftest` 0 · `check:responsive` 0
(after `npm run build`) · `check:responsive:selftest` 0 · `versions:selftest` 0.