### PR TITLE
Harden Go annotation cleanup validation

### DIFF
--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -294,10 +294,11 @@ per-migration timeout, and pre-migration check in the selected batch. Under
 global `none`, an explicit file mode restores a per-file transaction and may
 use migration timeouts.
 
-The Atlas header must be in the initial line-comment block and followed by a
-blank line. Unknown, duplicate, and file-level `all` values fail before the
-affected migration body or revision row changes. Validation applies only to
-the migrations selected after amount and baseline processing.
+The Atlas header must be in the initial line-comment block. A blank line after
+the header is accepted but not required. Unknown, duplicate, and file-level
+`all` values fail before the affected migration body or revision row changes.
+Validation applies only to the migrations selected after amount and baseline
+processing.
 
 When an `atlas.hcl` `migration` block is present, Ptah also defaults
 `revision-format` to `atlas`, so migration commands use

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -525,11 +525,10 @@ explicit `--lock-name` prints a note on stderr naming the lock that was not
 acquired.
 
 Atlas migration files may override global `file` or `none` with a leading
-header followed by a blank line:
+header. A blank line after the header is accepted but not required:
 
 ```sql
 -- atlas:txmode file
-
 ALTER TABLE users ADD COLUMN email TEXT;
 ```
 

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -60,9 +60,9 @@ A leading `-- atlas:txmode file` or `-- atlas:txmode none` header overrides
 global `file` or `none` for that migration. File-level `all`, unknown values,
 duplicates, and explicit file modes under global `all` fail before the affected
 body or revision row changes. The directive belongs to the initial line-comment
-header and requires a following blank line. Txtar `migration.sql` and
-`down.sql` sections carry independent modes; a mode before the
-`-- atlas:txtar` marker is rejected as an unsafe archive classification.
+header; a blank line after the header is accepted but not required. Txtar
+`migration.sql` and `down.sql` sections carry independent modes; a mode before
+the `-- atlas:txtar` marker is rejected as an unsafe archive classification.
 
 Directories in an external tool's format are gated on the `atlas.sum` the source
 directory carries, verified before the source layout is parsed and before the

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -175,8 +175,8 @@ people and pipelines share a directory:
 - **Transaction mode** (`--tx-mode`): `file` (default) wraps each migration
   in its own transaction; `all` runs the selected batch in one; `none`
   disables wrapping. A migration may select `file` or `none` with a leading
-  `-- atlas:txmode <mode>` header followed by a blank line. Explicit file modes
-  conflict with global `all`.
+  `-- atlas:txmode <mode>` header. A blank line after that header is accepted
+  but not required. Explicit file modes conflict with global `all`.
 - **Batch limit** (`--limit`): apply only the first N pending migrations —
   useful for staged rollouts and verifying one step at a time. `--allow-dirty`
   is the explicit recovery escape hatch that proceeds past a dirty revision

--- a/internal/annotationmeta/meta_test.go
+++ b/internal/annotationmeta/meta_test.go
@@ -155,10 +155,19 @@ type User struct {
 	placements := annotationmeta.CommentPlacements(file)
 
 	c.Assert(placements[comments[0]], qt.DeepEquals, annotationmeta.Placement{Scope: annotationmeta.ScopeFile})
-	c.Assert(placements[comments[1]], qt.DeepEquals, annotationmeta.Placement{Scope: annotationmeta.ScopeStruct})
+	c.Assert(placements[comments[1]], qt.DeepEquals, annotationmeta.Placement{
+		Scope:      annotationmeta.ScopeStruct,
+		StructName: "User",
+	})
 	c.Assert(placements[comments[2]], qt.DeepEquals, annotationmeta.Placement{
 		Scope:      annotationmeta.ScopeField,
+		StructName: "User",
+		FieldNames: []string{"ID"},
 		NamedField: true,
 	})
-	c.Assert(placements[comments[3]], qt.DeepEquals, annotationmeta.Placement{Scope: annotationmeta.ScopeField})
+	c.Assert(placements[comments[3]], qt.DeepEquals, annotationmeta.Placement{
+		Scope:            annotationmeta.ScopeField,
+		StructName:       "User",
+		EmbeddedTypeName: "Audit",
+	})
 }

--- a/internal/annotationmeta/scope.go
+++ b/internal/annotationmeta/scope.go
@@ -4,8 +4,11 @@ import "go/ast"
 
 // Placement describes the Go AST attachment of an annotation comment.
 type Placement struct {
-	Scope      Scope
-	NamedField bool
+	Scope            Scope
+	StructName       string
+	FieldNames       []string
+	NamedField       bool
+	EmbeddedTypeName string
 }
 
 // CommentPlacements classifies every comment in file using the attachment
@@ -29,16 +32,52 @@ func CommentPlacements(file *ast.File) map[*ast.Comment]Placement {
 			if !ok {
 				continue
 			}
-			setCommentGroupPlacement(general.Doc, Placement{Scope: ScopeStruct}, placements)
+			structName := typeSpec.Name.Name
+			setCommentGroupPlacement(general.Doc, Placement{
+				Scope:      ScopeStruct,
+				StructName: structName,
+			}, placements)
 			for _, field := range structType.Fields.List {
 				setCommentGroupPlacement(field.Doc, Placement{
-					Scope:      ScopeField,
-					NamedField: len(field.Names) > 0,
+					Scope:            ScopeField,
+					StructName:       structName,
+					FieldNames:       fieldNames(field),
+					NamedField:       len(field.Names) > 0,
+					EmbeddedTypeName: embeddedFieldTypeName(field),
 				}, placements)
 			}
 		}
 	}
 	return placements
+}
+
+func fieldNames(field *ast.Field) []string {
+	if len(field.Names) == 0 {
+		return nil
+	}
+	names := make([]string, len(field.Names))
+	for i, name := range field.Names {
+		names[i] = name.Name
+	}
+	return names
+}
+
+func embeddedFieldTypeName(field *ast.Field) string {
+	if len(field.Names) > 0 {
+		return ""
+	}
+	return embeddedTypeName(field.Type)
+}
+
+func embeddedTypeName(expr ast.Expr) string {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		return typed.Name
+	case *ast.StarExpr:
+		return embeddedTypeName(typed.X)
+	default:
+		return ""
+	}
 }
 
 func setCommentGroupPlacement(

--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -48,11 +48,14 @@ type Annotation struct {
 }
 
 type removedLine struct {
-	number     int
-	annotation Annotation
-	scope      annotationmeta.Scope
-	namedField bool
-	values     map[string]string
+	number           int
+	annotation       Annotation
+	scope            annotationmeta.Scope
+	structName       string
+	fieldNames       []string
+	namedField       bool
+	embeddedTypeName string
+	values           map[string]string
 }
 
 type filePlan struct {
@@ -807,9 +810,12 @@ func annotationLineNumbers(path string, data []byte, lines [][]byte) (map[int]re
 					Directive:  directive.Name,
 					Attributes: attributes,
 				},
-				scope:      placements[comment].Scope,
-				namedField: placements[comment].NamedField,
-				values:     values,
+				scope:            placements[comment].Scope,
+				structName:       placements[comment].StructName,
+				fieldNames:       placements[comment].FieldNames,
+				namedField:       placements[comment].NamedField,
+				embeddedTypeName: placements[comment].EmbeddedTypeName,
+				values:           values,
 			}
 		}
 	}

--- a/internal/goannotationcleanup/validation.go
+++ b/internal/goannotationcleanup/validation.go
@@ -9,20 +9,21 @@ import (
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/internal/annotationmeta"
 	"go.5x5.cz/ptah/internal/annotationparse"
+	"go.5x5.cz/ptah/internal/tableref"
 )
 
 // ValidateParsed proves that every planned removal came from a supported source
 // attachment and that directives the parser can collapse or skip produced the
 // corresponding schema object. Callers must run this against the same captured
 // source view before destructive cleanup.
-func (p *Plan) ValidateParsed(database *goschema.Database) error {
+func (p *Plan) ValidateParsed(sourceDB, exportedDB *goschema.Database) error {
 	var validationErrors []error
 	for _, removal := range p.removals() {
 		if err := annotationAttachmentError(removal); err != nil {
 			validationErrors = append(validationErrors, err)
 			continue
 		}
-		if !annotationRepresented(removal, database) {
+		if !annotationRepresented(removal, sourceDB, exportedDB) {
 			validationErrors = append(validationErrors, fmt.Errorf(
 				"%w: %s:%d: //%s did not produce a schema object",
 				ErrUnexportedAnnotation,
@@ -86,33 +87,489 @@ func annotationScopeError(removal removedLine, directive annotationmeta.Directiv
 	)
 }
 
-func annotationRepresented(removal removedLine, database *goschema.Database) bool {
-	if database == nil {
+type representationMatcher func(removedLine, *goschema.Database, *goschema.Database) bool
+
+var representationMatchers = map[string]representationMatcher{
+	"ptah:schema:field":      fieldRepresented,
+	"ptah:embedded":          embeddedRepresented,
+	"ptah:schema:index":      indexRepresented,
+	"ptah:schema:table":      tableRepresented,
+	"ptah:schema:schema":     schemaRepresented,
+	"ptah:schema:constraint": constraintRepresented,
+	"ptah:schema:enum":       enumRepresented,
+	"ptah:schema:extension":  extensionRepresented,
+	"ptah:schema:function":   functionRepresented,
+	"ptah:schema:sequence":   sequenceRepresented,
+	"ptah:schema:domain":     domainRepresented,
+	"ptah:schema:composite":  compositeRepresented,
+	"ptah:schema:range":      rangeRepresented,
+	"ptah:schema:view":       viewRepresented,
+	"ptah:schema:matview":    materializedViewRepresented,
+	"ptah:schema:trigger":    triggerRepresented,
+	"ptah:schema:rls:policy": rlsPolicyDirectiveRepresented,
+	"ptah:schema:rls:enable": rlsEnableRepresented,
+	"ptah:schema:role":       roleRepresented,
+	"ptah:schema:grant":      grantRepresented,
+	"ptah:schema:data":       dataRepresented,
+}
+
+func annotationRepresented(removal removedLine, sourceDB, exportedDB *goschema.Database) bool {
+	if sourceDB == nil || exportedDB == nil {
 		return false
 	}
-	switch removal.annotation.Directive {
-	case "ptah:schema:enum":
-		return slices.ContainsFunc(database.Enums, func(enum goschema.Enum) bool {
-			return enum.Name == removal.values["name"] &&
-				slices.Equal(enum.Values, splitAnnotationList(removal.values["values"]))
-		})
-	case "ptah:schema:rls:policy":
-		return slices.ContainsFunc(database.RLSPolicies, func(policy goschema.RLSPolicy) bool {
-			return policy.Name == removal.values["name"] &&
-				policy.Table == removal.values["table"] &&
-				policy.PolicyFor == removal.values["for"] &&
-				policy.ToRoles == removal.values["to"] &&
-				policy.UsingExpression == removal.values["using"] &&
-				policy.WithCheckExpression == removal.values["with_check"] &&
-				policy.Comment == removal.values["comment"]
-		})
-	case "ptah:schema:rls:enable":
-		return slices.ContainsFunc(database.RLSEnabledTables, func(table goschema.RLSEnabledTable) bool {
-			return table.Table == removal.values["table"] && table.Comment == removal.values["comment"]
-		})
-	default:
-		return true
+	matcher, ok := representationMatchers[removal.annotation.Directive]
+	if !ok {
+		return false
 	}
+	return matcher(removal, sourceDB, exportedDB)
+}
+
+func schemaRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Schemas, func(schema goschema.Schema) bool {
+		return schema.Name == removal.values["name"]
+	})
+}
+
+func enumRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Enums, func(enum goschema.Enum) bool {
+		return enum.Name == removal.values["name"] &&
+			enum.Schema == removal.values["schema"] &&
+			slices.Equal(enum.Values, splitAnnotationList(removal.values["values"]))
+	})
+}
+
+func extensionRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Extensions, func(extension goschema.Extension) bool {
+		return extension.Name == removal.values["name"]
+	})
+}
+
+func functionRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Functions, func(function goschema.Function) bool {
+		return function.Name == removal.values["name"] && function.Body == removal.values["body"]
+	})
+}
+
+func sequenceRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Sequences, func(sequence goschema.Sequence) bool {
+		return sameSchemaObject(sequence.Schema, sequence.Name, removal.values["schema"], removal.values["name"])
+	})
+}
+
+func domainRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Domains, func(domain goschema.Domain) bool {
+		return sameSchemaObject(domain.Schema, domain.Name, removal.values["schema"], removal.values["name"]) &&
+			domain.BaseType == removal.values["type"]
+	})
+}
+
+func compositeRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.CompositeTypes, func(composite goschema.CompositeType) bool {
+		return sameSchemaObject(composite.Schema, composite.Name, removal.values["schema"], removal.values["name"])
+	})
+}
+
+func rangeRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Ranges, func(rangeType goschema.Range) bool {
+		return sameSchemaObject(rangeType.Schema, rangeType.Name, removal.values["schema"], removal.values["name"]) &&
+			rangeType.Subtype == removal.values["subtype"]
+	})
+}
+
+func viewRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Views, func(view goschema.View) bool {
+		return view.Name == removal.values["name"] && view.Body == removal.values["body"]
+	})
+}
+
+func materializedViewRepresented(
+	removal removedLine,
+	_ *goschema.Database,
+	exportedDB *goschema.Database,
+) bool {
+	return slices.ContainsFunc(exportedDB.MaterializedViews, func(view goschema.MaterializedView) bool {
+		return view.Name == removal.values["name"] && view.Body == removal.values["body"]
+	})
+}
+
+func triggerRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Triggers, func(trigger goschema.Trigger) bool {
+		return trigger.Name == removal.values["name"] &&
+			sameTableRef(trigger.Table, removal.values["table"])
+	})
+}
+
+func rlsPolicyDirectiveRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return rlsPolicyRepresented(removal, exportedDB)
+}
+
+func roleRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Roles, func(role goschema.Role) bool {
+		return role.Name == removal.values["name"]
+	})
+}
+
+func grantRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.Grants, func(grant goschema.Grant) bool {
+		return grant.Role == removal.values["role"] &&
+			slices.Equal(grant.Privileges, splitGrantPrivileges(removal.values)) &&
+			grant.OnTable == removal.values["on_table"] &&
+			grant.OnSchema == removal.values["on_schema"] &&
+			grant.OnSequence == removal.values["on_sequence"]
+	})
+}
+
+func dataRepresented(removal removedLine, _ *goschema.Database, exportedDB *goschema.Database) bool {
+	return slices.ContainsFunc(exportedDB.ManagedData, func(data goschema.ManagedData) bool {
+		return sameSchemaObject(data.Schema, data.Table, removal.values["schema"], removal.values["table"]) &&
+			slices.Equal(data.Keys, splitAnnotationList(removal.values["key"])) &&
+			data.File == removal.values["file"]
+	})
+}
+
+func tableRepresented(removal removedLine, sourceDB, exportedDB *goschema.Database) bool {
+	table, ok := sourceTableForStruct(sourceDB, removal.structName)
+	if !ok {
+		return false
+	}
+	_, ok = exportedTableForSource(exportedDB, table)
+	return ok
+}
+
+func fieldRepresented(removal removedLine, sourceDB, exportedDB *goschema.Database) bool {
+	fields := sourceFieldsForRemoval(sourceDB, removal)
+	if len(fields) == 0 {
+		return false
+	}
+	sourceTable, ok := sourceTableForStruct(sourceDB, removal.structName)
+	if ok {
+		exportedTable, ok := exportedTableForSource(exportedDB, sourceTable)
+		if ok && fieldsRepresentedInTable(exportedDB, exportedTable.StructName, fields) {
+			return true
+		}
+	}
+	return fieldsRepresentedThroughEmbeddedUse(removal, sourceDB, exportedDB, fields)
+}
+
+func embeddedRepresented(removal removedLine, sourceDB, exportedDB *goschema.Database) bool {
+	sourceTable, ok := sourceTableForStruct(sourceDB, removal.structName)
+	if !ok {
+		return false
+	}
+	exportedTable, ok := exportedTableForSource(exportedDB, sourceTable)
+	if !ok {
+		return false
+	}
+	if !sourceEmbeddedRepresented(sourceDB, removal) {
+		return false
+	}
+	generatedFields := sourceGeneratedEmbeddedFields(sourceDB, removal.structName)
+	if len(generatedFields) == 0 {
+		return false
+	}
+	for _, field := range generatedFields {
+		if !exportedFieldExists(exportedDB, exportedTable.StructName, field.Name) {
+			return false
+		}
+	}
+	return true
+}
+
+func indexRepresented(removal removedLine, sourceDB, exportedDB *goschema.Database) bool {
+	indexes := sourceIndexesForRemoval(sourceDB, removal)
+	if len(indexes) == 0 {
+		return false
+	}
+	for _, index := range indexes {
+		target := sourceIndexTarget(sourceDB, index)
+		if target == "" || !exportedIndexExists(exportedDB, target, index.Name) {
+			return false
+		}
+	}
+	return true
+}
+
+func constraintRepresented(removal removedLine, sourceDB, exportedDB *goschema.Database) bool {
+	constraints := sourceConstraintsForRemoval(sourceDB, removal)
+	if len(constraints) == 0 {
+		return false
+	}
+	for _, constraint := range constraints {
+		target := sourceConstraintTarget(sourceDB, constraint)
+		if target == "" || !exportedConstraintExists(exportedDB, target, constraint.Name, constraint.Type) {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldsRepresentedInTable(database *goschema.Database, structName string, fields []goschema.Field) bool {
+	for _, field := range fields {
+		if !exportedFieldExists(database, structName, field.Name) {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldsRepresentedThroughEmbeddedUse(
+	removal removedLine,
+	sourceDB, exportedDB *goschema.Database,
+	fields []goschema.Field,
+) bool {
+	for _, sourceField := range fields {
+		if !fieldRepresentedThroughEmbeddedUse(removal, sourceDB, exportedDB, sourceField) {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldRepresentedThroughEmbeddedUse(
+	removal removedLine,
+	sourceDB, exportedDB *goschema.Database,
+	sourceField goschema.Field,
+) bool {
+	for _, generated := range sourceDB.Fields {
+		if !generated.GeneratedFromEmbedded || generated.FieldName != sourceField.FieldName {
+			continue
+		}
+		if !inlineEmbeddedPathContains(sourceDB, generated.StructName, removal.structName) {
+			continue
+		}
+		sourceTable, ok := sourceTableForStruct(sourceDB, generated.StructName)
+		if !ok {
+			continue
+		}
+		exportedTable, ok := exportedTableForSource(exportedDB, sourceTable)
+		if ok && exportedFieldExists(exportedDB, exportedTable.StructName, generated.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func inlineEmbeddedPathContains(database *goschema.Database, ownerStruct, embeddedStruct string) bool {
+	return inlineEmbeddedPathContainsSeen(database, ownerStruct, embeddedStruct, make(map[string]struct{}))
+}
+
+func inlineEmbeddedPathContainsSeen(
+	database *goschema.Database,
+	ownerStruct, embeddedStruct string,
+	seen map[string]struct{},
+) bool {
+	if _, ok := seen[ownerStruct]; ok {
+		return false
+	}
+	seen[ownerStruct] = struct{}{}
+	for _, embedded := range database.EmbeddedFields {
+		if embedded.StructName != ownerStruct || strings.EqualFold(embedded.Mode, "skip") {
+			continue
+		}
+		if !embeddedModeMaterializesFields(embedded.Mode) {
+			continue
+		}
+		if embedded.EmbeddedTypeName == embeddedStruct {
+			return true
+		}
+		if inlineEmbeddedPathContainsSeen(database, embedded.EmbeddedTypeName, embeddedStruct, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func embeddedModeMaterializesFields(mode string) bool {
+	return mode == "" || strings.EqualFold(mode, "inline")
+}
+
+func rlsPolicyRepresented(removal removedLine, database *goschema.Database) bool {
+	return slices.ContainsFunc(database.RLSPolicies, func(policy goschema.RLSPolicy) bool {
+		return policy.Name == removal.values["name"] &&
+			sameTableRef(policy.Table, removal.values["table"]) &&
+			policy.PolicyFor == canonicalRLSPolicyFor(removal.values["for"]) &&
+			policy.ToRoles == removal.values["to"] &&
+			policy.UsingExpression == removal.values["using"] &&
+			policy.WithCheckExpression == removal.values["with_check"] &&
+			policy.Comment == removal.values["comment"]
+	})
+}
+
+func canonicalRLSPolicyFor(value string) string {
+	if value == "" {
+		return "ALL"
+	}
+	return strings.ToUpper(value)
+}
+
+func rlsEnableRepresented(removal removedLine, sourceDB, exportedDB *goschema.Database) bool {
+	tables := sourceRLSEnabledTablesForRemoval(sourceDB, removal)
+	if len(tables) == 0 {
+		return false
+	}
+	for _, table := range tables {
+		if !exportedRLSEnabledTableExists(exportedDB, table) {
+			return false
+		}
+	}
+	return true
+}
+
+func sourceRLSEnabledTablesForRemoval(database *goschema.Database, removal removedLine) []goschema.RLSEnabledTable {
+	var tables []goschema.RLSEnabledTable
+	for _, table := range database.RLSEnabledTables {
+		if !sameTableRef(table.Table, removal.values["table"]) {
+			continue
+		}
+		tables = append(tables, table)
+	}
+	return tables
+}
+
+func exportedRLSEnabledTableExists(database *goschema.Database, source goschema.RLSEnabledTable) bool {
+	return slices.ContainsFunc(database.RLSEnabledTables, func(table goschema.RLSEnabledTable) bool {
+		return sameTableRef(table.Table, source.Table) && table.Comment == source.Comment
+	})
+}
+
+func sourceTableForStruct(database *goschema.Database, structName string) (goschema.Table, bool) {
+	return findFunc(database.Tables, func(table goschema.Table) bool {
+		return table.StructName == structName
+	})
+}
+
+func exportedTableForSource(database *goschema.Database, source goschema.Table) (goschema.Table, bool) {
+	return findFunc(database.Tables, func(table goschema.Table) bool {
+		return sameTableRef(table.QualifiedName(), source.QualifiedName())
+	})
+}
+
+func sourceFieldsForRemoval(database *goschema.Database, removal removedLine) []goschema.Field {
+	var fields []goschema.Field
+	for _, fieldName := range removal.fieldNames {
+		for _, field := range database.Fields {
+			if field.StructName == removal.structName && field.FieldName == fieldName {
+				fields = append(fields, field)
+			}
+		}
+	}
+	return fields
+}
+
+func sourceGeneratedEmbeddedFields(database *goschema.Database, structName string) []goschema.Field {
+	var fields []goschema.Field
+	for _, field := range database.Fields {
+		if field.StructName == structName && field.GeneratedFromEmbedded {
+			fields = append(fields, field)
+		}
+	}
+	return fields
+}
+
+func sourceEmbeddedRepresented(database *goschema.Database, removal removedLine) bool {
+	return slices.ContainsFunc(database.EmbeddedFields, func(embedded goschema.EmbeddedField) bool {
+		return embedded.StructName == removal.structName &&
+			embedded.EmbeddedTypeName == removal.embeddedTypeName &&
+			!strings.EqualFold(embedded.Mode, "skip")
+	})
+}
+
+func exportedFieldExists(database *goschema.Database, structName, name string) bool {
+	return slices.ContainsFunc(database.Fields, func(field goschema.Field) bool {
+		return field.StructName == structName && field.Name == name
+	})
+}
+
+func sourceIndexesForRemoval(database *goschema.Database, removal removedLine) []goschema.Index {
+	var indexes []goschema.Index
+	for _, index := range database.Indexes {
+		if index.StructName == removal.structName && index.Name == removal.values["name"] {
+			indexes = append(indexes, index)
+		}
+	}
+	return indexes
+}
+
+func sourceIndexTarget(database *goschema.Database, index goschema.Index) string {
+	if strings.TrimSpace(index.TableName) != "" {
+		return canonicalTableRef(index.TableName)
+	}
+	table, ok := sourceTableForStruct(database, index.StructName)
+	if !ok {
+		return ""
+	}
+	return table.QualifiedName()
+}
+
+func exportedIndexExists(database *goschema.Database, tableName, name string) bool {
+	return slices.ContainsFunc(database.Indexes, func(index goschema.Index) bool {
+		return index.Name == name && sameTableRef(index.TableName, tableName)
+	})
+}
+
+func sourceConstraintsForRemoval(database *goschema.Database, removal removedLine) []goschema.Constraint {
+	var constraints []goschema.Constraint
+	for _, constraint := range database.Constraints {
+		if constraint.StructName == removal.structName &&
+			constraint.Name == removal.values["name"] &&
+			constraint.Type == strings.ToUpper(removal.values["type"]) {
+			constraints = append(constraints, constraint)
+		}
+	}
+	return constraints
+}
+
+func sourceConstraintTarget(database *goschema.Database, constraint goschema.Constraint) string {
+	if strings.TrimSpace(constraint.Table) != "" {
+		return canonicalTableRef(constraint.Table)
+	}
+	table, ok := sourceTableForStruct(database, constraint.StructName)
+	if !ok {
+		return ""
+	}
+	return table.QualifiedName()
+}
+
+func exportedConstraintExists(database *goschema.Database, tableName, name, constraintType string) bool {
+	return slices.ContainsFunc(database.Constraints, func(constraint goschema.Constraint) bool {
+		return constraint.Name == name &&
+			constraint.Type == constraintType &&
+			sameTableRef(constraint.Table, tableName)
+	})
+}
+
+func sameSchemaObject(actualSchema, actualName, expectedSchema, expectedName string) bool {
+	return actualSchema == expectedSchema && actualName == expectedName
+}
+
+func sameTableRef(left, right string) bool {
+	return canonicalTableRef(left) == canonicalTableRef(right)
+}
+
+func canonicalTableRef(value string) string {
+	value = strings.TrimSpace(value)
+	ref, ok := tableref.Parse(value)
+	if !ok {
+		return value
+	}
+	return goschema.QualifyTableName(ref.Schema, ref.Name)
+}
+
+func splitGrantPrivileges(values map[string]string) []string {
+	if privileges := splitAnnotationList(values["privilege"]); len(privileges) > 0 {
+		return privileges
+	}
+	return splitAnnotationList(values["privileges"])
+}
+
+func findFunc[S ~[]E, E any](values S, predicate func(E) bool) (E, bool) {
+	for _, value := range values {
+		if predicate(value) {
+			return value, true
+		}
+	}
+	var zero E
+	return zero, false
 }
 
 func splitAnnotationList(value string) []string {

--- a/internal/goannotationexport/export.go
+++ b/internal/goannotationexport/export.go
@@ -219,11 +219,6 @@ func renderExport(plan exportPlan) (renderedExport, error) {
 	if err != nil {
 		return renderedExport{}, fmt.Errorf("parse Go annotations: %w", err)
 	}
-	if plan.options.Cleanup {
-		if err := plan.cleanup.ValidateParsed(db); err != nil {
-			return renderedExport{}, fmt.Errorf("validate Go annotation cleanup coverage: %w", err)
-		}
-	}
 	if !databaseHasSchemaObjects(db) {
 		return renderedExport{}, ErrNoAnnotations
 	}
@@ -265,6 +260,11 @@ func renderExport(plan exportPlan) (renderedExport, error) {
 	}
 	if !databaseHasSchemaObjects(exportedDB) {
 		return renderedExport{}, ErrNoExportableSchema
+	}
+	if plan.options.Cleanup {
+		if err := plan.cleanup.ValidateParsed(db, exportedDB); err != nil {
+			return renderedExport{}, fmt.Errorf("validate Go annotation cleanup coverage: %w", err)
+		}
 	}
 	return renderedExport{
 		database:    db,

--- a/internal/goannotationexport/export_test.go
+++ b/internal/goannotationexport/export_test.go
@@ -401,6 +401,185 @@ const placeholder = 0
 	}
 }
 
+func TestExport_FailurePath_CleanupRejectsTableBoundAnnotationsWithoutExportedTable(t *testing.T) {
+	c := qt.New(t)
+	outputData := []byte("previous useful schema\n")
+	tests := []struct {
+		name          string
+		helperSource  string
+		wantDirective string
+	}{
+		{
+			name: "field",
+			helperSource: `
+type Helper struct {
+	//ptah:schema:field name="ghost_id" type="BIGINT"
+	GhostID int64
+}
+`,
+			wantDirective: "ptah:schema:field",
+		},
+		{
+			name: "embedded",
+			helperSource: `
+type Audit struct {
+	//ptah:schema:field name="created_at" type="TIMESTAMP"
+	CreatedAt string
+}
+
+type Helper struct {
+	//ptah:embedded mode="inline"
+	Audit
+}
+`,
+			wantDirective: "ptah:embedded",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			source := filepath.Join(root, "model.go")
+			output := filepath.Join(root, "schema.hcl")
+			sourceData := []byte(`package models
+
+//ptah:schema:table name="users"
+type User struct{}
+` + test.helperSource)
+			c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(output, outputData, 0o600), qt.IsNil)
+
+			result, err := goannotationexport.Export(goannotationexport.Options{
+				RootDir:    root,
+				OutputPath: output,
+				Cleanup:    true,
+			})
+
+			c.Assert(err, qt.ErrorIs, goannotationcleanup.ErrUnexportedAnnotation)
+			c.Assert(err.Error(), qt.Contains, test.wantDirective)
+			c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+			assertFileBytes(c, source, sourceData)
+			assertFileBytes(c, output, outputData)
+		})
+	}
+}
+
+func TestExport_FailurePath_CleanupRejectsLossyTableBoundAnnotationsWithoutExportedTable(t *testing.T) {
+	c := qt.New(t)
+	outputData := []byte("previous useful schema\n")
+	tests := []struct {
+		name       string
+		helper     string
+		wantDetail string
+	}{
+		{
+			name: "index",
+			helper: `
+//ptah:schema:index name="idx_helper_ghost" fields="ghost_id"
+type Helper struct{}
+`,
+			wantDetail: "index cannot be rendered because the target table is absent",
+		},
+		{
+			name: "constraint",
+			helper: `
+//ptah:schema:constraint name="helper_ghost_check" type="CHECK" check="ghost_id > 0"
+type Helper struct{}
+`,
+			wantDetail: "constraint cannot be rendered because the target table is absent",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			source := filepath.Join(root, "model.go")
+			output := filepath.Join(root, "schema.hcl")
+			sourceData := []byte(`package models
+
+//ptah:schema:table name="users"
+type User struct{}
+` + test.helper)
+			c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(output, outputData, 0o600), qt.IsNil)
+
+			result, err := goannotationexport.Export(goannotationexport.Options{
+				RootDir:    root,
+				OutputPath: output,
+				Cleanup:    true,
+			})
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, "lossy HCL export")
+			c.Assert(err.Error(), qt.Contains, test.wantDetail)
+			c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+			assertFileBytes(c, source, sourceData)
+			assertFileBytes(c, output, outputData)
+		})
+	}
+}
+
+func TestExport_HappyPath_CleanupKeepsRepresentedTableBoundAnnotations(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name        string
+		annotation  string
+		wantHCL     string
+		wantRemoved int
+	}{
+		{
+			name: "index",
+			annotation: `
+	//ptah:schema:index name="idx_users_id" fields="id"
+	_ int
+`,
+			wantHCL:     `index "idx_users_id"`,
+			wantRemoved: 3,
+		},
+		{
+			name: "constraint",
+			annotation: `
+	//ptah:schema:constraint name="users_id_check" type="CHECK" check="id > 0"
+	_ int
+`,
+			wantHCL:     `check "users_id_check"`,
+			wantRemoved: 3,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			source := filepath.Join(root, "model.go")
+			output := filepath.Join(root, "schema.hcl")
+			sourceData := []byte(`package models
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="BIGINT"
+	ID int64
+` + test.annotation + `}
+`)
+			c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+
+			result, err := goannotationexport.Export(goannotationexport.Options{
+				RootDir:    root,
+				OutputPath: output,
+				Cleanup:    true,
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.RemovedLines, qt.Equals, test.wantRemoved)
+			after, err := os.ReadFile(source)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(after), qt.Not(qt.Contains), "ptah:schema")
+			outputData, err := os.ReadFile(output)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(outputData), qt.Contains, test.wantHCL)
+		})
+	}
+}
+
 func TestExport_FailurePath_CleanupRejectsFileScopedRLSWithoutExportedObject(t *testing.T) {
 	c := qt.New(t)
 	root := t.TempDir()

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -650,11 +650,11 @@ Atlas-compatible values:
   transaction may use migration timeouts. Failed non-transactional runs record
   statement-level dirty progress.
 
-Atlas file modes use a leading line-comment header followed by a blank line:
+Atlas file modes use a leading line-comment header. A blank line after the
+header is accepted but not required:
 
 ```sql
 -- atlas:txmode file
-
 ALTER TABLE users ADD COLUMN email TEXT;
 ```
 


### PR DESCRIPTION
## Summary
- validate Go annotation cleanup against the HCL schema that survives render/parse round-trip, not just the parser source database
- retain AST placement metadata for struct names, field names, and embedded field types so cleanup can prove table-bound annotations are represented
- document that atlas:txmode headers do not require a blank line; a blank line remains accepted

## Self-review
- pass 1 found over-strict cleanup validation for field-only/no-export and escaped RLS defaults; fixed by preserving ErrNoExportableSchema and canonicalizing RLS policy defaults
- pass 2 found missing happy-path coverage for represented index/constraint cleanup; added explicit cleanup tests
- checked for stale docs that still required a blank line after atlas:txmode

## Verification
- env GOCACHE=/private/tmp/ptah-master-audit-gocache go test ./internal/annotationmeta ./internal/goannotationcleanup ./internal/goannotationexport ./cmd/schema -count=1
- env GOCACHE=/private/tmp/ptah-master-audit-gocache go test ./migration/migrator -run 'Test.*TxMode|TestNewFSMigrator_Loads.*NoTransaction|TestNewFSMigrator_InvalidNoTransactionDirective' -count=1
- node docs/site/scripts/check-style.mjs
- scripts/check-test-style.sh
- env GOCACHE=/private/tmp/ptah-master-audit-gocache go tool qtlint ./internal/annotationmeta ./internal/goannotationcleanup ./internal/goannotationexport ./cmd/schema ./migration/migrator
- env GOCACHE=/private/tmp/ptah-master-audit-gocache golangci-lint run ./internal/annotationmeta ./internal/goannotationcleanup ./internal/goannotationexport ./cmd/schema ./migration/migrator
- git diff --check