### PR TITLE
ci: reject repository-local paths

### DIFF
--- a/.agents/skills/ptah-documentation-maintenance/SKILL.md
+++ b/.agents/skills/ptah-documentation-maintenance/SKILL.md
@@ -160,12 +160,12 @@ rg -n "Exact error text|Exact output label" --glob '*.md' --glob '*.go'
 The binding rules are in `docs/STYLE_GUIDE.md`. Use Inventario's docs as an
 additional quality reference for tone and structure, especially:
 
-- `/Users/buster/Work/denis/inventario/docs/site/src/content/docs/index.mdx`
-- `/Users/buster/Work/denis/inventario/docs/site/src/content/docs/getting-started.md`
-- `/Users/buster/Work/denis/inventario/docs/site/src/content/docs/self-hosting.md`
-- `/Users/buster/Work/denis/inventario/docs/site/src/content/docs/backup-and-restore.md`
-- `/Users/buster/Work/denis/inventario/docs/site/src/content/docs/groups-and-sharing.md`
-- `/Users/buster/Work/denis/inventario/docs/site/src/content/docs/reports.md`
+- [Home](https://github.com/denisvmedia/inventario/blob/master/docs/site/src/content/docs/index.mdx)
+- [Getting started](https://github.com/denisvmedia/inventario/blob/master/docs/site/src/content/docs/getting-started.md)
+- [Self-hosting](https://github.com/denisvmedia/inventario/blob/master/docs/site/src/content/docs/self-hosting.md)
+- [Backup and restore](https://github.com/denisvmedia/inventario/blob/master/docs/site/src/content/docs/backup-and-restore.md)
+- [Groups and sharing](https://github.com/denisvmedia/inventario/blob/master/docs/site/src/content/docs/groups-and-sharing.md)
+- [Reports](https://github.com/denisvmedia/inventario/blob/master/docs/site/src/content/docs/reports.md)
 
 Match the discipline, not the product structure exactly:
 

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -37,6 +37,9 @@ jobs:
           ! grep -F "All operations wrapped in transactions" README.md
           ! grep -F "locking prevents double-apply" README.md
 
+      - name: Check repository-local path leaks
+        run: scripts/check-repository-local-paths.sh
+
       - name: Check public Go API ledger
         run: scripts/check-public-api.sh
 

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -483,7 +483,7 @@
     "atlas_oss": "yes",
     "atlas_pro": "yes",
     "note": "Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails.",
-    "evidence": "conformance gaps.md probe `inspect-source-workflow`; /Users/buster/Work/denis/ptah/.codex/worktress/docs-feature-matrix/docs/site/src/content/docs/atlas/schema-commands.md"
+    "evidence": "conformance gaps.md probe `inspect-source-workflow`; docs/site/src/content/docs/atlas/schema-commands.md"
   },
   {
     "area": "Declarative / direct schema workflow",
@@ -1032,7 +1032,7 @@
     "atlas_oss": "yes",
     "atlas_pro": "yes",
     "note": "Reference engine of the PostgreSQL family: views, matviews, functions, triggers, sequences, roles, RLS and domains all render. Presets 12-13, 14-16, 17+ from the server banner.",
-    "evidence": "/tmp/ptah-mx schema render --dialect postgres (built from /Users/buster/Work/denis/ptah/.codex/worktress/docs-feature-matrix/cmd/ptah); core/platform/capability/capability.go Postgres13/Postgres16/Postgres17 + ForServerVersion; docs/site/src/content/docs/databases/postgresql.md (Version-dependent behavior); comparison.md#supported-databases cites the Atlas Open driver list. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names MySQL, MariaDB, PostgreSQL and SQLite, corroborating PostgreSQL on the free tier"
+    "evidence": "`ptah schema render --dialect postgres` built from cmd/ptah; core/platform/capability/capability.go Postgres13/Postgres16/Postgres17 + ForServerVersion; docs/site/src/content/docs/databases/postgresql.md (Version-dependent behavior); comparison.md#supported-databases cites the Atlas Open driver list. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names MySQL, MariaDB, PostgreSQL and SQLite, corroborating PostgreSQL on the free tier"
   },
   {
     "area": "Database engines",

--- a/internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
+++ b/internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
@@ -21,25 +21,20 @@
 #
 # Usage:
 #   ./regenerate.sh [path-to-atlas]
+#   PTAH_ATLAS_ORACLE=/path/to/atlas ./regenerate.sh
 #
 # After running, `git status` must be clean. A diff means either the oracle
 # changed or this script drifted from the committed corpus.
 
 set -euo pipefail
 
-ATLAS="${1:-$HOME/Work/denis/ptah-atlas-conformance/bin/atlas}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
 
 # shellcheck source=scripts/lib/atlas-ce-oracle.sh
 source "$ROOT/scripts/lib/atlas-ce-oracle.sh"
 atlas_ce_load_lock "$ROOT/scripts/atlas-ce-oracle.lock"
-
-if [ ! -x "$ATLAS" ]; then
-	echo "regenerate: oracle not found or not executable: $ATLAS" >&2
-	echo "regenerate: pass the path to the pinned Atlas CE binary as \$1" >&2
-	exit 1
-fi
+ATLAS="$(atlas_ce_resolve_binary "${1:-}")"
 
 actual_version="$(atlas_ce_verify_binary "$ATLAS")"
 

--- a/scripts/check-repository-local-paths.sh
+++ b/scripts/check-repository-local-paths.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Keep developer-specific Unix paths and conventional local checkout defaults
+# out of tracked files. The leading-character constraint avoids matching
+# synthetic Windows paths such as C:/Users/runner in cross-platform tests.
+pattern="(^|[[:space:]=\"(\`])/(Users|home)/[^/[:space:]]+|\\\$HOME/(Work|Projects)/"
+
+status=0
+matches="$(git grep -nE "$pattern" -- . ':(exclude)scripts/check-repository-local-paths.sh')" || status=$?
+
+if ((status > 1)); then
+	printf 'repository-local path check failed with exit code %d\n' "$status" >&2
+	exit "$status"
+fi
+if ((status == 0)); then
+	printf 'repository-local paths found in tracked files:\n%s\n' "$matches" >&2
+	exit 1
+fi

--- a/scripts/lib/atlas-ce-oracle.sh
+++ b/scripts/lib/atlas-ce-oracle.sh
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 
-# Shared lock-file and binary validation for scripts that measure Atlas CE as
-# an external black-box oracle. Call atlas_ce_load_lock before the other
-# functions.
+# Shared path resolution, lock-file loading, and binary validation for scripts
+# that measure Atlas CE as an external black-box oracle. Call
+# atlas_ce_load_lock before the version functions.
+
+atlas_ce_resolve_binary() {
+	local argument_path="${1:-}"
+
+	if [[ -n "$argument_path" ]]; then
+		printf '%s\n' "$argument_path"
+		return 0
+	fi
+	if [[ -n "${PTAH_ATLAS_ORACLE:-}" ]]; then
+		printf '%s\n' "$PTAH_ATLAS_ORACLE"
+		return 0
+	fi
+
+	printf 'atlas-ce: oracle path required; pass it as an argument or set PTAH_ATLAS_ORACLE\n' >&2
+	return 1
+}
 
 atlas_ce_load_lock() {
 	local lock_file="$1"

--- a/scripts/probe-atlas-apply-gate.sh
+++ b/scripts/probe-atlas-apply-gate.sh
@@ -36,18 +36,12 @@
 set -u
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ATLAS="${1:-${PTAH_ATLAS_ORACLE:-$HOME/Work/denis/ptah-atlas-conformance/bin/atlas}}"
 COMPAT="$ROOT/bin/ptah-compat"
 
 # shellcheck source=scripts/lib/atlas-ce-oracle.sh
 source "$ROOT/scripts/lib/atlas-ce-oracle.sh"
 atlas_ce_load_lock "$ROOT/scripts/atlas-ce-oracle.lock"
-
-if [ ! -x "$ATLAS" ]; then
-	echo "probe: oracle not found or not executable: $ATLAS" >&2
-	echo "probe: pass the path to the pinned Atlas CE binary as \$1" >&2
-	exit 1
-fi
+ATLAS="$(atlas_ce_resolve_binary "${1:-}")" || exit 1
 atlas_ce_verify_binary "$ATLAS" >/dev/null || exit 1
 
 if [ ! -x "$COMPAT" ]; then

--- a/scripts/probe-atlas-integrity-verbs.sh
+++ b/scripts/probe-atlas-integrity-verbs.sh
@@ -29,18 +29,12 @@
 set -u
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ATLAS="${1:-${PTAH_ATLAS_ORACLE:-$HOME/Work/denis/ptah-atlas-conformance/bin/atlas}}"
 COMPAT="$ROOT/bin/ptah-compat"
 
 # shellcheck source=scripts/lib/atlas-ce-oracle.sh
 source "$ROOT/scripts/lib/atlas-ce-oracle.sh"
 atlas_ce_load_lock "$ROOT/scripts/atlas-ce-oracle.lock"
-
-if [ ! -x "$ATLAS" ]; then
-	echo "probe: oracle not found or not executable: $ATLAS" >&2
-	echo "probe: pass the path to the pinned Atlas CE binary as \$1" >&2
-	exit 1
-fi
+ATLAS="$(atlas_ce_resolve_binary "${1:-}")" || exit 1
 atlas_ce_verify_binary "$ATLAS" >/dev/null || exit 1
 
 if [ ! -x "$COMPAT" ]; then


### PR DESCRIPTION
## Summary

- remove developer-specific checkout paths from the Atlas CE corpus generator, differential probes, feature-matrix evidence, and documentation-maintenance skill
- require the pinned external oracle path through an explicit argument or `PTAH_ATLAS_ORACLE`
- add a repository-wide CI guard that rejects Unix user-home paths and conventional local checkout defaults while preserving synthetic Windows path fixtures

## Why

The corpus generator contained a local sibling-checkout default, and several tracked documentation records contained absolute paths from one developer's machine. Besides exposing local filesystem structure, those values made repository behavior depend on an untracked workspace layout.

## Verification

- `scripts/check-repository-local-paths.sh`
- resolver argument, environment, and missing-path cases
- all three oracle consumers fail closed when no path is configured
- full Atlas CE v1.3.0 corpus regeneration with an explicit pinned binary; no fixture changes
- `shellcheck -x scripts/check-repository-local-paths.sh scripts/lib/atlas-ce-oracle.sh internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh`
- `shellcheck -x -e SC2015,SC2295 scripts/probe-atlas-apply-gate.sh scripts/probe-atlas-integrity-verbs.sh` (the exclusions are pre-existing findings outside this change)
- `actionlint -ignore SC2251 .github/workflows/go-lint.yml .github/workflows/atlas-oracle.yml` (the ignored findings are in the pre-existing documentation-safety block)
- `node docs/site/scripts/check-style.mjs`
- `node docs/site/scripts/build-feature-matrix.mjs --check`
- JSON parse check for `feature-matrix-rows.json`
- `git diff --cached --check`

The commit is GPG-signed and verified locally.
