### PR TITLE
fix(dbschema): harden postgres-family reader coverage

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           docker run --detach --name ptah-cockroachdb \
             --publish 26257:26257 \
-            cockroachdb/cockroach:v26.2.4 \
+            cockroachdb/cockroach:v26.2.5 \
             start-single-node --insecure --advertise-addr=localhost:26257
 
           docker run --detach --name ptah-yugabytedb \
@@ -200,6 +200,18 @@ jobs:
             sleep 2
           done
           echo "OCI registry is ready!"
+
+      - name: Run distributed SQL reader coverage
+        env:
+          COCKROACHDB_TEST_DSN: "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
+          YUGABYTEDB_TEST_DSN: "postgresql://yugabyte@localhost:5433/yugabyte?sslmode=disable"
+          COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+          YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
+        run: |
+          sh scripts/require-tests-ran.sh --package ./integration/gonative --tags integration \
+            --pattern '^TestPostgresFamilyReader_' \
+            --declared-in integration/gonative/postgres_family_reader_integration_test.go \
+            --timeout 8m
       
       - name: Run executor integration tests with live databases
         env:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -362,9 +362,13 @@ value or wants to pin a specific server version in tests/CI.
   advisory locks, and concurrent indexes. Spanner accepts only `NO ACTION` and
   `CASCADE` for `ON DELETE`; any `ON UPDATE` action fails before rendering.
   CockroachDB and YugabyteDB integration coverage uses opt-in common-subset
-  scenarios that run against live OSS containers in CI. Spanner currently has
-  capability, planning, rendering, URL, and detection coverage only; there is
-  no OSS Spanner PostgreSQL-interface container in the integration suite.
+  scenarios that run against live OSS containers in CI. The distributed-SQL
+  reader gate also seeds table, index, view, materialized view, and sequence
+  objects and then exercises `ptah db read`, `ptah-compat schema inspect`, and
+  the shared pgx reader so one broken catalog query cannot be hidden by a later
+  broad integration step. Spanner currently has capability, planning,
+  rendering, URL, and detection coverage only; there is no OSS Spanner
+  PostgreSQL-interface container in the integration suite.
 - **Object kinds across the PostgreSQL family (#929).** One planner and one
   renderer serve PostgreSQL, CockroachDB, YugabyteDB, and Spanner, so the
   `views`, `materialized_views`, `functions`, and `triggers` keys are what lets

--- a/docs/site/src/content/docs/databases/support-matrix.md
+++ b/docs/site/src/content/docs/databases/support-matrix.md
@@ -136,8 +136,12 @@ matching preset automatically.
   rendering.
 
 CockroachDB and YugabyteDB run in integration coverage against live
-open-source containers; Spanner coverage is offline (capability, planning,
-rendering, URL, and detection), so review generated SQL before relying on it.
+open-source containers. Their reader coverage seeds a table, index, view,
+materialized view, and sequence, then verifies both `ptah db read` and
+`ptah-compat schema inspect`; CockroachDB still keeps standalone sequences out
+of Ptah's portable modeled subset. Spanner coverage is offline (capability,
+planning, rendering, URL, and detection), so review generated SQL before
+relying on it.
 PostgreSQL and YugabyteDB reject unsupported database-scoped publications,
 subscriptions, logical replication slots, event triggers, and non-extension
 foreign-data objects before dev-database cleanup. PostgreSQL additionally

--- a/integration/gonative/postgres_family_reader_integration_test.go
+++ b/integration/gonative/postgres_family_reader_integration_test.go
@@ -1,0 +1,312 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"bytes"
+	"database/sql"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/cmd/readdb"
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+)
+
+func TestPostgresFamilyReader_CockroachDBCatalogObjects(t *testing.T) {
+	c := qt.New(t)
+	dsn := requireReachableTestDSN(t, "COCKROACHDB_TEST_DSN", "pgx", "CockroachDB")
+	sourceURL := requireReaderURL(t, "COCKROACHDB_URL", "CockroachDB")
+	fixture := cockroachReaderFixture()
+
+	result := exercisePostgresFamilyReader(c, t, dsn, sourceURL, fixture)
+
+	assertPostgresFamilyReaderCatalog(c, result.schema, fixture)
+	c.Assert(postgresFamilyCatalogHasSequence(result.schema, fixture.catalogSchema, fixture.sequence), qt.IsFalse)
+}
+
+func TestPostgresFamilyReader_YugabyteDBCatalogObjects(t *testing.T) {
+	c := qt.New(t)
+	dsn := requireReachableTestDSN(t, "YUGABYTEDB_TEST_DSN", "pgx", "YugabyteDB")
+	sourceURL := requireReaderURL(t, "YUGABYTEDB_URL", "YugabyteDB")
+	fixture := yugabyteReaderFixture()
+
+	result := exercisePostgresFamilyReader(c, t, dsn, sourceURL, fixture)
+
+	assertPostgresFamilyReaderCatalog(c, result.schema, fixture)
+	c.Assert(postgresFamilyCatalogHasSequence(result.schema, fixture.catalogSchema, fixture.sequence), qt.IsTrue)
+}
+
+type postgresFamilyReaderFixture struct {
+	databaseName     string
+	schema           string
+	catalogSchema    string
+	table            string
+	index            string
+	view             string
+	materializedView string
+	sequence         string
+	cleanup          []string
+	setup            []string
+}
+
+type postgresFamilyReaderResult struct {
+	schema *dbschematypes.DBSchema
+}
+
+func cockroachReaderFixture() postgresFamilyReaderFixture {
+	const (
+		table            = "ptah_1381_crdb_users"
+		index            = "idx_ptah_1381_crdb_users_email"
+		view             = "ptah_1381_crdb_active_users"
+		materializedView = "ptah_1381_crdb_user_emails"
+		sequence         = "ptah_1381_crdb_ticket_seq"
+	)
+	return postgresFamilyReaderFixture{
+		databaseName:     "CockroachDB",
+		schema:           "public",
+		catalogSchema:    "",
+		table:            table,
+		index:            index,
+		view:             view,
+		materializedView: materializedView,
+		sequence:         sequence,
+		cleanup: []string{
+			`DROP MATERIALIZED VIEW IF EXISTS public.` + materializedView,
+			`DROP VIEW IF EXISTS public.` + view,
+			`DROP TABLE IF EXISTS public.` + table + ` CASCADE`,
+			`DROP SEQUENCE IF EXISTS public.` + sequence,
+		},
+		setup: []string{
+			`CREATE SEQUENCE public.` + sequence,
+			`CREATE TABLE public.` + table + ` (` +
+				`id INT8 PRIMARY KEY, ` +
+				`email STRING NOT NULL, ` +
+				`active BOOL NOT NULL DEFAULT true` +
+				`)`,
+			`CREATE INDEX ` + index + ` ON public.` + table + ` (email)`,
+			`CREATE VIEW public.` + view + ` AS ` +
+				`SELECT id, email FROM public.` + table + ` WHERE active`,
+			`CREATE MATERIALIZED VIEW public.` + materializedView + ` AS ` +
+				`SELECT id, email FROM public.` + table,
+		},
+	}
+}
+
+func yugabyteReaderFixture() postgresFamilyReaderFixture {
+	const (
+		schema           = "ptah_1381_yb"
+		table            = "users"
+		index            = "idx_ptah_1381_yb_users_email"
+		view             = "active_users"
+		materializedView = "user_emails"
+		sequence         = "ticket_seq"
+	)
+	return postgresFamilyReaderFixture{
+		databaseName:     "YugabyteDB",
+		schema:           schema,
+		catalogSchema:    schema,
+		table:            table,
+		index:            index,
+		view:             view,
+		materializedView: materializedView,
+		sequence:         sequence,
+		cleanup: []string{
+			`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`,
+		},
+		setup: []string{
+			`CREATE SCHEMA ` + schema,
+			`CREATE SEQUENCE ` + schema + `.` + sequence,
+			`CREATE TABLE ` + schema + `.` + table + ` (` +
+				`id BIGINT PRIMARY KEY, ` +
+				`email TEXT NOT NULL, ` +
+				`active BOOLEAN NOT NULL DEFAULT true` +
+				`)`,
+			`CREATE INDEX ` + index + ` ON ` + schema + `.` + table + ` (email)`,
+			`CREATE VIEW ` + schema + `.` + view + ` AS ` +
+				`SELECT id, email FROM ` + schema + `.` + table + ` WHERE active`,
+			`CREATE MATERIALIZED VIEW ` + schema + `.` + materializedView + ` AS ` +
+				`SELECT id, email FROM ` + schema + `.` + table,
+		},
+	}
+}
+
+func requireReaderURL(t *testing.T, envName, databaseName string) string {
+	t.Helper()
+
+	rawURL := os.Getenv(envName)
+	if rawURL == "" {
+		t.Skipf("Skipping %s reader tests: %s environment variable not set", databaseName, envName)
+	}
+	return rawURL
+}
+
+func exercisePostgresFamilyReader(
+	c *qt.C,
+	t *testing.T,
+	dsn string,
+	sourceURL string,
+	fixture postgresFamilyReaderFixture,
+) postgresFamilyReaderResult {
+	c.Helper()
+	t.Setenv("PTAH_ATLAS_INSPECT_ALL_BLOCKS", "1")
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	executePostgresFamilyReaderStatements(c, db, fixture.cleanup, "cleanup "+fixture.databaseName+" reader fixture")
+	c.Cleanup(func() {
+		executePostgresFamilyReaderStatements(c, db, fixture.cleanup, "cleanup "+fixture.databaseName+" reader fixture")
+	})
+	executePostgresFamilyReaderStatements(c, db, fixture.setup, "setup "+fixture.databaseName+" reader fixture")
+
+	live := readPostgresFamilyReaderSchema(c, t, sourceURL, fixture.schema)
+	nativeSQL := runPostgresFamilyReadDB(c, t, sourceURL, fixture)
+	compatHCL := runPostgresFamilyCompatInspect(c, t, sourceURL, fixture)
+	assertPostgresFamilyReaderOutput(c, nativeSQL, fixture)
+	assertPostgresFamilyReaderOutput(c, compatHCL, fixture)
+
+	return postgresFamilyReaderResult{schema: live}
+}
+
+func executePostgresFamilyReaderStatements(c *qt.C, db *sql.DB, statements []string, label string) {
+	c.Helper()
+	for _, statement := range statements {
+		_, err := db.Exec(statement)
+		c.Assert(err, qt.IsNil, qt.Commentf("%s: %s", label, statement))
+	}
+}
+
+func readPostgresFamilyReaderSchema(
+	c *qt.C,
+	t *testing.T,
+	sourceURL string,
+	schema string,
+) *dbschematypes.DBSchema {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(t.Context(), sourceURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	live, err := dbschema.ReadSchemaWithSchemas(conn, []string{schema})
+	c.Assert(err, qt.IsNil)
+	return live
+}
+
+func runPostgresFamilyReadDB(c *qt.C, t *testing.T, sourceURL string, fixture postgresFamilyReaderFixture) string {
+	c.Helper()
+	cmd := readdb.NewReadDBCommand()
+	cmd.SetContext(t.Context())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--db-url", sourceURL, "--schemas", fixture.schema})
+	c.Assert(cmd.Execute(), qt.IsNil, qt.Commentf("stderr: %s", stderr.String()))
+	c.Assert(stderr.String(), qt.Not(qt.Contains), "is not a table")
+	return stdout.String()
+}
+
+func runPostgresFamilyCompatInspect(
+	c *qt.C,
+	t *testing.T,
+	sourceURL string,
+	fixture postgresFamilyReaderFixture,
+) string {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("ptah-compat")
+	cmd.SetContext(t.Context())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"schema", "inspect",
+		"--url", sourceURL,
+		"--schema", fixture.schema,
+		"--format", "{{ hcl . }}",
+		"--exclude", "*[type=role]",
+	})
+	c.Assert(cmd.Execute(), qt.IsNil, qt.Commentf("stderr: %s", stderr.String()))
+	c.Assert(stderr.String(), qt.Not(qt.Contains), "is not a table")
+	return stdout.String()
+}
+
+func assertPostgresFamilyReaderCatalog(
+	c *qt.C,
+	schema *dbschematypes.DBSchema,
+	fixture postgresFamilyReaderFixture,
+) {
+	c.Helper()
+	c.Assert(postgresFamilyCatalogHasTable(schema, fixture.catalogSchema, fixture.table), qt.IsTrue)
+	c.Assert(postgresFamilyCatalogHasTable(schema, fixture.catalogSchema, fixture.view), qt.IsFalse)
+	c.Assert(postgresFamilyCatalogHasTable(schema, fixture.catalogSchema, fixture.materializedView), qt.IsFalse)
+	c.Assert(postgresFamilyCatalogHasView(schema, fixture.catalogSchema, fixture.view), qt.IsTrue)
+	c.Assert(postgresFamilyCatalogHasMaterializedView(schema, fixture.catalogSchema, fixture.materializedView), qt.IsTrue)
+	c.Assert(postgresFamilyCatalogHasIndex(schema, fixture.catalogSchema, fixture.table, fixture.index), qt.IsTrue)
+}
+
+func assertPostgresFamilyReaderOutput(c *qt.C, output string, fixture postgresFamilyReaderFixture) {
+	c.Helper()
+	c.Assert(output, qt.Contains, fixture.table)
+	c.Assert(output, qt.Contains, fixture.index)
+	c.Assert(output, qt.Contains, fixture.view)
+	c.Assert(output, qt.Contains, fixture.materializedView)
+}
+
+func postgresFamilyCatalogHasTable(schema *dbschematypes.DBSchema, schemaName, tableName string) bool {
+	for _, table := range schema.Tables {
+		if table.Schema == schemaName && table.Name == tableName {
+			return true
+		}
+	}
+	return false
+}
+
+func postgresFamilyCatalogHasView(schema *dbschematypes.DBSchema, schemaName, viewName string) bool {
+	for _, view := range schema.Views {
+		if view.Schema == schemaName && view.Name == viewName {
+			return true
+		}
+	}
+	return false
+}
+
+func postgresFamilyCatalogHasMaterializedView(
+	schema *dbschematypes.DBSchema,
+	schemaName string,
+	viewName string,
+) bool {
+	for _, view := range schema.MatViews {
+		if view.Schema == schemaName && view.Name == viewName {
+			return true
+		}
+	}
+	return false
+}
+
+func postgresFamilyCatalogHasIndex(
+	schema *dbschematypes.DBSchema,
+	schemaName string,
+	tableName string,
+	indexName string,
+) bool {
+	for _, index := range schema.Indexes {
+		if index.Schema == schemaName && index.TableName == tableName && index.Name == indexName {
+			return true
+		}
+	}
+	return false
+}
+
+func postgresFamilyCatalogHasSequence(schema *dbschematypes.DBSchema, schemaName, sequenceName string) bool {
+	for _, sequence := range schema.Sequences {
+		if sequence.Schema == schemaName && sequence.Name == sequenceName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -483,6 +483,9 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 				''
 			) AS owned_sequence_name
 		FROM information_schema.columns col
+		JOIN information_schema.tables tbl ON tbl.table_schema = col.table_schema
+			AND tbl.table_name = col.table_name
+			AND tbl.table_type = 'BASE TABLE'
 		JOIN pg_namespace n ON n.nspname = col.table_schema
 		JOIN pg_class cls ON cls.relname = col.table_name AND cls.relnamespace = n.oid
 		LEFT JOIN pg_attribute a ON a.attrelid = cls.oid

--- a/internal/dbschema/postgres/reader_columns_internal_test.go
+++ b/internal/dbschema/postgres/reader_columns_internal_test.go
@@ -88,6 +88,9 @@ func plainColumnCatalog() pgColumnCatalog {
 // distinguish the two fixtures above on a real server either, and gets the empty
 // string the CASE's ELSE branch returns.
 func serveColumnQuery(catalog pgColumnCatalog, query string) (dbtest.QueryResult, error) {
+	if !queryRestrictsColumnsToBaseTables(query) {
+		return dbtest.QueryResult{}, fmt.Errorf("column query reads non-table relations:\n%s", query)
+	}
 	asksAboutDomains, err := queryAsksAboutDomains(query)
 	if err != nil {
 		return dbtest.QueryResult{}, err
@@ -128,6 +131,17 @@ func serveColumnQuery(catalog pgColumnCatalog, query string) (dbtest.QueryResult
 			"",
 		}},
 	}, nil
+}
+
+func queryRestrictsColumnsToBaseTables(query string) bool {
+	body := stripSQLComments(query)
+	if !strings.Contains(body, "information_schema.tables") {
+		return false
+	}
+	if !strings.Contains(body, "tbl.table_type = 'BASE TABLE'") {
+		return false
+	}
+	return true
 }
 
 // queryAsksAboutDomains reports whether the formatted_type projection reads

--- a/internal/migrateclean/migrateclean.go
+++ b/internal/migrateclean/migrateclean.go
@@ -529,16 +529,16 @@ func realmProbe(dialect string) string {
 	if platform.NormalizeDialect(dialect) != platform.Postgres {
 		return ""
 	}
-	// Which schemas belong to the realm is [schemaselection.PostgresNonSystemSchemas],
-	// shared so this gate and `schema inspect` cannot disagree about it. What
-	// this probe adds is the tables, which the gate needs and inspection does
-	// not.
+	// Which schemas belong to the realm is
+	// [schemaselection.PostgresNonSystemSchemasPredicate], shared so this gate
+	// and `schema inspect` cannot disagree about it. What this probe adds is
+	// the tables, which the gate needs and inspection does not.
 	return `
 		SELECT n.nspname, COALESCE(c.relname, '')
 		FROM pg_namespace n
 		LEFT JOIN pg_class c
 		  ON c.relnamespace = n.oid
 		 AND c.relkind IN ('r', 'p')
-		WHERE ` + schemaselection.PostgresNonSystemSchemas + `
+		WHERE ` + schemaselection.PostgresNonSystemSchemasPredicate(dialect) + `
 		ORDER BY n.nspname, c.relname`
 }

--- a/internal/schemaselection/schemaselection.go
+++ b/internal/schemaselection/schemaselection.go
@@ -34,24 +34,28 @@ import (
 // database URL to a single schema.
 const searchPathParam = "search_path"
 
-// PostgresNonSystemSchemas is the WHERE predicate that keeps the schemas a
-// realm describes and drops the server's own, over a `pg_namespace n`.
-//
-// CockroachDB exposes crdb_internal through the PostgreSQL catalog surface, but
-// its virtual relations are not ordinary user tables and PostgreSQL readers
-// cannot inspect them as comparison input.
+// PostgresNonSystemSchemasPredicate returns the WHERE predicate that keeps the
+// schemas a PostgreSQL-family realm describes and drops the server's own, over
+// a `pg_namespace n`.
 //
 // The ESCAPE clause matters: in LIKE, `_` matches any single character, so an
 // unescaped 'pg\_%' would also hide a user schema named `pgapp` and describe
 // less of the database than is there.
 //
-// It is one string rather than two because two callers ask about the same set
-// — this package's [RealmSchemas] and the not-clean gate's realm probe in
-// go.5x5.cz/ptah/internal/migrateclean, which needs each schema's tables as
-// well. Those two questions differ; "which schemas is the realm" does not.
-const PostgresNonSystemSchemas = `n.nspname <> 'information_schema'
-			  AND n.nspname <> 'crdb_internal'
-			  AND n.nspname NOT LIKE 'pg\_%' ESCAPE '\'`
+// The predicate is derived from the normalized dialect because PostgreSQL,
+// CockroachDB and YugabyteDB share a reader but not an identical system
+// namespace set. CockroachDB exposes crdb_internal through the PostgreSQL
+// catalog surface, but its virtual relations are not ordinary user tables and
+// PostgreSQL readers cannot inspect them as comparison input.
+func PostgresNonSystemSchemasPredicate(dialect string) string {
+	predicates := []string{`n.nspname <> 'information_schema'`}
+	if platform.NormalizeDialect(dialect) == platform.CockroachDB {
+		predicates = append(predicates, `n.nspname <> 'crdb_internal'`)
+	}
+	predicates = append(predicates, `n.nspname NOT LIKE 'pg\_%' ESCAPE '\'`)
+	return strings.Join(predicates, `
+			  AND `)
+}
 
 // RowQuerier is the part of *sql.DB and *sql.Tx [Selection.Resolve] needs.
 // Taking the narrow interface keeps this package off the connection layer,
@@ -270,7 +274,7 @@ func RealmSchemas(ctx context.Context, dialect string, q RowsQuerier) ([]string,
 	rows, err := q.QueryContext(ctx, `
 		SELECT n.nspname
 		FROM pg_namespace n
-		WHERE `+PostgresNonSystemSchemas)
+		WHERE `+PostgresNonSystemSchemasPredicate(dialect))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list realm schemas: %w", err)
 	}

--- a/internal/schemaselection/schemaselection_test.go
+++ b/internal/schemaselection/schemaselection_test.go
@@ -248,6 +248,26 @@ func TestRealmSchemas_PostgresFamilyQueryExcludesSystemSchemas(t *testing.T) {
 	c.Assert(queries[0], qt.Contains, "n.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'")
 }
 
+func TestPostgresNonSystemSchemasPredicate_DerivesSystemSchemasFromDialect(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("postgres", func(c *qt.C) {
+		predicate := schemaselection.PostgresNonSystemSchemasPredicate("postgres")
+
+		c.Assert(predicate, qt.Contains, "n.nspname <> 'information_schema'")
+		c.Assert(predicate, qt.Not(qt.Contains), "crdb_internal")
+		c.Assert(predicate, qt.Contains, "n.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'")
+	})
+
+	c.Run("cockroachdb", func(c *qt.C) {
+		predicate := schemaselection.PostgresNonSystemSchemasPredicate("cockroachdb")
+
+		c.Assert(predicate, qt.Contains, "n.nspname <> 'information_schema'")
+		c.Assert(predicate, qt.Contains, "n.nspname <> 'crdb_internal'")
+		c.Assert(predicate, qt.Contains, "n.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'")
+	})
+}
+
 // errString renders an error for comparison, so the table can carry the wanted
 // message as one field instead of a nil check plus a match in every row.
 func errString(err error) string {


### PR DESCRIPTION
Closes #1381.

## Summary
- restrict PostgreSQL-family column introspection to base tables before table-only projections run, fixing CockroachDB reads when views exist
- add live CockroachDB/YugabyteDB reader coverage that seeds a table, view, materialized view, index, and sequence, then exercises dbschema, `ptah db read`, and `ptah-compat schema inspect`
- add a dedicated CI guard so distributed-SQL reader coverage cannot be skipped by earlier broad integration failures
- derive PostgreSQL-family system-schema filtering from the normalized dialect and align CockroachDB CI with the measured v26.2.5 image
- document the measured reader coverage and the current CockroachDB standalone sequence boundary

## Verification
- `go test ./internal/schemaselection ./internal/migrateclean ./internal/dbschema/postgres ./cmd/readdb ./cmd/atlas -count=1`
- `go test ./internal/schemascope -count=1`
- `go test ./dbschema -count=1` (rerun outside sandbox because localhost bind is blocked)
- `scripts/check-test-style.sh`
- `go tool qtlint ./internal/schemaselection ./internal/migrateclean ./internal/dbschema/postgres ./integration/gonative`
- `node docs/site/scripts/check-style.mjs`
- `golangci-lint run ./internal/schemaselection ./internal/migrateclean ./internal/dbschema/postgres ./integration/gonative --build-tags integration --new-from-rev=origin/master --timeout 5m`
- live guard on CockroachDB v26.2.5 and YugabyteDB 2026.1.0.0-b118: `sh scripts/require-tests-ran.sh --package ./integration/gonative --tags integration --pattern '^TestPostgresFamilyReader_' --declared-in integration/gonative/postgres_family_reader_integration_test.go --timeout 8m`

## Notes
- A plain sandbox run of the live guard failed at `dial tcp ... operation not permitted`; the same command passed outside the sandbox against the local containers.
- Full `golangci-lint` over `./integration/gonative` still reports pre-existing unrelated issues, so the PR uses the diff-only lint gate above.