### PR TITLE
feat(schema): support index INCLUDE annotations

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -617,7 +617,8 @@ type IndexNode struct {
 	Condition string
 	// Operator specifies the operator class (gin_trgm_ops, etc.)
 	Operator string
-	// IncludeColumns contains PostgreSQL INCLUDE columns for covering indexes.
+	// IncludeColumns contains INCLUDE payload columns for PostgreSQL,
+	// YugabyteDB, and Spanner PostgreSQL-dialect covering indexes.
 	IncludeColumns []string
 	// StorageParams contains PostgreSQL index storage parameters rendered as
 	// WITH (key='value'), for example pages_per_range for BRIN indexes.

--- a/core/goschema/index_include_pipeline_test.go
+++ b/core/goschema/index_include_pipeline_test.go
@@ -1,0 +1,40 @@
+package goschema_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/renderer"
+)
+
+func TestIndexIncludeAnnotationRendersPostgreSQLCoveringIndex(t *testing.T) {
+	c := qt.New(t)
+
+	database := mustParseSource(c, "accounts.go", `package models
+
+//ptah:schema:table name="accounts"
+type Account struct {
+	//ptah:schema:field name="email" type="TEXT" not_null="true"
+	Email string
+
+	//ptah:schema:field name="display_name" type="TEXT" not_null="true"
+	DisplayName string
+
+	//ptah:schema:field name="created_at" type="TIMESTAMPTZ" not_null="true"
+	CreatedAt string
+
+	//ptah:schema:index name="idx_accounts_email" fields="email" include=" display_name, created_at "
+	_ int
+}
+`)
+
+	statements, err := renderer.GetOrderedCreateStatements(&database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(
+		strings.Join(statements, "\n"),
+		qt.Contains,
+		`CREATE INDEX IF NOT EXISTS "idx_accounts_email" ON "accounts" ("email") INCLUDE ("display_name", "created_at");`,
+	)
+}

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -248,6 +248,30 @@ func (s *schemaParseState) parseIndexComment(comment *ast.Comment, structName st
 	for i := range fields {
 		fields[i] = strings.TrimSpace(fields[i])
 	}
+	var includeColumns []string
+	if includeRaw, present := kv["include"]; present {
+		parts := strings.Split(includeRaw, ",")
+		includeColumns = make([]string, len(parts))
+		for i, part := range parts {
+			includeColumns[i] = strings.TrimSpace(part)
+			if includeColumns[i] != "" {
+				continue
+			}
+			ctx := s.annotationContext(comment, "//ptah:schema:index", structName)
+			return &ptaherr.ParseError{
+				File:      ctx.file,
+				Line:      ctx.line,
+				Directive: "ptah:schema:index",
+				Attribute: "include",
+				Err:       ptaherr.ErrInvalidAttributeValue,
+				Message: fmt.Sprintf(
+					"invalid include list for \"include\" on //ptah:schema:index at %s: column %d is empty; expected non-empty comma-separated column names",
+					structName,
+					i+1,
+				),
+			}
+		}
+	}
 
 	// Determine target table name - use 'table' attribute if specified, otherwise leave empty for later resolution
 	tableName := kv["table"]
@@ -273,17 +297,18 @@ func (s *schemaParseState) parseIndexComment(comment *ast.Comment, structName st
 	}
 
 	s.schemaIndexes = append(s.schemaIndexes, Index{
-		StructName:    structName,
-		Name:          kv["name"],
-		Fields:        fields,
-		Unique:        kv["unique"] == "true",
-		Comment:       kv["comment"],
-		Type:          kv["type"],                                  // PG: GIN/GIST/BTREE/HASH; CH: minmax/set(N)/bloom_filter/...
-		Condition:     firstNonEmpty(kv["where"], kv["condition"]), // PG/SQLite partial and SQL Server filtered indexes: WHERE clause
-		Operator:      kv["ops"],                                   // PG only: operator class (gin_trgm_ops, etc.)
-		NullsDistinct: parseBoolPtr(kv["nulls_distinct"]),
-		TableName:     tableName,   // Target table name
-		Granularity:   granularity, // CH only: GRANULARITY n for data-skipping indexes
+		StructName:     structName,
+		Name:           kv["name"],
+		Fields:         fields,
+		Unique:         kv["unique"] == "true",
+		Comment:        kv["comment"],
+		Type:           kv["type"],                                  // PG: GIN/GIST/BTREE/HASH; CH: minmax/set(N)/bloom_filter/...
+		Condition:      firstNonEmpty(kv["where"], kv["condition"]), // PG/SQLite partial and SQL Server filtered indexes: WHERE clause
+		Operator:       kv["ops"],                                   // PG only: operator class (gin_trgm_ops, etc.)
+		IncludeColumns: includeColumns,
+		NullsDistinct:  parseBoolPtr(kv["nulls_distinct"]),
+		TableName:      tableName,   // Target table name
+		Granularity:    granularity, // CH only: GRANULARITY n for data-skipping indexes
 	})
 	return nil
 }

--- a/core/goschema/postgresql_features_test.go
+++ b/core/goschema/postgresql_features_test.go
@@ -1,12 +1,14 @@
 package goschema_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/ptaherr"
 )
 
 func TestParseExtensionComment(t *testing.T) {
@@ -136,6 +138,15 @@ func TestParseIndexWithPostgreSQLFeatures(t *testing.T) {
 			},
 		},
 		{
+			name:    "covering index preserves trimmed include order",
+			comment: "//ptah:schema:index name=\"idx_name_covering\" fields=\"name\" include=\" display_name, created_at \"",
+			expected: goschema.Index{
+				Name:           "idx_name_covering",
+				Fields:         []string{"name"},
+				IncludeColumns: []string{"display_name", "created_at"},
+			},
+		},
+		{
 			name:    "cross-table index",
 			comment: "//ptah:schema:index name=\"idx_external\" fields=\"name,status\" table=\"products\"",
 			expected: goschema.Index{
@@ -184,7 +195,53 @@ type TestEntity struct {
 			c.Assert(idx.Type, qt.Equals, tt.expected.Type)
 			c.Assert(idx.Condition, qt.Equals, tt.expected.Condition)
 			c.Assert(idx.Operator, qt.Equals, tt.expected.Operator)
+			c.Assert(idx.IncludeColumns, qt.DeepEquals, tt.expected.IncludeColumns)
 			c.Assert(idx.TableName, qt.Equals, tt.expected.TableName)
+		})
+	}
+}
+
+func TestParseIndexIncludeFailurePath(t *testing.T) {
+	tests := []struct {
+		name          string
+		include       string
+		emptyPosition int
+	}{
+		{name: "empty", include: "", emptyPosition: 1},
+		{name: "whitespace", include: "   ", emptyPosition: 1},
+		{name: "commas", include: ", ,", emptyPosition: 1},
+		{name: "leading comma", include: ",display_name", emptyPosition: 1},
+		{name: "sparse", include: "display_name,,created_at", emptyPosition: 2},
+		{name: "whitespace element", include: "display_name, ,created_at", emptyPosition: 2},
+		{name: "trailing comma", include: "display_name,created_at,", emptyPosition: 3},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			source := `package test
+
+type TestEntity struct {
+	//ptah:schema:index name="idx_name" fields="name" include="` + test.include + `"
+	_ int
+}
+`
+
+			_, err := goschema.ParseSource("index.go", source)
+
+			var parseErr *ptaherr.ParseError
+			c.Assert(err, qt.ErrorAs, &parseErr)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidAttributeValue)
+			c.Assert(parseErr.Directive, qt.Equals, "ptah:schema:index")
+			c.Assert(parseErr.Attribute, qt.Equals, "include")
+			c.Assert(
+				err.Error(),
+				qt.Equals,
+				fmt.Sprintf(
+					`invalid include list for "include" on //ptah:schema:index at TestEntity: column %d is empty; expected non-empty comma-separated column names`,
+					test.emptyPosition,
+				),
+			)
 		})
 	}
 }

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -311,7 +311,8 @@ type Index struct {
 	Condition string
 	// Operator is the operator class (PostgreSQL only, e.g. "gin_trgm_ops").
 	Operator string
-	// IncludeColumns carries PostgreSQL INCLUDE columns for covering indexes.
+	// IncludeColumns carries INCLUDE payload columns for PostgreSQL,
+	// YugabyteDB, and Spanner PostgreSQL-dialect covering indexes.
 	IncludeColumns []string
 	// StorageParams carries PostgreSQL index storage parameters rendered as
 	// WITH (key='value'), for example pages_per_range for BRIN indexes.

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -117,6 +117,11 @@ const (
 	// that already decline CREATE INDEX CONCURRENTLY decline this too.
 	DropIndexConcurrently Capability = "drop_index_concurrently"
 
+	// IndexIncludeSPGiST marks PostgreSQL versions whose SP-GiST access
+	// method accepts INCLUDE payload columns. PostgreSQL added that support in
+	// 14; PostgreSQL 12–13 support INCLUDE only with B-tree and GiST.
+	IndexIncludeSPGiST Capability = "index_include_spgist"
+
 	// Views marks support for the standalone CREATE VIEW ... AS <query>
 	// object.
 	//
@@ -258,6 +263,9 @@ var registry = map[Capability]spec{
 	},
 	DropIndexConcurrently: {
 		doc: "DROP INDEX CONCURRENTLY (PostgreSQL; disabled on the PostgreSQL-compatible presets that do not emit CONCURRENTLY)",
+	},
+	IndexIncludeSPGiST: {
+		doc: "SP-GiST indexes with INCLUDE payload columns (PostgreSQL 14+)",
 	},
 	Views: {
 		doc: "standalone CREATE VIEW ... AS <query> objects",
@@ -451,6 +459,7 @@ func MySQL84() Capabilities {
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
 		DropIndexConcurrently:              false,
+		IndexIncludeSPGiST:                 false,
 		Views:                              true,
 		MaterializedViews:                  false,
 		Functions:                          true,
@@ -512,6 +521,7 @@ func MariaDB1011() Capabilities {
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
 		DropIndexConcurrently:              false,
+		IndexIncludeSPGiST:                 false,
 		Views:                              true,
 		MaterializedViews:                  false,
 		Functions:                          true,
@@ -570,6 +580,7 @@ func Postgres16() Capabilities {
 		EnumCustomType:                     true,
 		CreateIndexConcurrently:            true,
 		DropIndexConcurrently:              true,
+		IndexIncludeSPGiST:                 true,
 		Views:                              true,
 		MaterializedViews:                  true,
 		Functions:                          true,
@@ -593,10 +604,13 @@ func Postgres17() Capabilities {
 	return Postgres16().With(AlterGeneratedColumnExpression, true)
 }
 
-// Postgres13 is the preset for PostgreSQL 12–13: identical to Postgres16
-// except CREATE OR REPLACE TRIGGER, which arrived in PostgreSQL 14.
+// Postgres13 is the preset for PostgreSQL 12–13: unlike Postgres16 it lacks
+// CREATE OR REPLACE TRIGGER and SP-GiST INCLUDE columns, which both arrived in
+// PostgreSQL 14.
 func Postgres13() Capabilities {
-	return Postgres16().With(CreateOrReplaceTrigger, false)
+	return Postgres16().
+		With(CreateOrReplaceTrigger, false).
+		With(IndexIncludeSPGiST, false)
 }
 
 // ClickHouse24 is the preset for the ClickHouse 24.x line. It is deliberately
@@ -629,6 +643,7 @@ func ClickHouse24() Capabilities {
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
 		DropIndexConcurrently:              false,
+		IndexIncludeSPGiST:                 false,
 		Views:                              true,
 		MaterializedViews:                  true,
 		Functions:                          false,
@@ -668,6 +683,7 @@ func SQLite3() Capabilities {
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
 		DropIndexConcurrently:              false,
+		IndexIncludeSPGiST:                 false,
 		Views:                              true,
 		MaterializedViews:                  false,
 		Functions:                          false,
@@ -709,6 +725,7 @@ func SQLServer2022() Capabilities {
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
 		DropIndexConcurrently:              false,
+		IndexIncludeSPGiST:                 false,
 		Views:                              true,
 		MaterializedViews:                  false,
 		Functions:                          true,
@@ -758,6 +775,7 @@ func CockroachDB23() Capabilities {
 	return Postgres16().
 		With(CreateIndexConcurrently, false).
 		With(DropIndexConcurrently, false).
+		With(IndexIncludeSPGiST, false).
 		With(XMLType, false).
 		With(AdvisoryLocks, false)
 }
@@ -777,7 +795,9 @@ func CockroachDB23() Capabilities {
 // The same probe accepted advisory lock/unlock calls and row-level security
 // policy DDL, matching the enabled keys below.
 func YugabyteDB25() Capabilities {
-	return Postgres16().With(DropIndexConcurrently, false)
+	return Postgres16().
+		With(DropIndexConcurrently, false).
+		With(IndexIncludeSPGiST, false)
 }
 
 // SpannerPostgres is the conservative preset for Cloud Spanner's PostgreSQL
@@ -808,6 +828,7 @@ func SpannerPostgres() Capabilities {
 		With(EnumCustomType, false).
 		With(CreateIndexConcurrently, false).
 		With(DropIndexConcurrently, false).
+		With(IndexIncludeSPGiST, false).
 		With(MaterializedViews, false).
 		With(Functions, false).
 		With(Triggers, false).

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -173,10 +173,12 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(capability.MySQL84().Has(capability.DropConstraintGeneric), qt.IsTrue)
 	c.Assert(capability.MySQL8016().Has(capability.DropConstraintGeneric), qt.IsFalse)
 	c.Assert(capability.MySQL8016().Has(capability.CheckConstraintsEnforced), qt.IsTrue)
+	c.Assert(capability.Postgres13().Has(capability.IndexIncludeSPGiST), qt.IsFalse)
+	c.Assert(capability.Postgres16().Has(capability.IndexIncludeSPGiST), qt.IsTrue)
 	c.Assert(capability.MySQLLegacy().Has(capability.CheckConstraintsEnforced), qt.IsFalse)
 
-	// Postgres version presets gate CREATE OR REPLACE TRIGGER (PG 14+) and
-	// generated-column SET EXPRESSION (PG 17+).
+	// Postgres version presets gate CREATE OR REPLACE TRIGGER and SP-GiST
+	// INCLUDE (PG 14+), plus generated-column SET EXPRESSION (PG 17+).
 	c.Assert(capability.Postgres17().Has(capability.AlterGeneratedColumnExpression), qt.IsTrue)
 	c.Assert(capability.Postgres16().Has(capability.AlterGeneratedColumnExpression), qt.IsFalse)
 	c.Assert(capability.Postgres16().Has(capability.CreateOrReplaceTrigger), qt.IsTrue)
@@ -214,6 +216,7 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(cockroach.Has(capability.EnumCustomType), qt.IsTrue)
 	c.Assert(cockroach.Has(capability.ForeignKeys), qt.IsTrue)
 	c.Assert(cockroach.Has(capability.CreateIndexConcurrently), qt.IsFalse)
+	c.Assert(cockroach.Has(capability.IndexIncludeSPGiST), qt.IsFalse)
 	c.Assert(cockroach.Has(capability.XMLType), qt.IsFalse)
 	c.Assert(cockroach.Has(capability.AdvisoryLocks), qt.IsFalse)
 	c.Assert(cockroach.Has(capability.RoleManagement), qt.IsTrue)
@@ -225,12 +228,14 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(yugabyte.Has(capability.ForeignKeys), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.CreateIndexConcurrently), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.DropIndexConcurrently), qt.IsFalse)
+	c.Assert(yugabyte.Has(capability.IndexIncludeSPGiST), qt.IsFalse)
 	c.Assert(yugabyte.Has(capability.RoleManagement), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.RowLevelSecurity), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.Sequences), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.AdvisoryLocks), qt.IsTrue)
 
 	spanner := capability.SpannerPostgres()
+	c.Assert(spanner.Has(capability.IndexIncludeSPGiST), qt.IsFalse)
 	c.Assert(spanner.Has(capability.EnumCustomType), qt.IsFalse)
 	c.Assert(spanner.Has(capability.ForeignKeys), qt.IsTrue)
 	c.Assert(spanner.Has(capability.ForeignKeysCreateBackingIndex), qt.IsTrue)

--- a/core/renderer/circular_dependencies_test.go
+++ b/core/renderer/circular_dependencies_test.go
@@ -644,7 +644,7 @@ func TestRenderSQL_TypedNilGenericASTNode_FailurePath(t *testing.T) {
 	sql, err := renderer.RenderSQL("postgres", index)
 
 	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
-	c.Assert(err, qt.ErrorMatches, "invalid foreign key: AST node is nil")
+	c.Assert(err, qt.ErrorMatches, "index node is nil")
 	c.Assert(sql, qt.Equals, "")
 }
 

--- a/core/renderer/index_include_validation_test.go
+++ b/core/renderer/index_include_validation_test.go
@@ -92,6 +92,46 @@ func TestIndexIncludeUnsupportedDialectsFailClosed(t *testing.T) {
 	}
 }
 
+func TestIndexIncludeVisitorPathFailsClosedAndResetsOutput(t *testing.T) {
+	c := qt.New(t)
+	r, err := renderer.NewRenderer(platform.MySQL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ast.NewIndex("idx_seed", "accounts", "email").Accept(r), qt.IsNil)
+	c.Assert(r.Output(), qt.Not(qt.Equals), "")
+
+	err = indexIncludeNode("").Accept(r)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(r.Output(), qt.Equals, "")
+}
+
+func TestIndexIncludeVisitorPathRendersSupportedDialect(t *testing.T) {
+	c := qt.New(t)
+	r, err := renderer.NewRenderer(platform.Postgres)
+	c.Assert(err, qt.IsNil)
+
+	err = indexIncludeNode("GIST").Accept(r)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(r.Output(), qt.Contains, `USING GIST ("email") INCLUDE ("display_name");`)
+}
+
+func TestIndexIncludeVisitorPathDelegateFailureResetsOutput(t *testing.T) {
+	c := qt.New(t)
+	r, err := renderer.NewRenderer(platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ast.NewIndex("idx_seed", "accounts", "email").Accept(r), qt.IsNil)
+	c.Assert(r.Output(), qt.Not(qt.Equals), "")
+
+	nullsDistinct := true
+	invalid := indexIncludeNode("")
+	invalid.NullsDistinct = &nullsDistinct
+	err = invalid.Accept(r)
+
+	c.Assert(err, qt.ErrorMatches, "postgresql NULLS DISTINCT is only valid for unique indexes")
+	c.Assert(r.Output(), qt.Equals, "")
+}
+
 func TestIndexIncludeYugabyteBTREEAliasMatchesDefaultLSM(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/index_include_validation_test.go
+++ b/core/renderer/index_include_validation_test.go
@@ -1,0 +1,275 @@
+package renderer_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/core/ptaherr"
+	"go.5x5.cz/ptah/core/renderer"
+)
+
+func TestIndexIncludeSupportedDialects(t *testing.T) {
+	tests := []struct {
+		name     string
+		dialect  string
+		method   string
+		usingSQL string
+	}{
+		{name: "postgres default", dialect: platform.Postgres},
+		{name: "postgres btree", dialect: platform.Postgres, method: "BTREE"},
+		{name: "postgres gist", dialect: platform.Postgres, method: "GIST", usingSQL: " USING GIST"},
+		{name: "postgres spgist", dialect: platform.Postgres, method: "SPGIST", usingSQL: " USING SPGIST"},
+		{name: "yugabytedb default", dialect: platform.YugabyteDB},
+		{name: "yugabytedb lsm", dialect: platform.YugabyteDB, method: "LSM", usingSQL: " USING LSM"},
+		{name: "yugabytedb btree", dialect: platform.YugabyteDB, method: "BTREE"},
+		{name: "spanner default", dialect: platform.Spanner},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			statements, err := renderer.GetOrderedCreateStatements(indexIncludeSchema(test.method), test.dialect)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(
+				strings.Join(statements, "\n"),
+				qt.Contains,
+				test.usingSQL+` ("email") INCLUDE ("display_name");`,
+			)
+
+			sql, err := renderer.RenderSQL(test.dialect, indexIncludeNode(test.method))
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Contains, test.usingSQL+` ("email") INCLUDE ("display_name");`)
+		})
+	}
+}
+
+func TestIndexIncludeUnsupportedDialectsFailClosed(t *testing.T) {
+	dialects := []string{
+		platform.CockroachDB,
+		platform.MySQL,
+		platform.MariaDB,
+		platform.SQLite,
+		platform.ClickHouse,
+		platform.SQLServer,
+	}
+
+	for _, dialect := range dialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			statements, err := renderer.GetOrderedCreateStatements(indexIncludeSchema(""), dialect)
+
+			c.Assert(statements, qt.IsNil)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				fmt.Sprintf(
+					`%s does not support INCLUDE columns on index "idx_accounts_email"; target postgres, yugabytedb, or spanner`,
+					dialect,
+				),
+			)
+			var capabilityErr *ptaherr.CapabilityError
+			c.Assert(err, qt.ErrorAs, &capabilityErr)
+			c.Assert(capabilityErr.Feature, qt.Equals, "index INCLUDE columns")
+
+			sql, directErr := renderer.RenderSQL(dialect, indexIncludeNode(""))
+
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(directErr, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(directErr.Error(), qt.Equals, err.Error())
+		})
+	}
+}
+
+func TestIndexIncludeYugabyteBTREEAliasMatchesDefaultLSM(t *testing.T) {
+	c := qt.New(t)
+
+	defaultStatements, err := renderer.GetOrderedCreateStatements(indexIncludeSchema(""), platform.YugabyteDB)
+	c.Assert(err, qt.IsNil)
+	btreeStatements, err := renderer.GetOrderedCreateStatements(indexIncludeSchema("BTREE"), platform.YugabyteDB)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(btreeStatements, qt.DeepEquals, defaultStatements)
+	c.Assert(strings.Join(btreeStatements, "\n"), qt.Not(qt.Contains), "USING BTREE")
+
+	defaultSQL, err := renderer.RenderSQL(platform.YugabyteDB, indexIncludeNode(""))
+	c.Assert(err, qt.IsNil)
+	btreeSQL, err := renderer.RenderSQL(platform.YugabyteDB, indexIncludeNode("BTREE"))
+	c.Assert(err, qt.IsNil)
+	lsmSQL, err := renderer.RenderSQL(platform.YugabyteDB, indexIncludeNode("LSM"))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(btreeSQL, qt.Equals, defaultSQL)
+	c.Assert(btreeSQL, qt.Not(qt.Contains), "USING BTREE")
+	c.Assert(lsmSQL, qt.Contains, `USING LSM ("email") INCLUDE ("display_name")`)
+}
+
+func TestIndexIncludeUnsupportedAccessMethodsFailClosed(t *testing.T) {
+	tests := []struct {
+		name      string
+		dialect   string
+		method    string
+		supported string
+	}{
+		{name: "postgres gin", dialect: platform.Postgres, method: "GIN", supported: "the default, BTREE, GIST, or SPGIST access method"},
+		{name: "postgres hash", dialect: platform.Postgres, method: "HASH", supported: "the default, BTREE, GIST, or SPGIST access method"},
+		{name: "postgres brin", dialect: platform.Postgres, method: "BRIN", supported: "the default, BTREE, GIST, or SPGIST access method"},
+		{name: "yugabytedb gist", dialect: platform.YugabyteDB, method: "GIST", supported: "the default, LSM, or BTREE access method"},
+		{name: "yugabytedb spgist", dialect: platform.YugabyteDB, method: "SPGIST", supported: "the default, LSM, or BTREE access method"},
+		{name: "yugabytedb gin", dialect: platform.YugabyteDB, method: "GIN", supported: "the default, LSM, or BTREE access method"},
+		{name: "spanner btree", dialect: platform.Spanner, method: "BTREE", supported: "the default access method"},
+		{name: "spanner lsm", dialect: platform.Spanner, method: "LSM", supported: "the default access method"},
+		{name: "spanner gist", dialect: platform.Spanner, method: "GIST", supported: "the default access method"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			normalizedMethod := strings.ToUpper(strings.TrimSpace(test.method))
+
+			statements, err := renderer.GetOrderedCreateStatements(indexIncludeSchema(test.method), test.dialect)
+
+			c.Assert(statements, qt.IsNil)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				fmt.Sprintf(
+					`%s INCLUDE columns on index "idx_accounts_email" require %s; access method %q is not supported`,
+					test.dialect,
+					test.supported,
+					normalizedMethod,
+				),
+			)
+
+			sql, directErr := renderer.RenderSQL(test.dialect, indexIncludeNode(test.method))
+
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(directErr, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(directErr.Error(), qt.Equals, err.Error())
+		})
+	}
+}
+
+func TestIndexIncludeWhitespacePaddedAccessMethodsFailClosed(t *testing.T) {
+	for _, method := range []string{"   ", " GIST", "GIST "} {
+		t.Run(fmt.Sprintf("%q", method), func(t *testing.T) {
+			c := qt.New(t)
+
+			statements, err := renderer.GetOrderedCreateStatements(indexIncludeSchema(method), platform.Postgres)
+
+			c.Assert(statements, qt.IsNil)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				fmt.Sprintf(`index "idx_accounts_email" access method %q has leading or trailing whitespace`, method),
+			)
+
+			sql, directErr := renderer.RenderSQL(platform.Postgres, indexIncludeNode(method))
+
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(directErr, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(directErr.Error(), qt.Equals, err.Error())
+		})
+	}
+}
+
+func TestIndexIncludeSPGiSTPostgres13FailsClosed(t *testing.T) {
+	c := qt.New(t)
+	caps := capability.Postgres13()
+
+	statements, schemaErr := renderer.GetOrderedCreateStatementsWithCapabilities(
+		indexIncludeSchema("SPGIST"),
+		platform.Postgres,
+		caps,
+	)
+	sql, directErr := renderer.RenderSQLWithCapabilities(
+		platform.Postgres,
+		caps,
+		indexIncludeNode("SPGIST"),
+	)
+
+	c.Assert(statements, qt.IsNil)
+	c.Assert(schemaErr, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(
+		schemaErr,
+		qt.ErrorMatches,
+		`postgres INCLUDE columns on index "idx_accounts_email" require `+
+			`the default, BTREE, or GIST access method; access method "SPGIST" is not supported`,
+	)
+	c.Assert(sql, qt.Equals, "")
+	c.Assert(directErr, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(directErr.Error(), qt.Equals, schemaErr.Error())
+}
+
+func TestIndexIncludeSPGiSTPostgres14AndNewer(t *testing.T) {
+	c := qt.New(t)
+	caps := capability.Postgres16()
+
+	statements, schemaErr := renderer.GetOrderedCreateStatementsWithCapabilities(
+		indexIncludeSchema("SPGIST"),
+		platform.Postgres,
+		caps,
+	)
+	sql, directErr := renderer.RenderSQLWithCapabilities(
+		platform.Postgres,
+		caps,
+		indexIncludeNode("SPGIST"),
+	)
+
+	c.Assert(schemaErr, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, `USING SPGIST ("email") INCLUDE ("display_name")`)
+	c.Assert(directErr, qt.IsNil)
+	c.Assert(sql, qt.Contains, `USING SPGIST ("email") INCLUDE ("display_name")`)
+}
+
+func TestIndexIncludeEmptyModelColumnFailsClosed(t *testing.T) {
+	c := qt.New(t)
+	database := indexIncludeSchema("")
+	database.Indexes[0].IncludeColumns = []string{"display_name", " "}
+
+	statements, err := renderer.GetOrderedCreateStatements(database, platform.Postgres)
+
+	c.Assert(statements, qt.IsNil)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `index "idx_accounts_email" has an empty INCLUDE column at position 2`)
+}
+
+func indexIncludeSchema(method string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Account", Name: "accounts"}},
+		Fields: []goschema.Field{
+			{StructName: "Account", Name: "email", Type: "TEXT"},
+			{StructName: "Account", Name: "display_name", Type: "TEXT"},
+		},
+		Indexes: []goschema.Index{{
+			StructName:     "Account",
+			Name:           "idx_accounts_email",
+			Fields:         []string{"email"},
+			Type:           method,
+			IncludeColumns: []string{"display_name"},
+		}},
+	}
+}
+
+func indexIncludeNode(method string) *ast.IndexNode {
+	return &ast.IndexNode{
+		Name:           "idx_accounts_email",
+		Table:          "accounts",
+		Columns:        []string{"email"},
+		Type:           method,
+		IncludeColumns: []string{"display_name"},
+	}
+}

--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -314,12 +314,28 @@ func prepareASTNodeForRendering(
 		return prepareConstraintNode(dialect, caps, typed)
 	case *ast.ColumnNode:
 		return prepareColumnNode(dialect, caps, typed)
+	case *ast.IndexNode:
+		return prepareIndexNode(dialect, caps, typed)
 	default:
 		if isNilInterface(node) {
 			return nil, invalidASTForeignKeyError(dialect, "AST node is nil")
 		}
 		return node, nil
 	}
+}
+
+func prepareIndexNode(dialect string, caps capability.Capabilities, node *ast.IndexNode) (*ast.IndexNode, error) {
+	if node == nil {
+		return nil, &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrInvalidSchemaDiff,
+			Message: "index node is nil",
+		}
+	}
+	if err := validateIndexInclude(dialect, caps, node.Name, node.Type, node.IncludeColumns); err != nil {
+		return nil, err
+	}
+	return node, nil
 }
 
 func prepareStatementListNode(
@@ -788,6 +804,9 @@ func prepareDatabaseForRendering(
 			Message: err.Error(),
 		}
 	}
+	if err := validateDeclaredIndexIncludes(dialect, caps, database.Indexes); err != nil {
+		return goschema.Database{}, err
+	}
 
 	prepared := *database
 	prepared.Tables = slices.Clone(database.Tables)
@@ -855,6 +874,102 @@ func prepareDatabaseForRendering(
 		makeMySQLForeignKeyTableEnginesExplicit(&prepared, dialect)
 	}
 	return prepared, nil
+}
+
+func validateDeclaredIndexIncludes(
+	dialect string,
+	caps capability.Capabilities,
+	indexes []goschema.Index,
+) error {
+	for _, index := range indexes {
+		if err := validateIndexInclude(dialect, caps, index.Name, index.Type, index.IncludeColumns); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateIndexInclude(
+	dialect string,
+	caps capability.Capabilities,
+	indexName, indexType string,
+	includeColumns []string,
+) error {
+	if len(includeColumns) == 0 {
+		return nil
+	}
+	for i, column := range includeColumns {
+		if strings.TrimSpace(column) != "" {
+			continue
+		}
+		return &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrInvalidSchemaDiff,
+			Message: fmt.Sprintf("index %q has an empty INCLUDE column at position %d", indexName, i+1),
+		}
+	}
+	trimmedIndexType := strings.TrimSpace(indexType)
+	if trimmedIndexType != indexType {
+		return &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrInvalidSchemaDiff,
+			Message: fmt.Sprintf(
+				"index %q access method %q has leading or trailing whitespace",
+				indexName,
+				indexType,
+			),
+		}
+	}
+
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	switch normalizedDialect {
+	case platform.Postgres, platform.YugabyteDB, platform.Spanner:
+	default:
+		return &ptaherr.CapabilityError{
+			Dialect: dialect,
+			Feature: "index INCLUDE columns",
+			Err:     ptaherr.ErrUnsupportedFeature,
+			Message: fmt.Sprintf(
+				"%s does not support INCLUDE columns on index %q; target postgres, yugabytedb, or spanner",
+				normalizedDialect,
+				indexName,
+			),
+		}
+	}
+
+	method := strings.ToUpper(trimmedIndexType)
+	var allowed bool
+	var supportedMethods string
+	switch normalizedDialect {
+	case platform.Postgres:
+		allowed = method == "" || method == "BTREE" || method == "GIST" ||
+			(method == "SPGIST" && caps.Has(capability.IndexIncludeSPGiST))
+		supportedMethods = "the default, BTREE, or GIST access method"
+		if caps.Has(capability.IndexIncludeSPGiST) {
+			supportedMethods = "the default, BTREE, GIST, or SPGIST access method"
+		}
+	case platform.YugabyteDB:
+		allowed = method == "" || method == "LSM" || method == "BTREE"
+		supportedMethods = "the default, LSM, or BTREE access method"
+	case platform.Spanner:
+		allowed = method == ""
+		supportedMethods = "the default access method"
+	}
+	if allowed {
+		return nil
+	}
+	return &ptaherr.CapabilityError{
+		Dialect: dialect,
+		Feature: "index INCLUDE access method",
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: fmt.Sprintf(
+			"%s INCLUDE columns on index %q require %s; access method %q is not supported",
+			normalizedDialect,
+			indexName,
+			supportedMethods,
+			method,
+		),
+	}
 }
 
 func makeMySQLForeignKeyTableEnginesExplicit(database *goschema.Database, dialect string) {

--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -231,6 +231,19 @@ func (r *validatingRenderer) VisitConstraint(node *ast.ConstraintNode) error {
 	return nil
 }
 
+func (r *validatingRenderer) VisitIndex(node *ast.IndexNode) error {
+	prepared, err := prepareIndexNode(r.dialect, r.capabilities, node)
+	if err != nil {
+		r.Reset()
+		return err
+	}
+	if err := r.RenderVisitor.VisitIndex(prepared); err != nil {
+		r.Reset()
+		return err
+	}
+	return nil
+}
+
 // RenderSQL is a convenience function that creates a renderer and renders an AST node in one call.
 //
 // This function is useful for one-off SQL generation where you don't need to reuse the renderer.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -90,6 +90,7 @@ so typos fail fast. Current registry:
 | `enum_custom_type` | Enums are separate named types (PostgreSQL `CREATE TYPE … AS ENUM`) |
 | `create_index_concurrently` | `CREATE [UNIQUE] INDEX CONCURRENTLY` (PostgreSQL; a compatibility no-op on CockroachDB) |
 | `drop_index_concurrently` | `DROP INDEX CONCURRENTLY` (PostgreSQL; disabled on the PostgreSQL-compatible presets that do not emit `CONCURRENTLY`) |
+| `index_include_spgist` | `SPGIST` indexes with `INCLUDE` payload columns (PostgreSQL 14+) |
 | `views` | Standalone `CREATE VIEW … AS <query>` objects |
 | `materialized_views` | `CREATE MATERIALIZED VIEW`: a view whose query result is stored. Requires `views` |
 | `functions` | User-defined functions declared with a return type, a language, and a body |
@@ -140,6 +141,7 @@ composed sets yourself.
 | `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | `drop_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `index_include_spgist` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `views` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `materialized_views` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | `functions` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ |
@@ -162,7 +164,7 @@ older. `MariaDB1011()` covers the
 supported MariaDB lines (10.6+/11.x); `MariaDBLegacy()` is the conservative
 floor `ForServerVersion` assigns to pre-10.2 servers. `Postgres17()` covers
 PostgreSQL 17; `Postgres16()` covers 14–16; `Postgres13()` covers 12–13 (no
-`CREATE OR REPLACE TRIGGER`).
+`CREATE OR REPLACE TRIGGER` and no `SPGIST` indexes with `INCLUDE` columns).
 
 `CockroachDB23()` and `YugabyteDB25()` are PostgreSQL-family presets for the
 common distributed-SQL subset; `SpannerPostgres()` is deliberately
@@ -253,6 +255,11 @@ planner := mysql.NewWithCapabilities(caps)
 ```
 
 `With` copies — presets are never mutated.
+
+`capability.IndexIncludeSPGiST` distinguishes PostgreSQL 14 and newer from
+PostgreSQL 12–13 when rendering `SPGIST` indexes with `INCLUDE` payload
+columns. Whole-schema and direct-AST rendering consume the same resolved key,
+so a PostgreSQL 13 connection refuses that syntax before emitting SQL.
 
 ### Resolving a preset
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -664,8 +664,8 @@ comment is not one of the four: it is a relation-level attribute like
 through, and that criterion has a fifth surface the list above does not name:
 Ptah's own Go annotation surface. `//ptah:schema:index` parses `name`,
 `fields`/`columns`, `table`, `unique`, `comment`, `type`, `where`/`condition`,
-`ops`, `nulls_distinct` and `granularity` — no storage parameters, and no
-`include` either.
+`ops`, `include`, `nulls_distinct` and `granularity` — but no storage
+parameters.
 
 The consequence is measured. Against a database holding
 `CREATE INDEX i ON t USING brin (ts) WITH (pages_per_range = 32)`, a model
@@ -676,13 +676,15 @@ DROP INDEX IF EXISTS "i";
 CREATE INDEX IF NOT EXISTS "i" ON "t" USING BRIN ("ts");
 ```
 
-which drops the parameter. This is a pre-existing class rather than a new one:
-with the storage-parameter comparison removed, the identical plan is produced
-for `CREATE INDEX i ON t (a) INCLUDE (b)` against a model declaring
-`//ptah:schema:index name="i" fields="a"` — measured, both on PostgreSQL 17.10.
-Closing the class means adding index attributes to the annotation surface for
-everything the HCL surface can already say, which is its own change and is not
-attempted here.
+which drops the parameter. `include` is no longer part of this loss class: a
+model can declare `include="b"`, and PostgreSQL, YugabyteDB, and the Spanner
+PostgreSQL dialect preserve it as `INCLUDE ("b")`. Validation refuses
+CockroachDB and other dialects rather than dropping the payload. It also limits
+methods to default/`BTREE`/`GIST` on PostgreSQL 12–13, adds `SPGIST` on
+PostgreSQL 14 and newer, and accepts default/`LSM` on YugabyteDB. YugabyteDB's
+documented `BTREE` alias renders identically to its default LSM. Spanner accepts
+only the default. Closing the remaining class means adding a storage-parameter
+attribute to the annotation surface, which is not attempted here.
 
 ### The access-method loss was not silent in general
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -2369,7 +2369,8 @@ type IndexNode struct {
     Condition string
     // Operator specifies the operator class (gin_trgm_ops, etc.)
     Operator string
-    // IncludeColumns contains PostgreSQL INCLUDE columns for covering indexes.
+    // IncludeColumns contains INCLUDE payload columns for PostgreSQL,
+    // YugabyteDB, and Spanner PostgreSQL-dialect covering indexes.
     IncludeColumns []string
     // StorageParams contains PostgreSQL index storage parameters rendered as
     // WITH (key='value'), for example pages_per_range for BRIN indexes.
@@ -4236,7 +4237,8 @@ type Index struct {
     Condition string
     // Operator is the operator class (PostgreSQL only, e.g. "gin_trgm_ops").
     Operator string
-    // IncludeColumns carries PostgreSQL INCLUDE columns for covering indexes.
+    // IncludeColumns carries INCLUDE payload columns for PostgreSQL,
+    // YugabyteDB, and Spanner PostgreSQL-dialect covering indexes.
     IncludeColumns []string
     // StorageParams carries PostgreSQL index storage parameters rendered as
     // WITH (key='value'), for example pages_per_range for BRIN indexes.

--- a/docs/site/src/content/docs/reference/capabilities.md
+++ b/docs/site/src/content/docs/reference/capabilities.md
@@ -22,6 +22,8 @@ Capabilities answer questions that a dialect name alone cannot answer:
   `enum_inline_column`, `enum_custom_type`
 - Can PostgreSQL-style concurrent indexes be emitted?
   `create_index_concurrently`, `drop_index_concurrently`
+- Can PostgreSQL emit `SPGIST` indexes with `INCLUDE` payload columns?
+  `index_include_spgist`
 - Does the target support roles, RLS, XML, or advisory locks?
   `role_management`, `row_level_security`, `xml_type`, `advisory_locks`
 - Which schema objects can this target host?
@@ -95,6 +97,11 @@ names are shortened deterministically before collision checks.
 The Go API exposes `capability.DefaultDialects()` for guards and UIs that must
 cover every normalized dialect with a default `capability.ForDialect` preset
 without maintaining a second list.
+
+`capability.IndexIncludeSPGiST` records PostgreSQL's version boundary for
+`SPGIST` indexes with `INCLUDE` payload columns. It is disabled for PostgreSQL
+12–13 and enabled for PostgreSQL 14 and newer; whole-schema and direct-AST
+rendering both consume the resolved key and fail closed on older servers.
 
 ## Declarative database testing
 

--- a/docs/site/src/content/docs/reference/go-annotations.md
+++ b/docs/site/src/content/docs/reference/go-annotations.md
@@ -185,6 +185,7 @@ Declares an index for a table.
 | `condition` | No | Partial index condition. |
 | `fields` | No | Comma-separated Go field or column names. |
 | `granularity` | No | ClickHouse data-skipping index granularity. |
+| `include` | No | Comma-separated INCLUDE columns for PostgreSQL, YugabyteDB, or the Spanner PostgreSQL dialect. Order is preserved. |
 | `name` | No | Index name. |
 | `nulls_distinct` | No | Controls NULLS DISTINCT behavior where supported. `true`/`false`. |
 | `ops` | No | PostgreSQL operator class. |
@@ -192,6 +193,17 @@ Declares an index for a table.
 | `type` | No | Index type or method. |
 | `unique` | No | Creates a unique index. `true`/`false`; bare form allowed. |
 | `where` | No | Atlas-style partial index condition alias. |
+
+Omit `include` when the index has no payload columns. A present value with any
+empty element fails parsing instead of silently removing that element. This
+includes empty, whitespace-only, comma-only, sparse, and trailing-comma lists.
+
+The accepted access methods depend on the target: PostgreSQL accepts the
+default, `BTREE`, and `GIST`, plus `SPGIST` on PostgreSQL 14 and newer;
+YugabyteDB accepts the default and `LSM`, with `BTREE` normalized to its
+documented default-LSM alias; and the Spanner PostgreSQL dialect accepts only
+the default. CockroachDB and every other dialect reject `include` before
+emitting SQL.
 
 ### `//ptah:schema:constraint`
 

--- a/docs/site/src/content/docs/schema/go-annotations.md
+++ b/docs/site/src/content/docs/schema/go-annotations.md
@@ -85,6 +85,27 @@ attempts the built-in review targets and emits separate labeled sections only
 if every target can render the schema. Any unsupported feature fails atomically
 with empty standard output.
 
+### Add an INCLUDE covering index
+
+Use `include` to keep payload columns in a covering index without making them
+search keys. Ptah preserves the comma-separated order after trimming whitespace:
+
+```go
+type AccountIndexes struct {
+	//ptah:schema:index name="idx_accounts_email" fields="email" include="display_name,created_at" table="accounts"
+	_ int
+}
+```
+
+For PostgreSQL, YugabyteDB, and the Spanner PostgreSQL dialect, the annotation
+renders `INCLUDE ("display_name", "created_at")`. PostgreSQL accepts the
+default, `BTREE`, and `GIST` access methods, plus `SPGIST` on PostgreSQL 14 and
+newer. YugabyteDB accepts the default and `LSM`; `BTREE` is its documented
+alias for the default LSM and renders identically to the default. The Spanner
+PostgreSQL dialect accepts only the default. CockroachDB and every other
+dialect reject `include` before emitting SQL. Omit `include` when there are no
+payload columns; a present list with an empty element is a parse error.
+
 ## Compare before changing data
 
 For an existing database, inspect and compare first:

--- a/internal/annotationmeta/meta.go
+++ b/internal/annotationmeta/meta.go
@@ -354,6 +354,14 @@ var directives = []Directive{
 			attr("name", "Index name.", valueString, false, false),
 			attr("fields", "Comma-separated Go field or column names.", valueList, false, false),
 			alias("columns", "fields", "Legacy synonym for fields.", valueList, false),
+			attr(
+				"include",
+				"Comma-separated INCLUDE columns for covering indexes (PostgreSQL: default/BTREE/GIST, plus SPGIST on 14+; "+
+					"YugabyteDB: default/LSM, with BTREE as the default-LSM alias; Spanner PostgreSQL dialect: default only).",
+				valueList,
+				false,
+				false,
+			),
 			attr("unique", "Creates a unique index.", valueBoolean, false, true),
 			attr("comment", "Index comment.", valueString, false, false),
 			attr("type", "Index type or method.", valueString, false, false),

--- a/internal/annotationmeta/meta_test.go
+++ b/internal/annotationmeta/meta_test.go
@@ -46,6 +46,12 @@ func TestAllowsAttribute_AcceptsRetainedPlatformOverrides(t *testing.T) {
 	}
 }
 
+func TestAllowsAttribute_AcceptsIndexInclude(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(annotationmeta.AllowsAttribute("ptah:schema:index", "include"), qt.IsTrue)
+}
+
 func TestAllowsAttribute_RejectsDroppedCompatibilitySyntax(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/annotationschema/schema_test.go
+++ b/internal/annotationschema/schema_test.go
@@ -84,3 +84,26 @@ func TestGenerateOmitsDroppedAnnotationSyntax(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateIncludesIndexCoveringColumns(t *testing.T) {
+	c := qt.New(t)
+
+	generated, err := annotationschema.Generate()
+	c.Assert(err, qt.IsNil)
+
+	var doc map[string]any
+	c.Assert(json.Unmarshal(generated, &doc), qt.IsNil)
+	defs := doc["$defs"].(map[string]any)
+	index := defs["ptah.schema.index"].(map[string]any)
+	indexContainer := index["properties"].(map[string]any)
+	indexAttributes := indexContainer["attributes"].(map[string]any)
+	indexProperties := indexAttributes["properties"].(map[string]any)
+	include := indexProperties["include"].(map[string]any)
+
+	c.Assert(include["type"], qt.Equals, "string")
+	c.Assert(
+		include["description"],
+		qt.Equals,
+		"Comma-separated INCLUDE columns for covering indexes (PostgreSQL: default/BTREE/GIST, plus SPGIST on 14+; YugabyteDB: default/LSM, with BTREE as the default-LSM alias; Spanner PostgreSQL dialect: default only).",
+	)
+}

--- a/internal/capabilityprobe/doc.go
+++ b/internal/capabilityprobe/doc.go
@@ -21,7 +21,7 @@
 // row must not read as a probe that passed every row.
 //
 // It fails a run that decided LESS THAN ITS PLAN PROMISED for the same reason.
-// A floor of one row is barely a floor: twenty-three of twenty-four could go
+// A floor of one row is barely a floor: twenty-four of twenty-five could go
 // quietly unmeasured and the run would still exit zero. [Report.Decidable]
 // counts the keys the dialect's plan did not declare undecidable in advance —
 // derived from the plan, not written down per dialect, because a hand-kept
@@ -32,7 +32,7 @@
 //
 // # Why the deciding statement is not always the obvious one
 //
-// Four shapes of statement decide nothing on their own, and each of them was
+// Five shapes of statement decide nothing on their own, and each of them was
 // measured rather than assumed:
 //
 //   - Acceptance without enforcement. MySQL before 8.0.16 accepted a CHECK
@@ -49,6 +49,12 @@
 //     CONCURRENTLY without changing behavior. Real PostgreSQL refuses that
 //     statement inside an explicit transaction block and a keyword-only parser
 //     has no reason to, so the transaction block is the discriminator.
+//   - Acceptance of index syntax a server rewrites or drops. The SP-GiST
+//     INCLUDE probe reads the created index back from the server catalog and
+//     requires one SP-GiST key plus one non-key included column; accepting the
+//     statement without that exact shape is false, not support. A
+//     MySQL-family acceptance stays undecidable because its catalog cannot
+//     portably prove the distinction between key and included columns.
 //   - Acceptance of a same-spelled feature that is a different surface. MySQL
 //     9.7.1 accepts CREATE ROLE and GRANT while [capability.RoleManagement] is
 //     false for it, because that key names the PostgreSQL role surface Ptah's

--- a/internal/capabilityprobe/experiment.go
+++ b/internal/capabilityprobe/experiment.go
@@ -36,7 +36,7 @@ type decider func(ctx context.Context, s *session) (verdicts, []Attempt)
 
 // experiment is one measurement against a live server.
 //
-// It is not "one capability, one statement". Three of the twenty-four keys are
+// It is not "one capability, one statement". Three of the twenty-five keys are
 // a mutual-exclusion group decided by two statements, and running them as
 // three independent experiments would let the group report a combination
 // Validate rejects. Two more need a DML follow-up because DDL acceptance is
@@ -203,6 +203,81 @@ func concurrentIndex(key capability.Capability, setup []string, standalone, insi
 			return verdicts{key: decided(true)}, attempts
 		},
 	}
+}
+
+// indexIncludeSPGiST decides whether the server created the index shape the
+// statement requested, rather than merely accepting or rewriting its syntax.
+func indexIncludeSPGiST(setup []string, create, inspect string) experiment {
+	return experiment{
+		decides: []capability.Capability{capability.IndexIncludeSPGiST},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			created := s.exec(ctx, create)
+			attempts := []Attempt{created}
+			if !created.Accepted {
+				return verdicts{capability.IndexIncludeSPGiST: decided(false)}, attempts
+			}
+
+			matches, inspected := s.query(ctx, inspect)
+			attempts = append(attempts, inspected)
+			return verdicts{capability.IndexIncludeSPGiST: indexIncludeSPGiSTObservation(
+				created, inspected, matches,
+			)}, attempts
+		},
+	}
+}
+
+// uninspectableIndexIncludeSPGiST decides false on rejection. An unexpected
+// acceptance is undecidable because this dialect has no portable catalog proof
+// that distinguishes a key column from a non-key included column.
+func uninspectableIndexIncludeSPGiST(setup []string, create string) experiment {
+	return experiment{
+		decides: []capability.Capability{capability.IndexIncludeSPGiST},
+		setup:   setup,
+		decide: func(ctx context.Context, s *session) (verdicts, []Attempt) {
+			created := s.exec(ctx, create)
+			return verdicts{
+				capability.IndexIncludeSPGiST: uninspectableIndexIncludeSPGiSTObservation(created),
+			}, []Attempt{created}
+		},
+	}
+}
+
+func indexIncludeSPGiSTObservation(created, inspected Attempt, matches int64) observation {
+	if !created.Accepted {
+		return decided(false)
+	}
+	if !inspected.Accepted {
+		return cannotDecide(
+			"the index statement was accepted but metadata inspection %q failed (%s), so the run cannot tell "+
+				"whether the requested SP-GiST INCLUDE shape was created",
+			collapse(inspected.Statement), collapse(inspected.ServerErr),
+		)
+	}
+	if matches == 1 {
+		return decided(true)
+	}
+	if matches == 0 {
+		return annotated(false,
+			"the index statement was accepted but metadata found no SP-GiST index with exactly one key and one "+
+				"included column, so the server did not preserve the requested semantics",
+		)
+	}
+	return cannotDecide(
+		"the index statement was accepted but metadata found %d exact SP-GiST index shapes with one key and one "+
+			"included column; more than one match violates the probe's unique-name invariant",
+		matches,
+	)
+}
+
+func uninspectableIndexIncludeSPGiSTObservation(created Attempt) observation {
+	if !created.Accepted {
+		return decided(false)
+	}
+	return cannotDecide(
+		"the index statement was accepted, but this dialect has no portable metadata proof that the payload " +
+			"is a non-key included column; syntax acceptance alone does not establish SP-GiST INCLUDE support",
+	)
 }
 
 // storedResult decides MaterializedViews.

--- a/internal/capabilityprobe/plans.go
+++ b/internal/capabilityprobe/plans.go
@@ -78,6 +78,20 @@ func postgresPlan() plan {
 			"DROP INDEX CONCURRENTLY dic_one",
 			"DROP INDEX CONCURRENTLY dic_two",
 		),
+		indexIncludeSPGiST(
+			[]string{"CREATE TABLE iis (k text, payload int)"},
+			"CREATE INDEX iis_idx ON iis USING SPGIST (k) INCLUDE (payload)",
+			`SELECT COUNT(*)
+			 FROM pg_catalog.pg_index AS i
+			 JOIN pg_catalog.pg_class AS idx ON idx.oid = i.indexrelid
+			 JOIN pg_catalog.pg_am AS am ON am.oid = idx.relam
+			 JOIN pg_catalog.pg_namespace AS ns ON ns.oid = idx.relnamespace
+			 WHERE ns.nspname = current_schema()
+			   AND idx.relname = 'iis_idx'
+			   AND am.amname = 'spgist'
+			   AND i.indnkeyatts = 1
+			   AND i.indnatts = 2`,
+		),
 		acceptance(capability.Views,
 			[]string{"CREATE TABLE vsrc (n int)"},
 			"CREATE VIEW vw AS SELECT n FROM vsrc",
@@ -212,6 +226,10 @@ func mysqlFamilyPlan(dialect string) plan {
 			},
 			"DROP INDEX CONCURRENTLY dic_one ON dic",
 			"DROP INDEX CONCURRENTLY dic_two ON dic",
+		),
+		uninspectableIndexIncludeSPGiST(
+			[]string{"CREATE TABLE iis (k VARCHAR(255), payload INT)"},
+			"CREATE INDEX iis_idx ON iis USING SPGIST (k) INCLUDE (payload)",
 		),
 		acceptance(capability.Views,
 			[]string{"CREATE TABLE vsrc (n int)"},

--- a/internal/capabilityprobe/probe.go
+++ b/internal/capabilityprobe/probe.go
@@ -152,7 +152,7 @@ func (r *Report) Mismatches() []Row {
 // reads as a passed check is how a matrix comes to certify lines nobody ever
 // probed, and this repository has been bitten by that shape before. Failing on
 // "decided less than the plan promised" is the same argument one step further
-// in: a floor of one row lets twenty-three of twenty-four go quietly
+// in: a floor of one row lets twenty-four of twenty-five go quietly
 // unmeasured while the run still exits zero, and coverage that can erode
 // without turning anything red is coverage nobody is holding.
 func (r *Report) Err() error {

--- a/internal/capabilityprobe/probe_internal_test.go
+++ b/internal/capabilityprobe/probe_internal_test.go
@@ -10,6 +10,7 @@ package capabilityprobe
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"slices"
 	"testing"
@@ -121,10 +122,101 @@ func TestPlans_DeclareUndecidableOnlyWhereThisFileRecordsWhy(t *testing.T) {
 	}
 }
 
+func TestIndexIncludeSPGiSTObservation(t *testing.T) {
+	c := qt.New(t)
+
+	accepted := Attempt{Statement: "CREATE INDEX", Accepted: true}
+	inspected := Attempt{Statement: "SELECT index metadata", Accepted: true}
+	for _, tc := range []struct {
+		name      string
+		created   Attempt
+		inspected Attempt
+		matches   int64
+		want      observation
+	}{
+		{
+			name:    "create rejection proves the capability false",
+			created: Attempt{Statement: "CREATE INDEX", ServerErr: "syntax error"},
+			want:    decided(false),
+		},
+		{
+			name:      "metadata failure after acceptance is undecidable",
+			created:   accepted,
+			inspected: Attempt{Statement: "SELECT index metadata", ServerErr: "catalog unavailable"},
+			want: cannotDecide(
+				"the index statement was accepted but metadata inspection %q failed (%s), so the run cannot tell "+
+					"whether the requested SP-GiST INCLUDE shape was created",
+				"SELECT index metadata", "catalog unavailable",
+			),
+		},
+		{
+			name:      "exact semantic shape proves the capability true",
+			created:   accepted,
+			inspected: inspected,
+			matches:   1,
+			want:      decided(true),
+		},
+		{
+			name:      "accepted but absent semantic shape is false",
+			created:   accepted,
+			inspected: inspected,
+			want: annotated(false,
+				"the index statement was accepted but metadata found no SP-GiST index with exactly one key and one "+
+					"included column, so the server did not preserve the requested semantics",
+			),
+		},
+		{
+			name:      "multiple exact shapes violate the unique-name invariant",
+			created:   accepted,
+			inspected: inspected,
+			matches:   2,
+			want: cannotDecide(
+				"the index statement was accepted but metadata found %d exact SP-GiST index shapes with one key and one "+
+					"included column; more than one match violates the probe's unique-name invariant",
+				2,
+			),
+		},
+	} {
+		c.Run(tc.name, func(c *qt.C) {
+			got := indexIncludeSPGiSTObservation(tc.created, tc.inspected, tc.matches)
+			c.Assert(got, qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestUninspectableIndexIncludeSPGiSTObservation(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range []struct {
+		name    string
+		created Attempt
+		want    observation
+	}{
+		{
+			name:    "rejection proves the capability false",
+			created: Attempt{Statement: "CREATE INDEX", ServerErr: "syntax error"},
+			want:    decided(false),
+		},
+		{
+			name:    "unexpected acceptance is undecidable",
+			created: Attempt{Statement: "CREATE INDEX", Accepted: true},
+			want: cannotDecide(
+				"the index statement was accepted, but this dialect has no portable metadata proof that the payload " +
+					"is a non-key included column; syntax acceptance alone does not establish SP-GiST INCLUDE support",
+			),
+		},
+	} {
+		c.Run(tc.name, func(c *qt.C) {
+			got := uninspectableIndexIncludeSPGiSTObservation(tc.created)
+			c.Assert(got, qt.Equals, tc.want)
+		})
+	}
+}
+
 // TestDecidable_IsDerivedFromThePlanAndTheLine pins the floor's derivation
-// against what live servers actually decided on 2026-08-09: postgres:17 decided
-// 24 of 24, mysql:9.7 decided 23, mariadb:10.11 decided 22. Those runs are the
-// reason the floor can be this strict without failing a healthy server.
+// against the current registry and plan: postgres:17 owes 25 decisions,
+// mysql:9.7 owes 24, and mariadb:10.11 owes 23. The MySQL-family gaps remain
+// only the keys plans.go records as unmeasurable by those engines.
 func TestDecidable_IsDerivedFromThePlanAndTheLine(t *testing.T) {
 	c := qt.New(t)
 
@@ -409,7 +501,7 @@ func TestReportErr(t *testing.T) {
 // TestReportErr_TheFloorIsWhatThePlanPromised covers the erosion a
 // "decided at least one row" guard cannot see.
 //
-// A run that answered one row of twenty-four is not a run that measured this
+// A run that answered one row of twenty-five is not a run that measured this
 // server, and before the floor existed it exited zero. The rows below move the
 // decided count around a fixed promise, so the boundary is exercised from both
 // sides rather than only from the failing one.
@@ -432,19 +524,28 @@ func TestReportErr_TheFloorIsWhatThePlanPromised(t *testing.T) {
 		build: func() *Report {
 			return promisedReport(registered, capability.XMLType)
 		},
-		want: `(?s).*decided 23 of 24 capability rows, 1 fewer than the 24 the postgres plan promised to answer.*`,
+		want: fmt.Sprintf(
+			`(?s).*decided %d of %d capability rows, 1 fewer than the %d the postgres plan promised to answer.*`,
+			registered-1, registered, registered,
+		),
 	}, {
-		name: "the shape the old floor let through: one row decided out of twenty-four",
+		name: "the shape the old floor let through: one row decided out of twenty-five",
 		build: func() *Report {
 			return promisedReport(registered, everyKeyExcept(capability.XMLType)...)
 		},
-		want: `(?s).*decided 1 of 24 capability rows, 23 fewer than the 24 the postgres plan promised to answer.*`,
+		want: fmt.Sprintf(
+			`(?s).*decided 1 of %d capability rows, %d fewer than the %d the postgres plan promised to answer.*`,
+			registered, registered-1, registered,
+		),
 	}, {
 		name: "a plan that promised nothing still may not decide nothing",
 		build: func() *Report {
 			return promisedReport(0, everyKeyExcept()...)
 		},
-		want: `(?s).*decided 0 of 24 capability rows; a probe that measured nothing.*`,
+		want: fmt.Sprintf(
+			`(?s).*decided 0 of %d capability rows; a probe that measured nothing.*`,
+			registered,
+		),
 	}} {
 		c.Run(tc.name, func(c *qt.C) {
 			assertErrMatches(c, tc.build().Err(), tc.want)

--- a/internal/convert/goschematogo/goschematogo.go
+++ b/internal/convert/goschematogo/goschematogo.go
@@ -49,6 +49,9 @@ func Render(db *goschema.Database, opts Options) ([]File, error) {
 	if err := validatePackageName(opts.PackageName); err != nil {
 		return nil, err
 	}
+	if err := validateIndexIncludeColumns(db.Indexes); err != nil {
+		return nil, err
+	}
 
 	ctx := newRenderContext(db, opts)
 	if opts.SingleFile {
@@ -59,6 +62,32 @@ func Render(db *goschema.Database, opts Options) ([]File, error) {
 		return []File{file}, nil
 	}
 	return ctx.renderPerTableFiles()
+}
+
+func validateIndexIncludeColumns(indexes []goschema.Index) error {
+	for _, index := range indexes {
+		for i, column := range index.IncludeColumns {
+			switch {
+			case column == "":
+				return fmt.Errorf("index %q INCLUDE column %d is empty and cannot be represented in a Go annotation", index.Name, i+1)
+			case strings.TrimSpace(column) != column:
+				return fmt.Errorf(
+					"index %q INCLUDE column %d %q cannot be represented in a Go annotation: leading or trailing whitespace is not allowed",
+					index.Name,
+					i+1,
+					column,
+				)
+			case strings.Contains(column, ","):
+				return fmt.Errorf(
+					"index %q INCLUDE column %d %q cannot be represented in a Go annotation: commas delimit column names",
+					index.Name,
+					i+1,
+					column,
+				)
+			}
+		}
+	}
+	return nil
 }
 
 // WriteDir writes generated files to outDir.
@@ -409,6 +438,7 @@ func indexAttrs(index goschema.Index) []attr {
 	return []attr{
 		{name: "name", value: index.Name, set: true},
 		{name: "fields", value: strings.Join(index.Fields, ","), set: len(index.Fields) > 0},
+		{name: "include", value: strings.Join(index.IncludeColumns, ","), set: len(index.IncludeColumns) > 0},
 		{name: "unique", value: strconv.FormatBool(index.Unique), set: index.Unique},
 		{name: "type", value: index.Type, set: index.Type != ""},
 		{name: "condition", value: index.Condition, set: index.Condition != ""},

--- a/internal/convert/goschematogo/goschematogo_test.go
+++ b/internal/convert/goschematogo/goschematogo_test.go
@@ -52,10 +52,11 @@ func TestRenderPerTableFilesRoundTripThroughParser(t *testing.T) {
 			Values: []string{"active", "inactive"},
 		}},
 		Indexes: []goschema.Index{{
-			StructName: "OrderItem",
-			Name:       "idx_order_items_status",
-			Fields:     []string{"status"},
-			Condition:  "status <> 'inactive'",
+			StructName:     "OrderItem",
+			Name:           "idx_order_items_status",
+			Fields:         []string{"status"},
+			IncludeColumns: []string{"created_at", "tenant_id"},
+			Condition:      "status <> 'inactive'",
 		}},
 		Constraints: []goschema.Constraint{
 			{
@@ -135,6 +136,7 @@ func TestRenderPerTableFilesRoundTripThroughParser(t *testing.T) {
 	c.Assert(parsed.Fields, qt.HasLen, 3)
 	c.Assert(parsed.Indexes, qt.HasLen, 1)
 	c.Assert(parsed.Indexes[0].Condition, qt.Equals, "status <> 'inactive'")
+	c.Assert(parsed.Indexes[0].IncludeColumns, qt.DeepEquals, []string{"created_at", "tenant_id"})
 	c.Assert(parsed.Constraints, qt.DeepEquals, db.Constraints)
 	c.Assert(parsed.Functions, qt.HasLen, 1)
 	c.Assert(parsed.Functions[0].Body, qt.Equals, "BEGIN RAISE NOTICE \"touch\";\nRETURN NEW; END;")
@@ -169,6 +171,73 @@ func TestRenderSingleFileUsesOneSchemaFile(t *testing.T) {
 	c.Assert(files, qt.HasLen, 1)
 	c.Assert(files[0].Name, qt.Equals, "schema.go")
 	c.Assert(string(files[0].Data), qt.Contains, "type User struct")
+}
+
+func TestRenderRejectsUnrepresentableIndexIncludeColumns(t *testing.T) {
+	tests := []struct {
+		name   string
+		column string
+		err    string
+	}{
+		{
+			name:   "empty",
+			column: "",
+			err:    `index "idx_accounts_email" INCLUDE column 2 is empty and cannot be represented in a Go annotation`,
+		},
+		{
+			name:   "leading whitespace",
+			column: " display_name",
+			err:    `index "idx_accounts_email" INCLUDE column 2 " display_name" cannot be represented in a Go annotation: leading or trailing whitespace is not allowed`,
+		},
+		{
+			name:   "trailing whitespace",
+			column: "display_name ",
+			err:    `index "idx_accounts_email" INCLUDE column 2 "display_name " cannot be represented in a Go annotation: leading or trailing whitespace is not allowed`,
+		},
+		{
+			name:   "comma",
+			column: "display,name",
+			err:    `index "idx_accounts_email" INCLUDE column 2 "display,name" cannot be represented in a Go annotation: commas delimit column names`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			database := &goschema.Database{Indexes: []goschema.Index{{
+				Name:           "idx_accounts_email",
+				IncludeColumns: []string{"created_at", test.column},
+			}}}
+
+			files, err := goschematogo.Render(database, goschematogo.Options{SingleFile: true})
+
+			c.Assert(files, qt.IsNil)
+			c.Assert(err, qt.ErrorMatches, test.err)
+		})
+	}
+}
+
+func TestRenderAcceptsRepresentableIndexIncludeColumns(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Account", Name: "accounts"}},
+		Indexes: []goschema.Index{{
+			StructName:     "Account",
+			Name:           "idx_accounts_email",
+			Fields:         []string{"email"},
+			IncludeColumns: []string{"display_name", "created_at"},
+		}},
+	}
+
+	files, err := goschematogo.Render(database, goschematogo.Options{SingleFile: true})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 1)
+	c.Assert(
+		string(files[0].Data),
+		qt.Contains,
+		`include="display_name,created_at"`,
+	)
 }
 
 func TestRenderPerTableFileNamesIncludeSchema(t *testing.T) {

--- a/schemas/ptah-annotations.schema.json
+++ b/schemas/ptah-annotations.schema.json
@@ -664,6 +664,10 @@
               "description": "ClickHouse data-skipping index granularity.",
               "type": "string"
             },
+            "include": {
+              "description": "Comma-separated INCLUDE columns for covering indexes (PostgreSQL: default/BTREE/GIST, plus SPGIST on 14+; YugabyteDB: default/LSM, with BTREE as the default-LSM alias; Spanner PostgreSQL dialect: default only).",
+              "type": "string"
+            },
             "name": {
               "description": "Index name.",
               "type": "string"


### PR DESCRIPTION
## Classification

GENERAL CAPABILITY

## Summary

- add `include=` to native `//ptah:schema:index` metadata and parsing
- preserve ordered INCLUDE payload columns through Go schema generation
- validate the exact dialect, access-method, and PostgreSQL-version matrix before rendering
- expose PostgreSQL 14+ SP-GiST INCLUDE support through the capability registry
- probe the exact SP-GiST method/key/payload shape instead of trusting accepted syntax
- update the generated annotation schema, public API snapshot, conformance status, and user documentation

## Capability ownership

1. The semantic implementation lives in the shared `core/goschema`, `core/renderer`, and `core/platform/capability` packages, with annotation metadata and conversion support below the CLI layer.
2. Native Ptah consumes it through the existing schema render, compare, plan, and migration-generation paths that operate on `goschema.Index.IncludeColumns`.
3. No new native command or flag is needed because `include=` is itself the native annotation surface. Atlas HCL already carries INCLUDE columns through the same shared model, so no compatibility-only command change or exposure issue is required.

## Behavior

- omitted `include` remains empty; present empty, sparse, or trailing-comma lists fail parsing
- PostgreSQL accepts default, BTREE, and GiST methods; SP-GiST is enabled only for PostgreSQL 14 and newer
- YugabyteDB accepts default and LSM; its documented BTREE alias normalizes to the byte-identical default LSM rendering
- the Spanner PostgreSQL dialect accepts only its default method
- CockroachDB and all other dialects fail closed before emitting SQL
- direct AST rendering and whole-schema rendering enforce the same rules
- Go annotation generation refuses identifiers that the comma-list syntax cannot round-trip without corruption

## Verification

- `go test ./... -count=1`
- `go vet ./...`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...` — 0 issues
- focused parser, renderer, capability, converter, metadata, and schema-generator tests
- `scripts/check-coverage.sh` — 77.3% with a 70% threshold
- annotation JSON Schema freshness guard
- all public API guards, including released-baseline compatibility
- test-style and documentation-style guards
- complete documentation links, redirects, page-health, exit-code, version, build, and responsive checks
- Astro build: 62 pages
- responsive audit: 61 routes at two viewports
- `npm audit`: 0 vulnerabilities
- `git diff --check`

Independent final review found no remaining findings.
