### PR TITLE
ci: grant reusable integration workflow permissions

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -93,4 +93,9 @@ jobs:
   complete-integration:
     name: complete integration contour
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Reusable workflows may preserve or reduce caller permissions, but cannot
+    # add scopes that the calling job did not grant.
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/go-integration-tests.yml

--- a/internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
+++ b/internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
@@ -112,7 +112,13 @@ seal_refused() {
 		echo "regenerate: oracle refused ${case_dir#"$HERE"/} but still wrote atlas.sum" >&2
 		exit 1
 	fi
-	printf '%s\n' "$out" | sed "s|$case_dir|<case-dir>|g" >"$case_dir/atlas.refused"
+	# The community binary can append generic installation advice to a refusal.
+	# It is not part of the format-specific verdict and varies with invocation
+	# context, so exclude that exact footer from the deterministic corpus.
+	printf '%s\n' "$out" |
+		sed -e "s|$case_dir|<case-dir>|g" \
+			-e "/^You're running the community build of Atlas, which differs from the official version\\.$/,\$d" \
+		>"$case_dir/atlas.refused"
 	printf '  %-52s %s\n' "${case_dir#"$HERE"/}" "REFUSED (exit $ec)"
 }
 


### PR DESCRIPTION
## Summary

- grant the reusable complete-integration caller the token scopes declared by the called workflow
- keep the additional `pull-requests: read` scope limited to that caller job
- document why the grant is required by the reusable-workflow permission chain
- exclude Atlas CE's generic installation footer from deterministic refusal fixtures

## Root cause

PR #1389 added the `complete-integration` reusable-workflow call to the Atlas CE Oracle workflow. The called integration workflow declares `contents: read` and `pull-requests: read`, but the caller job inherited only `contents: read`. GitHub rejects a reusable workflow that attempts to elevate `GITHUB_TOKEN` permissions, so every Atlas CE Oracle run after `2a6e0a9` ended immediately with `startup_failure` and no jobs.

Once the workflow could start, it exposed a second regression: the shortened oracle job invokes corpus regeneration before any other refusing oracle command. Atlas CE can append generic installation advice to that first refusal, although the format-specific error and exit code are unchanged. The generator now removes only that exact footer and keeps the refusal verdict intact.

## Verification

- `actionlint v1.7.12 .github/workflows/atlas-oracle.yml .github/workflows/go-integration-tests.yml`
- `shellcheck -x internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh scripts/lib/atlas-ce-oracle.sh`
- `go test -race ./internal/atlasmigrateimport -count=1`
- complete corpus regeneration with the pinned Atlas CE v1.3.0 binary; no generated fixture changed
- `git diff --check`
- the PR's Atlas CE Oracle run must start jobs instead of ending with `startup_failure`

Follow-up to #1389.
