### PR TITLE
fix(migrate): report undecidable additions

### DIFF
--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -1,6 +1,7 @@
 package atlas
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"strings"
@@ -36,7 +37,17 @@ type atlasMigrateDiffOptions struct {
 	edit        bool
 }
 
+type atlasMigrateDiffRunner func(
+	context.Context,
+	*dbschema.DatabaseConnection,
+	atlasmigrate.DiffOptions,
+) (atlasmigrate.DiffResult, error)
+
 func newAtlasMigrateDiffCommand() *cobra.Command {
+	return newAtlasMigrateDiffCommandWithRunner(atlasmigrate.GenerateDiff)
+}
+
+func newAtlasMigrateDiffCommandWithRunner(run atlasMigrateDiffRunner) *cobra.Command {
 	opts := atlasMigrateDiffOptions{}
 	cmd := &cobra.Command{
 		Use:   "diff [flags] [name]",
@@ -68,7 +79,7 @@ diff policy values.`,
 			if len(args) == 1 {
 				name = args[0]
 			}
-			return runAtlasMigrateDiff(cmd, opts, name)
+			return runAtlasMigrateDiff(cmd, opts, name, run)
 		},
 	}
 	flags := cmd.Flags()
@@ -100,6 +111,7 @@ func runAtlasMigrateDiff(
 	cmd *cobra.Command,
 	opts atlasMigrateDiffOptions,
 	name string,
+	run atlasMigrateDiffRunner,
 ) (runErr error) {
 	formatConfigured := cmd.Flags().Changed("format")
 	// dirURLSpelled is --dir as the command line, its environment twin and the
@@ -246,7 +258,7 @@ func runAtlasMigrateDiff(
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	diffResult, err := atlasmigrate.GenerateDiff(cmd.Context(), conn, atlasmigrate.DiffOptions{
+	diffResult, err := run(cmd.Context(), conn, atlasmigrate.DiffOptions{
 		Dir: migrationsDir,
 		// The same handle the preflight gate captured through. Handing it to the
 		// writer is what keeps the publication bound to the project root the
@@ -276,6 +288,7 @@ func runAtlasMigrateDiff(
 		Policy:             policy,
 		Qualifier:          qualifier,
 		DryRun:             opts.dryRun,
+		Diagnostics:        cmd.ErrOrStderr(),
 		Vars:               schemaVars,
 		PreparePublication: preparePublication,
 		// The same predicate the preflight above already applied, re-applied to

--- a/cmd/atlas/migrate_diff_diagnostics_internal_test.go
+++ b/cmd/atlas/migrate_diff_diagnostics_internal_test.go
@@ -1,0 +1,60 @@
+package atlas
+
+// White-box testing required: the command runner seam observes the exact
+// DiffOptions assembled at the Cobra boundary without mutating package globals.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+)
+
+func TestMigrateDiffCommand_RoutesDiagnosticsToCobraStderr(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	desiredPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(
+		desiredPath,
+		[]byte("CREATE TABLE desired (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	called := 0
+	cmd := newAtlasMigrateDiffCommandWithRunner(func(
+		_ context.Context,
+		_ *dbschema.DatabaseConnection,
+		opts atlasmigrate.DiffOptions,
+	) (atlasmigrate.DiffResult, error) {
+		called++
+		_, err := fmt.Fprint(opts.Diagnostics, "migrate diff diagnostic\n")
+		return atlasmigrate.DiffResult{Synced: true}, err
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{
+		"--dev-url", "sqlite://" + filepath.Join(dir, "dev.db"),
+		"--dir", "file://" + migrationsDir,
+		"--to", "file://" + desiredPath,
+		"diagnostics",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(called, qt.Equals, 1)
+	c.Assert(stderr.String(), qt.Equals, "migrate diff diagnostic\n")
+	c.Assert(stdout.String(), qt.Equals,
+		"The migration directory is synced with the desired state, no changes to be made\n",
+	)
+}

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -80,6 +80,13 @@ comparison it got before the field existed. Set it when a reader was asked about
 less than the whole database, or a projection left something out on purpose;
 leaving it zero there is how an object nobody looked at becomes a `DROP`.
 
+`schemadiff.CompareReportingUndecidedAdditions` exposes desired additions that
+an offline comparison could not plan safely, and
+`schemadiff.CompareWithDatabaseReportingUndecidedAdditions` provides the same
+report while resolving the connected catalog's identifier semantics and
+default comparison options. Command adapters use that report for warnings;
+embedders can choose their own diagnostic policy.
+
 `goschema.Finalize` rebuilds materialized inline, JSON, and relation fields on
 every call. `Field.GeneratedFromEmbedded` identifies those derived fields so a
 caller can mutate the source fields or embedded declarations and finalize the

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -8659,6 +8659,7 @@ func Compare(generated *goschema.Database, database *types.DBSchema) *difftypes.
 func CompareReportingUndecidedAdditions(generated *goschema.Database, database *types.DBSchema, ...) (*difftypes.SchemaDiff, []coverage.Object)
 func CompareWithDatabase(ctx context.Context, conn *dbschema.DatabaseConnection, ...) (*difftypes.SchemaDiff, error)
 func CompareWithDatabaseInfo(generated *goschema.Database, database *types.DBSchema, info types.DBInfo, ...) (*difftypes.SchemaDiff, error)
+func CompareWithDatabaseReportingUndecidedAdditions(ctx context.Context, conn *dbschema.DatabaseConnection, ...) (*difftypes.SchemaDiff, []coverage.Object, error)
 func CompareWithDialect(generated *goschema.Database, database *types.DBSchema, dialect string) *difftypes.SchemaDiff
 func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, ...) *difftypes.SchemaDiff
 

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -448,10 +448,9 @@ carries the fact itself, in its header:
 
 A comparator reading that document has three states for an object instead of
 two: present, absent, and **not described**. Only the middle one is a removal.
-The four commands that consume a desired-state document — `schema diff`,
-`schema apply`, `migrate diff`, and `migrate diff` writing its migration file —
-each resolve that document separately, and all four now report the database
-above as synced.
+The four commands that consume a desired-schema document — `schema diff`,
+`schema apply`, `schema plan`, and `migrate diff` — each resolve that document
+separately, and all four now report the database above as synced.
 
 The lines are HCL comments, so they change nothing for any other reader: the
 pinned Atlas community binary v1.3.0 reads a document carrying them at exit 0

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"strings"
 	"time"
@@ -85,6 +86,9 @@ type DiffOptions struct {
 	Policy      atlasschema.DiffPolicy
 	Qualifier   Qualifier
 	DryRun      bool
+	// Diagnostics receives non-fatal notices about desired objects whose
+	// creation cannot be planned safely from the replayed directory's coverage.
+	Diagnostics io.Writer
 	// Vars supplies values for HCL schema-file `variable` blocks, as `--var`
 	// spells them; see [go.5x5.cz/ptah/internal/schemafile.Options].
 	Vars []string
@@ -244,6 +248,7 @@ func generateDiff(
 		func(replayConn *dbschema.DatabaseConnection) error {
 			replayed, compared, err := compareReplayedState(
 				ctx, replayConn, runtime, schemas, devDefaultSchema, desired,
+				opts.Diagnostics,
 			)
 			if err != nil {
 				return err
@@ -529,6 +534,7 @@ func compareReplayedState(
 	schemas []string,
 	defaultSchema string,
 	desired *goschema.Database,
+	diagnostics io.Writer,
 ) (*dbschematypes.DBSchema, *difftypes.SchemaDiff, error) {
 	readNames, err := schemascope.ReadNames(ctx, replayConn.Info(), schemas, replayConn)
 	if err != nil {
@@ -538,10 +544,18 @@ func compareReplayedState(
 	if err != nil {
 		return nil, nil, err
 	}
-	diff, err := schemadiff.CompareWithDatabase(ctx, replayConn, desired, replayed, nil)
+	diff, undecided, err := schemadiff.CompareWithDatabaseReportingUndecidedAdditions(
+		ctx, replayConn, desired, replayed, nil,
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("compare dev database schema: %w", err)
 	}
+	atlasschema.ReportUndecidedAdditions(
+		diagnostics,
+		undecided,
+		"the replayed migration directory",
+		"--to",
+	)
 	return replayed, diff, nil
 }
 

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -5,6 +5,7 @@ package atlasmigrate
 // GenerateDiff API.
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -18,6 +19,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"go.5x5.cz/ptah/core/coverage"
+	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/dbschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/atlasmigrateimport"
@@ -29,6 +32,151 @@ import (
 	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/migration/migrator"
 )
+
+const undecidedSequenceDiagnostic = "Warning: sequence \"order_seq\" is declared by --to but no change was planned for it:" +
+	" the replayed migration directory records `ptah:not-described sequence`," +
+	" so this comparison cannot tell it apart from one that already exists," +
+	" and the creation Ptah renders for it has no IF NOT EXISTS guard.\n"
+
+func TestCompareReplayedState_PreservesDesiredCoverage(t *testing.T) {
+	c := qt.New(t)
+	conn := connectDiffComparisonSQLite(c)
+	current := &dbschematypes.DBSchema{
+		Extensions: []dbschematypes.DBExtension{{Name: "pgcrypto"}},
+	}
+	desired := &goschema.Database{
+		NotDescribed: coverage.Set{}.WithKind(coverage.Extension),
+	}
+	runtime := diffRuntime{
+		readDevSchema: func(
+			*dbschema.DatabaseConnection,
+			[]string,
+			string,
+		) (*dbschematypes.DBSchema, error) {
+			return current, nil
+		},
+	}
+
+	replayed, diff, err := compareReplayedState(
+		c.Context(), conn, runtime, nil, conn.Info().Schema, desired, nil,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(replayed, qt.Equals, current)
+	c.Assert(diff.ExtensionsRemoved, qt.HasLen, 0)
+}
+
+func TestCompareReplayedState_PreservesExplicitRemoval(t *testing.T) {
+	c := qt.New(t)
+	conn := connectDiffComparisonSQLite(c)
+	current := &dbschematypes.DBSchema{
+		Extensions: []dbschematypes.DBExtension{{Name: "pgcrypto"}},
+	}
+	runtime := diffRuntime{
+		readDevSchema: func(
+			*dbschema.DatabaseConnection,
+			[]string,
+			string,
+		) (*dbschematypes.DBSchema, error) {
+			return current, nil
+		},
+	}
+
+	_, diff, err := compareReplayedState(
+		c.Context(), conn, runtime, nil, conn.Info().Schema,
+		&goschema.Database{}, nil,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{"pgcrypto"})
+}
+
+func TestCompareReplayedState_ReportsUndecidedAddition(t *testing.T) {
+	c := qt.New(t)
+	conn := connectDiffComparisonSQLite(c)
+	current := &dbschematypes.DBSchema{
+		NotDescribed: coverage.Set{}.WithKind(coverage.Sequence),
+	}
+	runtime := diffRuntime{
+		readDevSchema: func(
+			*dbschema.DatabaseConnection,
+			[]string,
+			string,
+		) (*dbschematypes.DBSchema, error) {
+			return current, nil
+		},
+	}
+	diagnostics := &bytes.Buffer{}
+
+	_, diff, err := compareReplayedState(
+		c.Context(), conn, runtime, nil, conn.Info().Schema,
+		&goschema.Database{Sequences: []goschema.Sequence{{Name: "order_seq"}}},
+		diagnostics,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diff.HasChanges(), qt.IsFalse)
+	c.Assert(diagnostics.String(), qt.Equals, undecidedSequenceDiagnostic)
+}
+
+func connectDiffComparisonSQLite(c *qt.C) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(
+		c.Context(),
+		atlasurl.SQLiteURLFromPath(c.TempDir()+"/catalog.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+	return conn
+}
+
+func TestGenerateDiff_RoutesUndecidedAdditionDiagnostics(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	desiredPath := filepath.Join(dir, "schema.hcl")
+	c.Assert(os.WriteFile(
+		desiredPath,
+		[]byte("sequence \"order_seq\" {}\n"),
+		0o600,
+	), qt.IsNil)
+	desired, err := atlassource.ClassifySet(
+		"--to",
+		[]string{"file://" + desiredPath},
+		atlassource.ProjectEnv{},
+	)
+	c.Assert(err, qt.IsNil)
+	conn := connectDiffComparisonSQLite(c)
+	diagnostics := &bytes.Buffer{}
+
+	result, err := generateDiff(c.Context(), conn, DiffOptions{
+		Dir:         migrationsDir,
+		Desired:     desired,
+		Name:        "undecided_sequence",
+		Diagnostics: diagnostics,
+	}, diffRuntime{
+		readDevSchema: func(
+			*dbschema.DatabaseConnection,
+			[]string,
+			string,
+		) (*dbschematypes.DBSchema, error) {
+			return &dbschematypes.DBSchema{
+				NotDescribed: coverage.Set{}.WithKind(coverage.Sequence),
+			}, nil
+		},
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
+	})
+	artifacts, readErr := os.ReadDir(migrationsDir)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Synced, qt.IsTrue)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	c.Assert(result.SumPath, qt.Equals, "")
+	c.Assert(diagnostics.String(), qt.Equals, undecidedSequenceDiagnostic)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(artifacts, qt.HasLen, 0)
+}
 
 func TestWriteMigrationFilesAt_CollisionRejectsStalePlan(t *testing.T) {
 	c := qt.New(t)

--- a/internal/atlasschema/diff.go
+++ b/internal/atlasschema/diff.go
@@ -146,7 +146,7 @@ func Diff(ctx context.Context, opts DiffOptions) (atlasreport.SchemaDiff, error)
 	compareOpts := config.DefaultCompareOptions()
 	compareOpts.Dialect = dialect
 	compared, undecided := schemadiff.CompareReportingUndecidedAdditions(to, fromDB, compareOpts)
-	reportUndecidedAdditions(opts.Diagnostics, undecided)
+	ReportUndecidedAdditions(opts.Diagnostics, undecided, "--from", "--to")
 
 	diff := applyDiffPolicy(compared, opts.Policy)
 	var statements []string

--- a/internal/atlasschema/scope.go
+++ b/internal/atlasschema/scope.go
@@ -118,27 +118,31 @@ func refuseUnmatchedExclude(selectors []string) error {
 		atlasfilter.AllowUnmatchedExcludeEnvVar)
 }
 
-// reportUndecidedAdditions names every object the comparison declined to plan a
-// creation for because the CURRENT side's document declared it does not describe
-// that kind (`// ptah:not-described <kind>`) and the creation Ptah would emit
-// carries no IF NOT EXISTS guard.
+// ReportUndecidedAdditions names every object the comparison declined to plan a
+// creation for because the CURRENT side's coverage record says it does not
+// describe that kind (`// ptah:not-described <kind>` in a document) and the
+// creation Ptah would emit carries no IF NOT EXISTS guard.
 //
 // Withholding one is defensible; withholding it in silence is not. Only a
-// document can be the current side of `schema diff` -- an introspected database
-// declares no limits -- so a `--from` file is the one place this arises today,
-// and the notice goes here for the same reason [reportEmptySelection] does:
-// stdout is what CI compares, and "Schemas are synced" there says the two
-// states agree, which is not what a withheld addition means.
-func reportUndecidedAdditions(diagnostics io.Writer, undecided []coverage.Object) {
+// currentDescription and desiredDescription name the two command-specific
+// inputs in prose, so schema diff can say `--from` and migrate diff can name
+// the replayed migration directory without producing a misleading diagnostic.
+func ReportUndecidedAdditions(
+	diagnostics io.Writer,
+	undecided []coverage.Object,
+	currentDescription string,
+	desiredDescription string,
+) {
 	if diagnostics == nil {
 		return
 	}
 	for _, object := range undecided {
 		fmt.Fprintf(diagnostics,
-			"Warning: %s %q is declared by --to but no change was planned for it:"+
-				" --from records `%s %s`, so this comparison cannot tell it apart from one that already exists,"+
+			"Warning: %s %q is declared by %s but no change was planned for it:"+
+				" %s records `%s %s`, so this comparison cannot tell it apart from one that already exists,"+
 				" and the creation Ptah renders for it has no IF NOT EXISTS guard.\n",
-			object.Kind, object.Name, coverage.DirectiveMarker, object.Kind)
+			object.Kind, object.Name, desiredDescription, currentDescription,
+			coverage.DirectiveMarker, object.Kind)
 	}
 }
 

--- a/migration/schemadiff/database.go
+++ b/migration/schemadiff/database.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"go.5x5.cz/ptah/config"
+	"go.5x5.cz/ptah/core/coverage"
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/dbschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
@@ -22,17 +23,40 @@ func CompareWithDatabase(
 	database *dbschematypes.DBSchema,
 	opts *config.CompareOptions,
 ) (*difftypes.SchemaDiff, error) {
+	diff, _, err := CompareWithDatabaseReportingUndecidedAdditions(
+		ctx, conn, generated, database, opts,
+	)
+	return diff, err
+}
+
+// CompareWithDatabaseReportingUndecidedAdditions performs the same
+// database-aware comparison as [CompareWithDatabase] and also reports desired
+// additions that the current state's coverage record makes undecidable.
+//
+// The comparison resolves live catalog identifier semantics before comparing
+// and applies [config.DefaultCompareOptions] when opts is nil, just as
+// [CompareWithDatabase] does. See [CompareReportingUndecidedAdditions] for the
+// meaning and ordering of the second return.
+func CompareWithDatabaseReportingUndecidedAdditions(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	generated *goschema.Database,
+	database *dbschematypes.DBSchema,
+	opts *config.CompareOptions,
+) (*difftypes.SchemaDiff, []coverage.Object, error) {
 	if conn == nil {
-		return nil, fmt.Errorf("compare schemas: database connection is nil")
+		return nil, nil, fmt.Errorf("compare schemas: database connection is nil")
 	}
 	info := conn.Info()
 	names := collectIdentifierNames(generated, database, info.Schema)
 	semantics, err := conn.ResolveIdentifierSemantics(ctx, names)
 	if err != nil {
-		return nil, fmt.Errorf("compare schemas: %w", err)
+		return nil, nil, fmt.Errorf("compare schemas: %w", err)
 	}
 	info.IdentifierSemantics = semantics
-	return CompareWithDatabaseInfo(generated, database, info, opts)
+	return compareWithDatabaseInfoReportingUndecidedAdditions(
+		generated, database, info, opts,
+	)
 }
 
 func collectIdentifierNames(

--- a/migration/schemadiff/database_reporting_test.go
+++ b/migration/schemadiff/database_reporting_test.go
@@ -1,0 +1,42 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/coverage"
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasurl"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+func TestCompareWithDatabaseReportingUndecidedAdditionsUsesDatabaseDefaults(t *testing.T) {
+	c := qt.New(t)
+	conn, err := dbschema.ConnectToDatabase(
+		c.Context(),
+		atlasurl.SQLiteURLFromPath(c.TempDir()+"/catalog.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+	desired := &goschema.Database{
+		Sequences: []goschema.Sequence{{Name: "order_seq"}},
+	}
+	current := &types.DBSchema{
+		Extensions:   []types.DBExtension{{Name: "plpgsql"}},
+		NotDescribed: coverage.Set{}.WithKind(coverage.Sequence),
+	}
+
+	diff, undecided, err := schemadiff.CompareWithDatabaseReportingUndecidedAdditions(
+		c.Context(), conn, desired, current, nil,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diff.HasChanges(), qt.IsFalse)
+	c.Assert(diff.ExtensionsRemoved, qt.HasLen, 0)
+	c.Assert(undecided, qt.DeepEquals, []coverage.Object{
+		{Kind: coverage.Sequence, Name: "order_seq"},
+	})
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -48,6 +48,18 @@ func CompareWithDatabaseInfo(
 	info types.DBInfo,
 	opts *config.CompareOptions,
 ) (*difftypes.SchemaDiff, error) {
+	diff, _, err := compareWithDatabaseInfoReportingUndecidedAdditions(
+		generated, database, info, opts,
+	)
+	return diff, err
+}
+
+func compareWithDatabaseInfoReportingUndecidedAdditions(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	info types.DBInfo,
+	opts *config.CompareOptions,
+) (*difftypes.SchemaDiff, []coverage.Object, error) {
 	merged := config.DefaultCompareOptions()
 	if opts != nil {
 		*merged = *opts
@@ -60,31 +72,32 @@ func CompareWithDatabaseInfo(
 	// here instead, before anything is compared (stokaro/ptah#1312).
 	if generated != nil {
 		if err := reservedrole.ValidateDeclared(info.Dialect, generated.Roles); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	generated = fromschema.AssignDefaultForeignKeyNames(generated, info.Dialect)
 	semantics := info.IdentifierSemantics.Normalize(info.Dialect)
 	if !info.IdentifierSemantics.IsZero() &&
 		!info.IdentifierSemantics.Equal(semantics) {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"%w: invalid identifier semantics snapshot",
 			ptaherr.ErrInvalidSchemaDiff,
 		)
 	}
 	names := collectIdentifierNames(generated, database, semantics.DefaultSchema)
 	if err := identifiervalidation.ValidateCoverage(semantics, names); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := identifiervalidation.ValidateTarget(
 		generated,
 		info.Dialect,
 		semantics,
 	); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	merged.IdentifierSemantics = &semantics
-	return CompareWithOptions(generated, database, merged), nil
+	diff, undecided := CompareReportingUndecidedAdditions(generated, database, merged)
+	return diff, undecided, nil
 }
 
 // CompareWithOptions performs schema comparison between generated and database schemas


### PR DESCRIPTION
## Summary

- expose database-aware undecidable-addition reporting through `migration/schemadiff`
- route `migrate diff` coverage warnings to Cobra standard error instead of silently reporting a synchronized directory
- preserve both non-destructive `NotDescribed` handling and explicit object removals
- document the public API and correct the desired-schema command inventory

Fixes #1276.

## Capability ownership

**GENERAL CAPABILITY**

1. The semantic implementation lives in the public `migration/schemadiff` package. `CompareWithDatabaseReportingUndecidedAdditions` resolves live identifier semantics and default comparison policy before returning both the diff and withheld additions.
2. Native Ptah and embedders can consume the reporting API directly without depending on `cmd/atlas`; the compatibility command only selects the stderr diagnostic policy.
3. No new native CLI spelling is needed in this change because the ambiguous state is produced by replaying a migration directory carrying coverage metadata. The shared API is the native exposure boundary, so there is no compatibility-only semantic implementation or unrecorded exposure gap.

This changes behavior before v1: `migrate diff` now explains withheld additions instead of allowing an empty plan to look fully synchronized. It does not make Ptah looser than Atlas or discard any modeled capability.

## Verification

- `go test ./... -count=1`
- `go test -race ./internal/atlasmigrate ./cmd/atlas -run 'Test(GenerateDiff_RoutesUndecidedAdditionDiagnostics|MigrateDiffCommand_RoutesDiagnosticsToCobraStderr)$' -count=1`
- `golangci-lint run ./...`
- `scripts/check-public-api.sh`
- `scripts/check-public-api-snapshot.sh`
- `scripts/check-public-api-released.sh`
- `scripts/check-test-style.sh`
- `node docs/site/scripts/check-style.mjs`
- `git diff --check`

The complete unit suite required ordinary localhost and fixture-write permissions; the sandbox-only run failed at those unrelated infrastructure boundaries, and the identical run passed outside the sandbox.
