### PR TITLE
Harden MySQL metadata witness sessions

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -329,7 +329,7 @@ jobs:
       # family lives in the authority on its membership, so a test added there
       # is covered the day it lands and one renamed out of the family fails.
       # 5m rather than 3m is headroom for a shared runner, not a measurement:
-      # the family takes about 21s of package time against MySQL 9.7.1 and
+      # the family takes about one minute of package time against MySQL 9.7.1 and
       # MariaDB 10.11.18.
       - name: Run MySQL-family rolled-back progress tests
         env:

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -475,6 +475,25 @@ func (dc *DatabaseConnection) WithSession(
 	return use(&scoped)
 }
 
+// WithSessionOrCurrent calls use with one physical database session. Pool-backed
+// connections pin a new session and discard it afterward; already pinned
+// connections reuse the current session and leave its lifecycle with the caller.
+func (dc *DatabaseConnection) WithSessionOrCurrent(
+	ctx context.Context,
+	use func(*DatabaseConnection) error,
+) error {
+	if dc == nil || dc.db == nil {
+		return fmt.Errorf("database session requires an open database connection")
+	}
+	if use == nil {
+		return fmt.Errorf("database session callback is nil")
+	}
+	if dc.pinned {
+		return use(dc)
+	}
+	return dc.WithSession(ctx, use)
+}
+
 func refineMySQLForeignKeyCapabilities(
 	dialect string,
 	caps capability.Capabilities,

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -156,6 +156,12 @@ func TestDatabaseConnectionWithSession_RebindsAllDatabaseOperations(t *testing.T
 		nested, nestedErr := scoped.Conn(ctx)
 		c.Assert(nestedErr, qt.ErrorMatches, `database connection is already pinned to a session`)
 		c.Assert(nested, qt.IsNil)
+		currentErr := scoped.WithSessionOrCurrent(ctx, func(current *DatabaseConnection) error {
+			c.Assert(current, qt.Equals, scoped)
+			_, execErr := current.ExecContext(ctx, "CURRENT")
+			return execErr
+		})
+		c.Assert(currentErr, qt.IsNil)
 		c.Assert(scoped.Close(), qt.IsNil)
 		return nil
 	})
@@ -164,7 +170,7 @@ func TestDatabaseConnectionWithSession_RebindsAllDatabaseOperations(t *testing.T
 	_, err = conn.ExecContext(ctx, "ROOT")
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.QueryCount(), qt.Equals, 1)
-	c.Assert(db.ExecCount(), qt.Equals, 3)
+	c.Assert(db.ExecCount(), qt.Equals, 4)
 }
 
 func TestResolveDatabaseCapabilities_MySQLKeepsVersionBaseline(t *testing.T) {

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -191,6 +191,10 @@ callback. Root MySQL capability metadata remains conservative; on MySQL 8.4+
 the scoped connection refines its referenced-key policy from
 `restrict_fk_on_non_standard_key` on the pinned session before the callback,
 so planning and execution can safely use that same effective policy.
+Use `dbschema.DatabaseConnection.WithSessionOrCurrent` for reusable components
+that may run inside an existing pinned callback or from a pool-backed
+connection; it pins only when needed and otherwise leaves the current session
+lifecycle with the caller.
 
 `dbschema.DatabaseConnection.WithUntrustedSQLSession` pins a session that will
 execute SQL the caller does not trust and applies every engine-level

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5427,6 +5427,7 @@ func (dc *DatabaseConnection) SchemaWriter() types.SchemaWriter
 func (dc *DatabaseConnection) WithExecutor(executor types.SchemaExecutor) *DatabaseConnection
 func (dc *DatabaseConnection) WithIsolatedQuerySession(ctx context.Context, opts *sql.TxOptions, use func(IsolatedQueryer) error) (resultErr error)
 func (dc *DatabaseConnection) WithSession(ctx context.Context, use func(*DatabaseConnection) error) (resultErr error)
+func (dc *DatabaseConnection) WithSessionOrCurrent(ctx context.Context, use func(*DatabaseConnection) error) error
 func (dc *DatabaseConnection) WithUntrustedSQLSession(ctx context.Context, use func(*DatabaseConnection) error) error
 func (dc *DatabaseConnection) Writer() types.SchemaExecutor
 

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -230,9 +230,20 @@ the affected direction instead because their inner statements are opaque.
 MySQL and MariaDB do not support `--tx-mode all`. Ordinary session settings
 remain valid. Ptah runs the body on one pinned session, discards it afterward,
 and replays safe settings such as `SET SESSION time_zone` from a verified
-committed prefix before an automatic retry. A durable unknown-outcome witness
-blocks automatic retry until the database is inspected and the revision is
-repaired.
+committed prefix before an automatic retry.
+
+Temporary tables are also allowed: their DDL does not make permanent InnoDB
+work durable by itself, and discarding the session prevents temporary state
+from leaking into a retry. If a later implicit commit makes a prefix containing
+a temporary object durable, automatic resume refuses because that object cannot
+be reconstructed safely.
+
+A same-named temporary table cannot shadow the Atlas revision table: before
+reading or writing revision metadata, Ptah refuses and discards a pinned
+session that already contains that temporary table. It also rejects statements
+that directly reference the metadata relation, including through a
+schema-qualified name. A durable unknown-outcome witness blocks automatic retry
+until the database is inspected and the revision is repaired.
 
 The migration advisory lock serializes Ptah clients that use the same lock
 name. It cannot freeze DDL from a client that ignores that lock. Do not run

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -192,6 +192,10 @@ callback, so planning and execution use the same effective policy.
 
 The scoped connection must not escape the callback. Ptah discards the physical
 connection afterward so session-local state cannot leak to a later pool user.
+Use `dbschema.DatabaseConnection.WithSessionOrCurrent` when the same operation
+can be called either from a pool-backed connection or from an existing pinned
+session; it pins only when needed and otherwise reuses the caller's current
+session lifecycle.
 
 `dbschema.DatabaseConnection.WithIsolatedQuerySession` exposes a query-only
 `dbschema.IsolatedQueryer` on one physical session. Transaction-capable drivers

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -389,13 +389,26 @@ skips is only ever the prefix that really survived:
   rolls back retries from the first statement, while a durable DDL/DML prefix
   resumes at the first statement not witnessed as complete. Ptah pins and then
   discards the physical session; a retry replays safe session settings from the
-  verified prefix before it continues. If a witness committed before a failing
-  statement whose lack of side effects cannot be proven, the row remains marked
-  unknown and automatic retry stops for manual inspection. MySQL and MariaDB do
-  not support `all`.
+  verified prefix before it continues. Temporary tables remain available:
+  their DDL does not make permanent InnoDB work durable by itself, and
+  discarding the session prevents temporary state from leaking into a retry. If
+  a later implicit commit makes a prefix containing a temporary object durable,
+  automatic resume refuses because that object cannot be reconstructed safely.
+  The configured migration metadata table name is reserved. Before reading or
+  writing revision metadata, Ptah refuses and discards a pinned session that
+  already contains a same-named temporary table. It also rejects statements
+  that directly reference the metadata relation, including through a
+  schema-qualified name.
+  If a witness committed before a failing statement whose lack of side effects
+  cannot be proven, the row remains marked unknown and automatic retry stops for
+  manual inspection. MySQL and MariaDB do not support `all`.
 
 Recorded progress therefore excludes transactional work that a rollback undid,
 while non-transactional mode retains work that no rollback could undo.
+On MySQL and MariaDB, non-transactional mode keeps revision bookkeeping on a
+separate checked metadata session while the migration body runs on its own
+discarded session, so body-local temporary objects cannot shadow the metadata
+table.
 
 **A non-transactional statement was interrupted.** If the process exits, the
 context is canceled, or its deadline expires while an autocommit statement is

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -672,6 +672,25 @@ removes both transactional DML and its witness. A retry skips only the verified
 durable prefix and replays safe session settings from that prefix on a newly
 pinned session before continuing.
 
+Temporary tables remain available in `file` mode. Creating one does not make
+permanent InnoDB work durable by itself, and Ptah discards the pinned physical
+session after every attempt, so a temporary table or nontransactional temporary
+table data cannot leak into the retry. If a later implicit commit makes a
+prefix containing a temporary object durable, automatic resume refuses that
+prefix because the object cannot be reconstructed safely.
+
+The configured migration metadata table name is reserved. Before reading or
+writing revision metadata, Ptah refuses and discards a pinned MySQL-family
+session that already contains a same-named temporary table. It also rejects
+migration statements that directly reference the metadata relation. This
+prevents a temporary table from shadowing the permanent InnoDB witness,
+including through a schema-qualified name.
+
+In `none` mode, MySQL and MariaDB keep revision bookkeeping on a separate
+checked metadata session while the migration body runs on its own discarded
+session. Body-local temporary objects therefore cannot shadow revision
+bookkeeping, while nontransactional progress is still recorded durably.
+
 The witness requires InnoDB for revision metadata, the session default, and
 every existing base table in the selected database. Ptah-created native and
 Atlas revision tables declare `ENGINE=InnoDB`; an existing revision table using
@@ -707,6 +726,8 @@ from the outer statement:
 - `USE` and qualified references to another database. The connection URL,
   engine preflight, migration target, and metadata table must refer to one
   database.
+- Direct references to the configured migration metadata table. That relation
+  is reserved for Ptah's transaction witness.
 - Executable comments, `CALL`, prepared or dynamic SQL, and table locks.
 - Definitions of views, triggers, routines, and events; references to existing
   views or trigger-bearing tables; and stored-routine calls.

--- a/migration/migrator/implicit_commit.go
+++ b/migration/migrator/implicit_commit.go
@@ -52,6 +52,15 @@ func (m *Migrator) validateTransactionalProgressSQL(
 	statements := splitSQLStatementsForConnection(m.conn, migrationSQLForDirection(migration, direction))
 	for i, statement := range statements {
 		tokens := significantSQLTokens(statement, m.connectionDialect())
+		if m.mysqlReferencesMigrationMetadata(tokens) {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because it references Ptah's migration "+
+					"metadata table %s, which is reserved for transaction-witness bookkeeping; choose another relation name",
+				migration.Version,
+				i+1,
+				m.qualifiedMigrationsTable(),
+			)
+		}
 		if mysqlExecutableComment(tokens) {
 			return fmt.Errorf(
 				"migration %d cannot run tx-mode file statement %d because MySQL-family executable comments "+
@@ -361,6 +370,22 @@ func mysqlCreateTableLike(tokens []lexer.Token) bool {
 			continue
 		}
 		if depth == 0 && token.MatchIdentifierValue("LIKE") {
+			return true
+		}
+	}
+	return false
+}
+
+func mysqlCreatesTemporaryTable(tokens []lexer.Token) bool {
+	if len(tokens) < 3 || !tokens[0].MatchIdentifierValue("CREATE") {
+		return false
+	}
+	tableKeyword := mysqlTableKeyword(tokens)
+	if tableKeyword < 0 {
+		return false
+	}
+	for _, token := range tokens[1:tableKeyword] {
+		if token.MatchIdentifierValue("TEMPORARY") {
 			return true
 		}
 	}

--- a/migration/migrator/implicit_commit_internal_test.go
+++ b/migration/migrator/implicit_commit_internal_test.go
@@ -747,6 +747,56 @@ func TestMySQLReferencedCatalogName_IgnoresNonRelationIdentifiers(t *testing.T) 
 	}
 }
 
+func TestMySQLReferencesNamedRelation_Present(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CREATE TEMPORARY TABLE schema_migrations (version BIGINT)",
+		"CREATE TEMPORARY TABLE app.schema_migrations (version BIGINT)",
+		"ALTER TABLE staging RENAME TO schema_migrations",
+		"ALTER TABLE staging RENAME schema_migrations",
+		"RENAME TABLE staging TO app.schema_migrations",
+		"SELECT * FROM `APP`.`SCHEMA_MIGRATIONS`",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlReferencesNamedRelation(
+				significantSQLTokens(statement, "mysql"),
+				"app",
+				"app",
+				"schema_migrations",
+			)
+			c.Assert(got, qt.IsTrue)
+		})
+	}
+}
+
+func TestMySQLReferencesNamedRelation_Absent(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CREATE TEMPORARY TABLE audit.schema_migrations (version BIGINT)",
+		"CREATE TEMPORARY TABLE app.other_table (version BIGINT)",
+		"ALTER TABLE users RENAME COLUMN legacy TO schema_migrations",
+		"ALTER TABLE users RENAME INDEX legacy TO schema_migrations",
+		"SELECT schema_migrations FROM app.users",
+		"SELECT * FROM audit.schema_migrations",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlReferencesNamedRelation(
+				significantSQLTokens(statement, "mysql"),
+				"app",
+				"app",
+				"schema_migrations",
+			)
+			c.Assert(got, qt.IsFalse)
+		})
+	}
+}
+
 func TestMySQLInvokedRoutine(t *testing.T) {
 	c := qt.New(t)
 	routines := map[string]struct{}{"next_job_id": {}}
@@ -821,6 +871,39 @@ func TestMySQLCreateTableLike_Absent(t *testing.T) {
 	for _, statement := range statements {
 		c.Run(statement, func(c *qt.C) {
 			got := mysqlCreateTableLike(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsFalse)
+		})
+	}
+}
+
+func TestMySQLCreatesTemporaryTable_Present(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CREATE TEMPORARY TABLE jobs (id BIGINT)",
+		"CREATE OR REPLACE TEMPORARY TABLE jobs (id BIGINT)",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlCreatesTemporaryTable(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsTrue)
+		})
+	}
+}
+
+func TestMySQLCreatesTemporaryTable_Absent(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CREATE TABLE jobs (id BIGINT)",
+		"CREATE TEMPORARY VIEW jobs AS SELECT 1",
+		"ALTER TABLE jobs ADD COLUMN temporary BIGINT",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlCreatesTemporaryTable(significantSQLTokens(statement, "mysql"))
 			c.Assert(got, qt.IsFalse)
 		})
 	}

--- a/migration/migrator/metadata_presence.go
+++ b/migration/migrator/metadata_presence.go
@@ -88,6 +88,29 @@ WHERE table_schema = ? AND table_name = ? AND table_type = 'BASE TABLE'`, schema
 	return nil
 }
 
+// refuseMySQLTemporaryMetadataShadow detects session state that would redirect
+// revision reads and writes away from the permanent InnoDB witness. MySQL and
+// MariaDB let a temporary table shadow a same-named permanent table even when
+// the reference is schema-qualified. WithSession discards the pinned connection
+// after this refusal, so the stale temporary object cannot reach a retry.
+func (m *Migrator) refuseMySQLTemporaryMetadataShadow(ctx context.Context) error {
+	if !implicitCommitDialect(m.connectionDialect()) {
+		return nil
+	}
+	var table string
+	var createSQL string
+	if err := m.conn.QueryRowContext(ctx, "SHOW CREATE TABLE "+m.qualifiedMigrationsTable()).Scan(&table, &createSQL); err != nil {
+		return fmt.Errorf("failed to inspect the pinned-session migration metadata table: %w", err)
+	}
+	if mysqlCreatesTemporaryTable(significantSQLTokens(createSQL, m.connectionDialect())) {
+		return fmt.Errorf(
+			"pinned MySQL-family session contains temporary table %s that shadows Ptah's migration metadata; retry on a clean session",
+			m.qualifiedMigrationsTable(),
+		)
+	}
+	return nil
+}
+
 func (m *Migrator) requireTransactionalTargetEngines(ctx context.Context) error {
 	if !implicitCommitDialect(m.connectionDialect()) {
 		return nil
@@ -394,6 +417,42 @@ func mysqlReferencedCatalogName(tokens []lexer.Token, names map[string]struct{})
 	return "", false
 }
 
+func (m *Migrator) mysqlReferencesMigrationMetadata(tokens []lexer.Token) bool {
+	metadataSchema := configuredOrConnectionSchema(m.metadataTableSchemaName(), m.connectionSchemaName())
+	return mysqlReferencesNamedRelation(
+		tokens,
+		m.connectionSchemaName(),
+		metadataSchema,
+		m.migrationsTableName(),
+	)
+}
+
+func mysqlReferencesNamedRelation(
+	tokens []lexer.Token,
+	selectedSchema string,
+	targetSchema string,
+	targetName string,
+) bool {
+	for i, token := range tokens {
+		name, identifier := mysqlMigrationIdentifierValue(token)
+		if !identifier || !strings.EqualFold(name, targetName) || !mysqlRelationReference(tokens, i) {
+			continue
+		}
+		referencedSchema := selectedSchema
+		if i >= 2 && tokens[i-1].Value == "." {
+			schema, schemaIdentifier := mysqlMigrationIdentifierValue(tokens[i-2])
+			if !schemaIdentifier {
+				continue
+			}
+			referencedSchema = schema
+		}
+		if strings.EqualFold(referencedSchema, targetSchema) {
+			return true
+		}
+	}
+	return false
+}
+
 func mysqlRelationReference(tokens []lexer.Token, index int) bool {
 	if index >= 2 && tokens[index-1].Value == "." {
 		return mysqlDirectRelationReference(tokens, index-2)
@@ -469,14 +528,20 @@ func mysqlFollowsRenameTargetPrefix(tokens []lexer.Token) bool {
 }
 
 func mysqlFollowsAlterTableRenameTargetPrefix(tokens []lexer.Token) bool {
-	if len(tokens) < 4 || !tokens[0].MatchIdentifierValue("ALTER") ||
-		!tokens[1].MatchIdentifierValue("TABLE") ||
-		!matchesAnyKeyword(tokens[len(tokens)-1], "TO", "AS") {
+	if len(tokens) < 4 || !tokens[0].MatchIdentifierValue("ALTER") {
 		return false
 	}
-	return slices.ContainsFunc(tokens[2:len(tokens)-1], func(token lexer.Token) bool {
-		return token.MatchIdentifierValue("RENAME")
-	})
+	tableKeyword := mysqlTableKeyword(tokens)
+	if tableKeyword < 0 {
+		return false
+	}
+	optionStart := mysqlTableNameEnd(tokens, tableKeyword+1)
+	if optionStart < 0 || optionStart >= len(tokens) || !tokens[optionStart].MatchIdentifierValue("RENAME") {
+		return false
+	}
+	renamePrefix := tokens[optionStart+1:]
+	return len(renamePrefix) == 0 ||
+		(len(renamePrefix) == 1 && matchesAnyKeyword(renamePrefix[0], "TO", "AS"))
 }
 
 func mysqlFollowsDropObjectPrefix(tokens []lexer.Token) bool {

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -1000,7 +1000,7 @@ func (m *Migrator) GetRevisions(ctx context.Context) ([]MigrationRevision, error
 	return queryMigrationRows(
 		ctx,
 		m,
-		m.getRevisionsSQL,
+		(*Migrator).getRevisionsSQL,
 		m.scanRevisionRow,
 		"failed to query migration revisions",
 		"failed to scan migration revision",
@@ -1011,7 +1011,7 @@ func (m *Migrator) GetRevisions(ctx context.Context) ([]MigrationRevision, error
 func queryMigrationRows[T any](
 	ctx context.Context,
 	m *Migrator,
-	query func() string,
+	query func(*Migrator) string,
 	scan func(rowScanner) (T, error),
 	queryErr string,
 	scanErr string,
@@ -1024,7 +1024,38 @@ func queryMigrationRows[T any](
 		return []T{}, nil
 	}
 
-	return queryMigrationRowsFrom(ctx, m.conn, query(), scan, queryErr, scanErr, iterErr)
+	var revisions []T
+	err := m.withMigrationMetadataSession(ctx, func(scoped *Migrator) error {
+		rows, err := queryMigrationRowsFrom(
+			ctx,
+			scoped.conn,
+			query(scoped),
+			scan,
+			queryErr,
+			scanErr,
+			iterErr,
+		)
+		revisions = rows
+		return err
+	})
+	return revisions, err
+}
+
+func (m *Migrator) withMigrationMetadataSession(ctx context.Context, use func(*Migrator) error) error {
+	if !implicitCommitDialect(m.connectionDialect()) {
+		return use(m)
+	}
+	return m.conn.WithSessionOrCurrent(ctx, func(conn *dbschema.DatabaseConnection) error {
+		scoped := *m
+		scoped.conn = conn
+		if scoped.migrationsSchema == "" {
+			scoped.migrationsSchema = scoped.connectionSchemaName()
+		}
+		if err := scoped.refuseMySQLTemporaryMetadataShadow(ctx); err != nil {
+			return err
+		}
+		return use(&scoped)
+	})
 }
 
 type migrationRowsQueryer interface {
@@ -2127,6 +2158,9 @@ func (m *Migrator) withTransactionalMigrationSession(
 		scoped.conn = conn
 		if scoped.migrationsSchema == "" {
 			scoped.migrationsSchema = scoped.connectionSchemaName()
+		}
+		if err := scoped.refuseMySQLTemporaryMetadataShadow(ctx); err != nil {
+			return err
 		}
 		if err := scoped.restoreNoTransactionSessionPrefix(
 			ctx,

--- a/migration/migrator/no_transaction_session.go
+++ b/migration/migrator/no_transaction_session.go
@@ -33,6 +33,24 @@ func (m *Migrator) withNoTransactionSession(
 	if m.conn.Writer().IsDryRun() || m.noTransactionSession != nil {
 		return use(m)
 	}
+	if implicitCommitDialect(m.connectionDialect()) {
+		return m.conn.WithSession(ctx, func(metadataConn *dbschema.DatabaseConnection) error {
+			metadataScoped := *m
+			metadataScoped.conn = metadataConn
+			if metadataScoped.migrationsSchema == "" {
+				metadataScoped.migrationsSchema = metadataScoped.connectionSchemaName()
+			}
+			if err := metadataScoped.refuseMySQLTemporaryMetadataShadow(ctx); err != nil {
+				return err
+			}
+			return m.conn.WithSession(ctx, func(bodyConn *dbschema.DatabaseConnection) error {
+				scoped := metadataScoped
+				scoped.noTransactionSession = bodyConn
+				scoped.postgresIndexObservation = nil
+				return use(&scoped)
+			})
+		})
+	}
 	return m.conn.WithSession(ctx, func(conn *dbschema.DatabaseConnection) error {
 		scoped := *m
 		scoped.noTransactionSession = conn

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -778,33 +778,45 @@ checksum = VALUES(checksum)`
 // exactly the recovery run this guard exists to send the operator towards
 // (#966).
 func (m *Migrator) dirtyRevision(ctx context.Context) (*MigrationRevision, error) {
-	query := sqlutil.Rebind(m.conn.Info().Dialect, m.getDirtyRevisionSQL())
-	args := []any{migrationStateApplied}
-	if m.revisionTableFormat.isAtlas() {
-		args = nil
-	}
-	revision, err := m.scanRevisionRow(m.conn.QueryRowContext(ctx, query, args...))
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	revision.Dirty = true
-	return &revision, nil
+	var revision *MigrationRevision
+	err := m.withMigrationMetadataSession(ctx, func(scoped *Migrator) error {
+		query := sqlutil.Rebind(scoped.conn.Info().Dialect, scoped.getDirtyRevisionSQL())
+		args := []any{migrationStateApplied}
+		if scoped.revisionTableFormat.isAtlas() {
+			args = nil
+		}
+		scanned, err := scoped.scanRevisionRow(scoped.conn.QueryRowContext(ctx, query, args...))
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		scanned.Dirty = true
+		revision = &scanned
+		return nil
+	})
+	return revision, err
 }
 
 func (m *Migrator) getRevision(ctx context.Context, version int64) (*MigrationRevision, error) {
-	query := sqlutil.Rebind(m.conn.Info().Dialect, m.getRevisionSQL())
-	revision, err := m.scanRevisionRow(m.conn.QueryRowContext(ctx, query, m.revisionVersionArg(version)))
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	revision.Dirty = revision.State != migrationStateApplied
-	return &revision, nil
+	var revision *MigrationRevision
+	err := m.withMigrationMetadataSession(ctx, func(scoped *Migrator) error {
+		query := sqlutil.Rebind(scoped.conn.Info().Dialect, scoped.getRevisionSQL())
+		scanned, err := scoped.scanRevisionRow(
+			scoped.conn.QueryRowContext(ctx, query, scoped.revisionVersionArg(version)),
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		scanned.Dirty = scanned.State != migrationStateApplied
+		revision = &scanned
+		return nil
+	})
+	return revision, err
 }
 
 func (m *Migrator) scanRevisionRow(row rowScanner) (MigrationRevision, error) {

--- a/migration/migrator/rolled_back_progress_integration_test.go
+++ b/migration/migrator/rolled_back_progress_integration_test.go
@@ -259,6 +259,46 @@ func TestRolledBackProgress_MariaDBRejectsMSSQLInitialSQLMode(t *testing.T) {
 	runRejectsInitialSQLMode(t, dbURL, "mariadb_initial_mssql", "%27MSSQL%27", "MSSQL")
 }
 
+func TestRolledBackProgress_MySQLIsolatesTemporaryTablesBetweenAttempts(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runIsolatesTemporaryTablesBetweenAttempts(t, dbURL, "mysql_tmp")
+}
+
+func TestRolledBackProgress_MariaDBIsolatesTemporaryTablesBetweenAttempts(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runIsolatesTemporaryTablesBetweenAttempts(t, dbURL, "mariadb_tmp")
+}
+
+func TestRolledBackProgress_MySQLRejectsTemporaryMetadataShadow(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsTemporaryMetadataShadow(t, dbURL, "mysql_shadow")
+}
+
+func TestRolledBackProgress_MariaDBRejectsTemporaryMetadataShadow(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsTemporaryMetadataShadow(t, dbURL, "mariadb_shadow")
+}
+
+func TestRolledBackProgress_MySQLRejectsStaleTemporaryMetadataShadowBeforeDirtyCheck(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsStaleTemporaryMetadataShadowBeforeDirtyCheck(t, dbURL, "mysql_dirty_shadow")
+}
+
+func TestRolledBackProgress_MariaDBRejectsStaleTemporaryMetadataShadowBeforeDirtyCheck(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsStaleTemporaryMetadataShadowBeforeDirtyCheck(t, dbURL, "mariadb_dirty_shadow")
+}
+
+func TestRolledBackProgress_MySQLRejectsStaleTemporaryMetadataShadowBeforePlanning(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsStaleTemporaryMetadataShadowBeforePlanning(t, dbURL, "mysql_stale_shadow")
+}
+
+func TestRolledBackProgress_MariaDBRejectsStaleTemporaryMetadataShadowBeforePlanning(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsStaleTemporaryMetadataShadowBeforePlanning(t, dbURL, "mariadb_stale_shadow")
+}
+
 func TestRolledBackProgress_MySQLRejectsInheritedStorageEngine(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
 	runRejectsInheritedStorageEngine(t, dbURL, "mysql_create_like")
@@ -1959,6 +1999,292 @@ func runRejectsMSSQLSQLModeChange(t *testing.T, dbURL, prefix string) {
 	c.Assert(err, qt.ErrorMatches, `.*migration 1 cannot run tx-mode file statement 1 because changing sql_mode can make the MySQL-family server disagree with Ptah's prevalidated statement boundaries; configure a stable session mode before migration or use tx-mode none`)
 	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
 	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+func runIsolatesTemporaryTablesBetweenAttempts(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer issue887CloseConnection(t, conn)
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY) ENGINE=InnoDB",
+		names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	failingMigration := migrator.CreateMigrationFromSQL(
+		1,
+		"fail after writing a temporary table",
+		fmt.Sprintf(
+			"SET SESSION default_tmp_storage_engine = MyISAM; "+
+				"CREATE TEMPORARY TABLE %s (id INTEGER PRIMARY KEY); "+
+				"INSERT INTO %s VALUES (1); "+
+				"INSERT INTO %s SELECT id FROM %s; "+
+				"INSERT INTO %s VALUES (1)",
+			names.createdTable,
+			names.createdTable,
+			names.ledgerTable,
+			names.createdTable,
+			names.createdTable,
+		),
+		fmt.Sprintf("DELETE FROM %s", names.ledgerTable),
+	)
+	err = issue887Migrator(conn, names, failingMigration).MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `(?s).*Duplicate entry '1'.*`)
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(1))
+	c.Assert(issue887AppliedCount(t, conn, names), qt.Equals, int64(0))
+
+	retryMigration := migrator.CreateMigrationFromSQL(
+		1,
+		"retry on a fresh session",
+		fmt.Sprintf(
+			"SET SESSION default_tmp_storage_engine = MyISAM; "+
+				"CREATE TEMPORARY TABLE %s (id INTEGER PRIMARY KEY); "+
+				"INSERT INTO %s VALUES (1); "+
+				"INSERT INTO %s SELECT id FROM %s",
+			names.createdTable,
+			names.createdTable,
+			names.ledgerTable,
+			names.createdTable,
+		),
+		fmt.Sprintf("DELETE FROM %s", names.ledgerTable),
+	)
+	err = issue887Migrator(conn, names, retryMigration).MigrateUpWithOptions(
+		ctx,
+		migrator.MigrateUpOptions{AllowDirty: true},
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(1))
+}
+
+func runRejectsTemporaryMetadataShadow(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer issue887CloseConnection(t, conn)
+
+	runRejectsTemporaryMetadataShadowCase(
+		t,
+		conn,
+		issue887Names(prefix+"_native"),
+		migrator.RevisionTableFormatPtah,
+		issue887NativeMetadataShadowSQL,
+	)
+	runRejectsTemporaryMetadataShadowCase(
+		t,
+		conn,
+		issue887Names(prefix+"_atlas"),
+		migrator.RevisionTableFormatAtlas,
+		issue887AtlasMetadataShadowSQL,
+	)
+}
+
+func runRejectsTemporaryMetadataShadowCase(
+	t *testing.T,
+	conn *dbschema.DatabaseConnection,
+	names issue887TestNames,
+	format migrator.RevisionTableFormat,
+	shadowSQL func(string, issue887TestNames) string,
+) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	migration := migrator.CreateMigrationFromSQL(
+		1,
+		"attempt to shadow migration metadata",
+		shadowSQL(conn.Info().Schema, names),
+		fmt.Sprintf("DROP TABLE %s", names.createdTable),
+	)
+	err := issue887MigratorWithFormat(conn, names, format, migration).MigrateUp(ctx)
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`.*migration 1 cannot run tx-mode file statement 1 because it references Ptah's migration metadata table .*which is reserved for transaction-witness bookkeeping; choose another relation name`,
+	)
+	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+func runRejectsStaleTemporaryMetadataShadowBeforeDirtyCheck(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer issue887CloseConnection(t, conn)
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	migration := migrator.CreateMigrationFromSQL(
+		1,
+		"would read fake dirty metadata",
+		fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY) ENGINE=InnoDB", names.createdTable),
+		fmt.Sprintf("DROP TABLE %s", names.createdTable),
+	)
+	mig := issue887MigratorWithFormat(conn, names, migrator.RevisionTableFormatPtah, migration).WithoutMigrationLock()
+	c.Assert(mig.Initialize(ctx), qt.IsNil)
+
+	err = conn.WithSession(ctx, func(scoped *dbschema.DatabaseConnection) error {
+		if _, execErr := scoped.ExecContext(ctx, issue887NativeTemporaryMetadataShadowTableSQL(names)); execErr != nil {
+			return execErr
+		}
+		if _, execErr := scoped.ExecContext(ctx, issue887NativeTemporaryDirtyMetadataShadowInsertSQL(names)); execErr != nil {
+			return execErr
+		}
+		return issue887MigratorWithFormat(
+			scoped,
+			names,
+			migrator.RevisionTableFormatPtah,
+			migration,
+		).WithoutMigrationLock().MigrateUp(ctx)
+	})
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`.*pinned MySQL-family session contains temporary table .* that shadows Ptah's migration metadata; retry on a clean session.*`,
+	)
+	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+func issue887NativeMetadataShadowSQL(_ string, names issue887TestNames) string {
+	return fmt.Sprintf(`CREATE TEMPORARY TABLE %s (
+version BIGINT PRIMARY KEY,
+description TEXT NOT NULL,
+applied_at TIMESTAMP NOT NULL,
+state VARCHAR(32) NOT NULL,
+applied INTEGER NOT NULL,
+total INTEGER NOT NULL,
+error TEXT NULL,
+error_stmt TEXT NULL,
+execution_time_ms BIGINT NOT NULL,
+checksum VARCHAR(64) NOT NULL
+) ENGINE=InnoDB;
+INSERT INTO %s VALUES (1, 'shadow', CURRENT_TIMESTAMP, 'pending', 0, 3, NULL, NULL, 0, '');
+CREATE TABLE %s (id INTEGER PRIMARY KEY) ENGINE=InnoDB`,
+		names.revisionsTable,
+		names.revisionsTable,
+		names.createdTable,
+	)
+}
+
+func issue887AtlasMetadataShadowSQL(schema string, names issue887TestNames) string {
+	qualifiedMetadata := schema + "." + names.revisionsTable
+	return fmt.Sprintf(`CREATE TEMPORARY TABLE %s (
+version VARCHAR(255) PRIMARY KEY,
+description TEXT NOT NULL,
+type BIGINT NOT NULL,
+applied BIGINT NOT NULL,
+total BIGINT NOT NULL,
+executed_at TIMESTAMP NOT NULL,
+execution_time BIGINT NOT NULL,
+error TEXT NULL,
+error_stmt TEXT NULL,
+hash VARCHAR(255) NOT NULL,
+partial_hashes JSON NULL,
+operator_version VARCHAR(255) NOT NULL
+) ENGINE=InnoDB;
+INSERT INTO %s VALUES ('1', 'shadow', 2, 0, 3, CURRENT_TIMESTAMP, 0, NULL, NULL, '', JSON_ARRAY(), 'ptah');
+CREATE TABLE %s (id INTEGER PRIMARY KEY) ENGINE=InnoDB`,
+		qualifiedMetadata,
+		qualifiedMetadata,
+		names.createdTable,
+	)
+}
+
+func runRejectsStaleTemporaryMetadataShadowBeforePlanning(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer issue887CloseConnection(t, conn)
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	migration := migrator.CreateMigrationFromSQL(
+		1,
+		"would create target after fake applied metadata",
+		fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY) ENGINE=InnoDB", names.createdTable),
+		fmt.Sprintf("DROP TABLE %s", names.createdTable),
+	)
+	mig := issue887MigratorWithFormat(conn, names, migrator.RevisionTableFormatPtah, migration).WithoutMigrationLock()
+	c.Assert(mig.Initialize(ctx), qt.IsNil)
+
+	err = conn.WithSession(ctx, func(scoped *dbschema.DatabaseConnection) error {
+		if _, execErr := scoped.ExecContext(ctx, issue887NativeTemporaryMetadataShadowTableSQL(names)); execErr != nil {
+			return execErr
+		}
+		if _, execErr := scoped.ExecContext(ctx, issue887NativeTemporaryAppliedMetadataShadowInsertSQL(names)); execErr != nil {
+			return execErr
+		}
+		return issue887MigratorWithFormat(
+			scoped,
+			names,
+			migrator.RevisionTableFormatPtah,
+			migration,
+		).WithoutMigrationLock().MigrateUp(ctx)
+	})
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`.*pinned MySQL-family session contains temporary table .* that shadows Ptah's migration metadata; retry on a clean session.*`,
+	)
+	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+func issue887NativeTemporaryMetadataShadowTableSQL(names issue887TestNames) string {
+	return fmt.Sprintf(`CREATE TEMPORARY TABLE %s (
+version BIGINT PRIMARY KEY,
+description TEXT NOT NULL,
+applied_at TIMESTAMP NOT NULL,
+state VARCHAR(32) NOT NULL,
+applied INTEGER NOT NULL,
+total INTEGER NOT NULL,
+error TEXT NULL,
+error_stmt TEXT NULL,
+execution_time_ms BIGINT NOT NULL,
+checksum VARCHAR(64) NOT NULL
+) ENGINE=InnoDB`,
+		names.revisionsTable,
+	)
+}
+
+func issue887NativeTemporaryAppliedMetadataShadowInsertSQL(names issue887TestNames) string {
+	return fmt.Sprintf(
+		"INSERT INTO %s VALUES (1, 'stale shadow', CURRENT_TIMESTAMP, 'applied', 1, 1, NULL, NULL, 0, '')",
+		names.revisionsTable,
+	)
+}
+
+func issue887NativeTemporaryDirtyMetadataShadowInsertSQL(names issue887TestNames) string {
+	return fmt.Sprintf(
+		"INSERT INTO %s VALUES (1, 'dirty shadow', CURRENT_TIMESTAMP, 'pending', 0, 1, 'fake', '', 0, '')",
+		names.revisionsTable,
+	)
 }
 
 func runRejectsInheritedStorageEngine(t *testing.T, dbURL, prefix string) {


### PR DESCRIPTION
## Summary

- pin MySQL/MariaDB revision reads and dirty-state checks to a checked metadata session
- reject same-named temporary metadata shadows before dirty checks, revision listing, execution, and `tx-mode none` bookkeeping
- keep `tx-mode none` body SQL on a separate discarded body session so temporary body objects cannot shadow revision metadata
- document the metadata-table reservation and the MySQL/MariaDB session split

## Why

#1367 merged the main MySQL-family transaction witness hardening. This follow-up closes a narrower gap found during self-review: a pinned body session could carry temporary state whose name shadows the configured revision table. MySQL and MariaDB resolve same-named temporary tables before permanent tables even for schema-qualified references, so revision metadata needs its own checked session boundary.

The patch keeps temporary tables usable in migration bodies. It only refuses temporary objects that would redirect Ptah's own metadata reads or writes.

## Verification

- `gopls check migration/migrator/no_transaction_session.go migration/migrator/migrator.go migration/migrator/revisions.go migration/migrator/rolled_back_progress_integration_test.go dbschema/connection.go dbschema/connection_internal_test.go`
- `golangci-lint run ./...`
- `go vet ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `scripts/check-public-api.sh`
- `scripts/check-public-api-snapshot.sh`
- `scripts/check-public-api-released.sh`
- `node docs/site/scripts/check-style.mjs`
- `npm run check:links`
- `npm run check:responsive`
- `sh scripts/require-tests-ran.sh --package ./migration/migrator --pattern '^TestRolledBackProgress_' --declared-in migration/migrator/rolled_back_progress_integration_test.go --timeout 5m`
  - `listed=57 ran=57 passed=57 failed=0 skipped=0`
- `go test ./dbschema ./migration/migrator -count=1`
- `go test -race ./migration/migrator -count=1`
- `go test ./...` with live DB env unset

Related: #887, #1367
