### PR TITLE
ci: derive partitioned index test guard

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -273,35 +273,22 @@ jobs:
             --pattern '^TestReverseRecreatedTable_DropTableRollbackApplies_Integration$' --timeout 5m
 
       # The third ./migration/generator live-test step, alongside the two above.
-      # Every test in it decides something only a server can answer -- whether
+      # Every test in it decides something only a server can answer: whether
       # PostgreSQL refuses a concurrent index on a partitioned parent, which
       # index a partition's copy makes undroppable, and whether a
-      # never-analyzed relation is empty or merely unmeasured. All six skip
-      # themselves when no DSN is set, and a skip reads as a pass, so two guards
-      # run and they fail on different things. The -list lines fail the step
-      # when a rename leaves the -run pattern matching nothing; the --- PASS
-      # greps over the captured log fail it when the tests were reached and
-      # skipped themselves. Neither alone is enough: -list answers from the
-      # source whether or not anything ran, and a PASS grep cannot tell a
-      # renamed test from one that never existed.
+      # never-analyzed relation is empty or merely unmeasured. These tests skip
+      # themselves when no DSN is set, and a skip reads as a pass, so use the
+      # derived guard from #1367 instead of hand-maintained name greps.
       - name: Run partitioned and row-statistics concurrent-index tests
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
         run: |
-          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres$'
-          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres$'
-          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres$'
-          go test ./migration/generator -list '^TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres$' | grep -q '^TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres$'
-          go test ./migration/generator -list '^TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres$' | grep -q '^TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres$'
-          go test ./migration/generator -list '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$' | grep -q '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$'
-          go test -v -count=1 ./migration/generator -run '^(TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres|TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres|TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres|TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres|TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres)$' -timeout 10m > partitioned-index.log || { cat partitioned-index.log; exit 1; }
-          cat partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres' partitioned-index.log
+          sh scripts/require-tests-ran.sh --package ./migration/generator \
+            --pattern '^(TestGenerateMigration_(PartitionedParent|UnknownRowStatistics|EmptyNeverAnalyzed)|TestReadSchema_PartitionAttached)' \
+            --declared-in migration/generator/partitioned_index_cycle_postgres_live_test.go \
+            --declared-in migration/generator/partitioned_index_shadow_postgres_live_test.go \
+            --declared-in migration/generator/partitioned_stats_postgres_live_test.go \
+            --timeout 10m
 
       - name: Run database-realm cleanup and replay tests
         env:


### PR DESCRIPTION
## Summary

- replace the partitioned/index row-statistics workflow step's hand-maintained `go test -list | grep` and `--- PASS:` greps with `scripts/require-tests-ran.sh`
- guard the step by derived selection plus `--declared-in` files, so rename/addition/skip failures match the #1367 guard model
- remove the pipeline-status and manual-name-list shape called out in the #1367 review feedback

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/go-integration-tests.yml"); puts "yaml ok"'`
- `git diff --check`
- `env GOCACHE=/private/tmp/ptah-go-cache-1367-guard go test ./migration/generator -list '^(TestGenerateMigration_(PartitionedParent|UnknownRowStatistics|EmptyNeverAnalyzed)|TestReadSchema_PartitionAttached)'`
  - listed the expected 6 tests
- `env GOCACHE=/private/tmp/ptah-go-cache-1367-guard sh scripts/require-tests-ran.sh --package ./migration/generator --pattern '^(TestGenerateMigration_(PartitionedParent|UnknownRowStatistics|EmptyNeverAnalyzed)|TestReadSchema_PartitionAttached)' --declared-in migration/generator/partitioned_index_cycle_postgres_live_test.go --declared-in migration/generator/partitioned_index_shadow_postgres_live_test.go --declared-in migration/generator/partitioned_stats_postgres_live_test.go --timeout 10m`
  - expected local failure without `POSTGRES_TEST_DSN`: `listed=6 ran=6 passed=0 failed=0 skipped=6`, then `a skip reads as a pass`

Follow-up: #1367
