### PR TITLE
fix(compat): silence migrate new success output

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1390,7 +1390,7 @@ func TestCompatCommand_MigrateNewCreatesAtlasSkeletonFileByDefault(t *testing.T)
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "Generated empty migration file:")
+	c.Assert(out.String(), qt.Equals, "")
 	matches, globErr := filepath.Glob(filepath.Join(dir, "*_manual_hotfix.sql"))
 	c.Assert(globErr, qt.IsNil)
 	c.Assert(matches, qt.HasLen, 1)
@@ -1413,7 +1413,7 @@ func TestCompatCommand_MigrateNewAcceptsExplicitAtlasDirFormat(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "Generated empty migration file:")
+	c.Assert(out.String(), qt.Equals, "")
 	matches, globErr := filepath.Glob(filepath.Join(dir, "*_manual_hotfix.sql"))
 	c.Assert(globErr, qt.IsNil)
 	c.Assert(matches, qt.HasLen, 1)
@@ -3994,7 +3994,7 @@ func TestCompatCommand_MigrateNewResolvesProjectRelativeMigrationDir(t *testing.
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "Generated empty migration file:")
+	c.Assert(out.String(), qt.Equals, "")
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 1)
 	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
 	c.Assert(err, qt.IsNil)

--- a/cmd/atlas/editor_flags_test.go
+++ b/cmd/atlas/editor_flags_test.go
@@ -32,7 +32,7 @@ func TestCompatCommand_MigrateNewEditOpensEditor(t *testing.T) {
 	// Atlas-format file opens in $EDITOR and atlas.sum is refreshed afterwards
 	// so the directory still validates.
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
-	c.Assert(out.String(), qt.Contains, "Generated empty migration file:")
+	c.Assert(out.String(), qt.Equals, "")
 	created, globErr := filepath.Glob(filepath.Join(dir, "*_add_users.sql"))
 	c.Assert(globErr, qt.IsNil)
 	c.Assert(created, qt.HasLen, 1)

--- a/cmd/atlas/migrate_new.go
+++ b/cmd/atlas/migrate_new.go
@@ -3,6 +3,7 @@ package atlas
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 
 	"github.com/spf13/cobra"
@@ -69,6 +70,21 @@ func newAtlasMigrateNewCommand() *cobra.Command {
 	return cmd
 }
 
+// newSilentNativeMigrateCreateCommand keeps the native create capability and
+// its editor, checksum, and error behavior intact while removing its success
+// report from the Atlas-compatible adapter. The adapter creates this target for
+// each execution, so the discarded writer cannot leak into native Ptah or a
+// later help run.
+func newSilentNativeMigrateCreateCommand() *cobra.Command {
+	cmd := migrate.NewMigrateCreateCommand()
+	run := cmd.RunE
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		cmd.SetOut(io.Discard)
+		return run(cmd, args)
+	}
+	return cmd
+}
+
 // checkAtlasMigrateNewName refuses a migration name that cannot become a file,
 // after the atlas.sum gate and before anything is written.
 //
@@ -98,7 +114,7 @@ func atlasMigrateNewVerb() atlasVerb {
 		short:      "Create a new migration file",
 		native:     "migrations create",
 		writesDir:  true,
-		factory:    migrate.NewMigrateCreateCommand,
+		factory:    newSilentNativeMigrateCreateCommand,
 		flags: []atlasargs.Flag{
 			// `ptah migrations create` registers no default for its own
 			// --migrations-dir, so before this default was declared here the
@@ -203,7 +219,7 @@ func runAtlasMigrateNewConverted(cmd *cobra.Command, verb atlasVerb, source atla
 	if err := verifyAtlasWriteDirCoveredChecksum(cmd, source); err != nil {
 		return err
 	}
-	written, err := atlasmigrate.WriteSkeletonMigration(
+	_, err = atlasmigrate.WriteSkeletonMigration(
 		migrateDiffWriterRoot(source.project, source.localDir),
 		source.localDir.Path,
 		source.format,
@@ -212,7 +228,6 @@ func runAtlasMigrateNewConverted(cmd *cobra.Command, verb atlasVerb, source atla
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate %s: %w", verb.use, err))
 	}
-	reportAtlasMigrateNewFiles(cmd, written)
 	return nil
 }
 
@@ -236,24 +251,4 @@ func verifyAtlasWriteDirCoveredChecksum(cmd *cobra.Command, source atlasMigrateS
 		return err
 	}
 	return verifyCoveredAtlasDirChecksum(cmd, captured.FileSystem, source.format, requireAtlasSum)
-}
-
-// reportAtlasMigrateNewFiles prints the created files the way the forwarded
-// `ptah migrations create` prints them, so naming a directory's layout does not
-// change how this verb reports what it made.
-//
-// The community binary prints nothing at all on success here. That divergence
-// is older than this path — it is what `migrate new --dir-format atlas` already
-// does on the forwarding branch — and matching it on the converted branch alone
-// would make one verb report two ways.
-func reportAtlasMigrateNewFiles(cmd *cobra.Command, written []string) {
-	out := cmd.OutOrStdout()
-	if len(written) == 1 {
-		fmt.Fprintf(out, "Generated empty migration file:\n")
-		fmt.Fprintf(out, "SQL:  %s\n", written[0])
-		return
-	}
-	fmt.Fprintf(out, "Generated empty migration files:\n")
-	fmt.Fprintf(out, "UP:   %s\n", written[0])
-	fmt.Fprintf(out, "DOWN: %s\n", written[1])
 }

--- a/cmd/atlas/migrate_new_converted_test.go
+++ b/cmd/atlas/migrate_new_converted_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migratesum"
 )
 
 // These tests pin stokaro/ptah#845 on `ptah-compat migrate new`: an empty
@@ -136,6 +138,35 @@ func newConvertedBodies(c *qt.C, dir string, names []string) map[string]string {
 	return bodies
 }
 
+// assertMigrateNewArtifacts pins every byte the command writes. The expected
+// checksum is computed over the exact covered names after the generated
+// version is known, so the assertion remains deterministic across clock ticks
+// while still catching a wrong file set, order, name, or body.
+func assertMigrateNewArtifacts(c *qt.C, dir string, layout newConvertedLayout) {
+	c.Helper()
+	c.Assert(newConvertedNames(c, dir), qt.DeepEquals, layout.files)
+	c.Assert(newConvertedSumEntries(c, dir), qt.DeepEquals, layout.covered)
+	c.Assert(newConvertedBodies(c, dir, layout.files), qt.DeepEquals, layout.body)
+
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	actualNames := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		normalized := newConvertedVersionRe.ReplaceAllString(entry.Name(), "<V>")
+		actualNames[normalized] = entry.Name()
+	}
+	covered := make([]string, len(layout.covered))
+	for i, normalized := range layout.covered {
+		covered[i] = actualNames[normalized]
+		c.Assert(covered[i], qt.Not(qt.Equals), "")
+	}
+	wantSum, err := migratesum.ComputeAtlasFiles(os.DirFS(dir), covered)
+	c.Assert(err, qt.IsNil)
+	gotSum, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotSum, qt.DeepEquals, wantSum.Bytes())
+}
+
 // TestCompatMigrateNewConverted_WritesTheSelectedLayout is the discriminator for
 // #845 on `migrate new`: the created file names, their bytes, and the covered
 // set of the atlas.sum written beside them all follow the selected layout.
@@ -159,13 +190,13 @@ func TestCompatMigrateNewConverted_WritesTheSelectedLayout(t *testing.T) {
 			c := qt.New(t)
 			dir := c.TempDir()
 
-			_, stderr, err := runCompatExit("migrate", "new", "addcol",
+			stdout, stderr, err := runCompatExit("migrate", "new", "addcol",
 				"--dir", "file://"+dir, "--dir-format", layout.format)
 
 			c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
-			c.Assert(newConvertedNames(c, dir), qt.DeepEquals, layout.files)
-			c.Assert(newConvertedSumEntries(c, dir), qt.DeepEquals, layout.covered)
-			c.Assert(newConvertedBodies(c, dir, layout.files), qt.DeepEquals, layout.body)
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, "")
+			assertMigrateNewArtifacts(c, dir, layout)
 		})
 	}
 }
@@ -189,12 +220,13 @@ func TestCompatMigrateNewConverted_QuerySpellingWritesTheSelectedLayout(t *testi
 			c := qt.New(t)
 			dir := c.TempDir()
 
-			_, stderr, err := runCompatExit("migrate", "new", "addcol",
+			stdout, stderr, err := runCompatExit("migrate", "new", "addcol",
 				"--dir", "file://"+dir+"?format="+layout.format)
 
 			c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
-			c.Assert(newConvertedNames(c, dir), qt.DeepEquals, layout.files)
-			c.Assert(newConvertedSumEntries(c, dir), qt.DeepEquals, layout.covered)
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, "")
+			assertMigrateNewArtifacts(c, dir, layout)
 		})
 	}
 }
@@ -239,10 +271,12 @@ func TestCompatMigrateNewConverted_QueryFormatOutranksDirFormatFlag(t *testing.T
 			c := qt.New(t)
 			dir := c.TempDir()
 
-			_, stderr, err := runCompatExit("migrate", "new", "addcol",
+			stdout, stderr, err := runCompatExit("migrate", "new", "addcol",
 				"--dir", "file://"+dir+tt.query, "--dir-format", tt.dirFormat)
 
 			c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, "")
 			c.Assert(newConvertedNames(c, dir), qt.DeepEquals, tt.want)
 		})
 	}
@@ -446,20 +480,17 @@ func TestCompatMigrateNewConverted_RefusesWhatItCannotReadBack(t *testing.T) {
 	}
 }
 
-// TestCompatMigrateNewConverted_NativeAtlasLayoutIsUnchanged is the
-// non-interference control for #845's "native Atlas directory behavior remains
-// unchanged" criterion.
+// TestCompatMigrateNew_NativeAtlasLayoutWritesSameArtifactsSilently is the
+// native-layout half of stokaro/ptah#1235 findings 3.1 and 3.2. The migration
+// and atlas.sum stay unchanged while the compatibility-only success report is
+// removed.
 //
-// It is not proved by reverting the change — that only shows the old refusal
-// comes back. It is proved by the INVERSE: the atlas layout, and the two
-// spellings that select it, must still take the forwarding branch and produce
-// the single empty `<V>_<name>.sql` plus an atlas.sum covering it, with the
-// forwarded command's own report on stdout. A dispatcher that sent the atlas
-// layout down the converted path would fail here, because
+// The atlas layout, and the two spellings that select it, must still take the
+// forwarding branch and produce the single empty `<V>_<name>.sql` plus an
+// atlas.sum covering it. A dispatcher that sent the atlas layout down the
+// converted path would fail here, because
 // [atlasmigrateimport.SkeletonFiles] refuses that format outright.
-//
-// Reverted, every row passes unchanged; that is the point of a control.
-func TestCompatMigrateNewConverted_NativeAtlasLayoutIsUnchanged(t *testing.T) {
+func TestCompatMigrateNew_NativeAtlasLayoutWritesSameArtifactsSilently(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name string
@@ -495,9 +526,14 @@ func TestCompatMigrateNewConverted_NativeAtlasLayoutIsUnchanged(t *testing.T) {
 			stdout, stderr, err := runCompatExit(args...)
 
 			c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
-			c.Assert(stdout, qt.Contains, "Generated empty migration file:")
-			c.Assert(newConvertedNames(c, dir), qt.DeepEquals, []string{"<V>_addcol.sql"})
-			c.Assert(newConvertedSumEntries(c, dir), qt.DeepEquals, []string{"<V>_addcol.sql"})
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, "")
+			assertMigrateNewArtifacts(c, dir, newConvertedLayout{
+				format:  "atlas",
+				files:   []string{"<V>_addcol.sql"},
+				covered: []string{"<V>_addcol.sql"},
+				body:    map[string]string{"<V>_addcol.sql": ""},
+			})
 		})
 	}
 }

--- a/cmd/atlas/migrate_new_project_test.go
+++ b/cmd/atlas/migrate_new_project_test.go
@@ -52,7 +52,7 @@ func TestMigrateNewWithAtlasProjectEnumIdentifiers(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(output.String(), qt.Contains, "Generated empty migration file:")
+	c.Assert(output.String(), qt.Equals, "")
 	migrations, globErr := filepath.Glob(filepath.Join(root, "migrations", "*_manual_hotfix.sql"))
 	c.Assert(globErr, qt.IsNil)
 	c.Assert(migrations, qt.HasLen, 1)

--- a/cmd/atlas/project_config_ignored_test.go
+++ b/cmd/atlas/project_config_ignored_test.go
@@ -112,7 +112,7 @@ func TestCompatConvertedMigrateNewReportsIgnoredAtlasConstructs(t *testing.T) {
 	stdout, stderr, err := runCompatExit("migrate", "new", "add_users", "--env", "local")
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(stdout, qt.Contains, "Generated empty migration file:")
+	c.Assert(stdout, qt.Equals, "")
 	c.Assert(
 		stderr,
 		qt.Equals,

--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -223,6 +223,61 @@ func TestCompatBinaryAtlasSuccessPaths(t *testing.T) {
 	})
 }
 
+// TestCompatBinaryMigrateNewSuccessIsSilent pins the real process boundary for
+// stokaro/ptah#1235 findings 3.1 and 3.2: exit 0, byte-empty stdout and stderr,
+// and the Atlas migration plus atlas.sum still written and valid.
+func TestCompatBinaryMigrateNewSuccessIsSilent(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	dir := c.TempDir()
+	run := newCompatProcess(
+		binPath,
+		"migrate", "new", "manual_hotfix",
+		"--dir", "file://"+dir,
+	)
+	var stdout, stderr bytes.Buffer
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+
+	err := run.Run()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr.String()))
+	c.Assert(stdout.String(), qt.Equals, "")
+	c.Assert(stderr.String(), qt.Equals, "")
+	migrations, globErr := filepath.Glob(filepath.Join(dir, "*_manual_hotfix.sql"))
+	c.Assert(globErr, qt.IsNil)
+	c.Assert(migrations, qt.HasLen, 1)
+	result, verifyErr := migratesum.VerifyDirWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(verifyErr, qt.IsNil)
+	c.Assert(result.OK(), qt.IsTrue)
+}
+
+func TestCompatBinaryMigrateNewFailureStaysLoud(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	dir := c.TempDir()
+	run := newCompatProcess(
+		binPath,
+		"migrate", "new", "manual_hotfix",
+		"--dir", "file://"+dir,
+		"--edit",
+	)
+	run.Env = append(os.Environ(), "VISUAL=", "EDITOR=")
+	var stdout, stderr bytes.Buffer
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+
+	err := run.Run()
+	var exitErr *exec.ExitError
+
+	c.Assert(err, qt.ErrorAs, &exitErr)
+	c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+	c.Assert(stdout.String(), qt.Equals, "")
+	c.Assert(stderr.String(), qt.Equals,
+		"Error: no editor configured: set $EDITOR or $VISUAL, or pass --editor\n",
+	)
+}
+
 func TestCompatBinaryAtlasFailurePaths(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)

--- a/cmd/ptah/main_test.go
+++ b/cmd/ptah/main_test.go
@@ -64,6 +64,44 @@ func TestPtahNativeSchemaApplyHelpResolves(t *testing.T) {
 	c.Assert(stderr.String(), qt.Equals, "")
 }
 
+// TestPtahNativeMigrationsCreateKeepsSuccessReport is the negative control for
+// the compatibility-only silence of `ptah-compat migrate new`. Native Ptah
+// keeps reporting the two paths it created.
+func TestPtahNativeMigrationsCreateKeepsSuccessReport(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildPtahBinary(c)
+	dir := c.TempDir()
+	run := newPtahProcess(
+		binPath,
+		"migrations", "create", "manual_hotfix",
+		"--migrations-dir", dir,
+	)
+	var stdout, stderr bytes.Buffer
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+
+	err := run.Run()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr.String()))
+	c.Assert(stderr.String(), qt.Equals, "")
+	files, globErr := filepath.Glob(filepath.Join(dir, "*_manual_hotfix.*.sql"))
+	c.Assert(globErr, qt.IsNil)
+	c.Assert(files, qt.HasLen, 2)
+	downPath := files[0]
+	upPath := files[1]
+	c.Assert(downPath, qt.Matches, `^.*\.down\.sql$`)
+	c.Assert(upPath, qt.Matches, `^.*\.up\.sql$`)
+	upPath, pathErr := filepath.EvalSymlinks(upPath)
+	c.Assert(pathErr, qt.IsNil)
+	downPath, pathErr = filepath.EvalSymlinks(downPath)
+	c.Assert(pathErr, qt.IsNil)
+	c.Assert(stdout.String(), qt.Equals,
+		"Generated empty migration files:\n"+
+			"UP:   "+upPath+"\n"+
+			"DOWN: "+downPath+"\n",
+	)
+}
+
 func TestPtahNativeMigrationsUpRejectsMalformedAtlasTxMode(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildPtahBinary(c)

--- a/docs/site/src/content/docs/atlas/conformance.md
+++ b/docs/site/src/content/docs/atlas/conformance.md
@@ -46,6 +46,32 @@ claim is limited to the corpus represented by the generated reports. Expanding
 live and differential coverage is tracked in
 [`stokaro/ptah-atlas-conformance#167`](https://github.com/stokaro/ptah-atlas-conformance/issues/167).
 
+## `migrate new` success streams
+
+Findings 3.1 and 3.2 in
+[`stokaro/ptah#1235`](https://github.com/stokaro/ptah/issues/1235) were measured
+against the pinned Atlas CE v1.3.0 binary on August 11, 2026. Both tools exit 0
+and write the same migration and `atlas.sum` artifacts; only their process
+output differed.
+
+| Directory layout | Pinned binary | Ptah before | Ptah now |
+| --- | --- | --- | --- |
+| Atlas | Stdout and stderr are byte-empty | Stdout names the migration by absolute path | Both streams are byte-empty |
+| Converted | Stdout and stderr are byte-empty | Stdout names one or two migrations by absolute path | Both streams are byte-empty |
+
+The change is limited to the `ptah-compat migrate new` adapter. Migration
+names, file contents, `atlas.sum`, editor execution, warnings, and failure
+diagnostics remain unchanged. Native `ptah migrations create` still reports the
+paths it creates.
+
+Re-run the focused evidence from the Ptah repository:
+
+```bash
+go test ./cmd/atlas -run '^TestCompatMigrateNew' -count=1
+go test ./cmd/ptah-compat -run '^TestCompatBinaryMigrateNew' -count=1
+go test ./cmd/ptah -run '^TestPtahNativeMigrationsCreateKeepsSuccessReport$' -count=1
+```
+
 ## Workflow parity
 
 Each workflow below states the native Ptah command, the Atlas-compatible


### PR DESCRIPTION
## Summary

- make successful `ptah-compat migrate new` runs byte-silent on stdout and
  stderr, matching the pinned Atlas CE v1.3.0 process contract
- apply the same behavior to native Atlas directories and all five converted
  layouts without changing files, `atlas.sum`, editor behavior, warnings, or
  failures
- retain the useful created-path report on native `ptah migrations create`
- document the measured #1235 findings 3.1 and 3.2 on the non-overlapping Atlas
  conformance page

## Classification

COMPATIBILITY ADAPTER

This change only reproduces Atlas's `migrate new` success-stream contract. The
underlying migration creation capability remains shared, and the native Ptah
surface keeps its existing report.

## Root cause

The native-Atlas branch forwarded the success report from
`cmd/migrate`, while the converted-layout branch called a separate
`reportAtlasMigrateNewFiles` helper. Both exposed Ptah's absolute created paths
on a compatibility command whose Atlas counterpart emits no success bytes.

The forwarded command is freshly created for each execution and now discards
only its final success writer. Returned errors and stderr remain visible. The
converted branch simply stops printing its post-write report.

## Measured behavior

Against the pinned Atlas CE v1.3.0 binary:

- Atlas layout: both tools exit 0 and write the same migration plus
  `atlas.sum`; CE emits 0/0 stdout/stderr bytes, while Ptah previously emitted
  101 stdout bytes
- golang-migrate: both tools exit 0 and write the same `.up.sql`, `.down.sql`,
  and `atlas.sum`; CE emits 0/0 bytes, while Ptah previously emitted 201 stdout
  bytes

The same silence is asserted across Flyway, Goose, dbmate, and Liquibase.

## Verification

- focused red/green `cmd/atlas` migrate-new matrix
- `cmd/ptah-compat` real-process success and failure controls
- `cmd/ptah` real-process native-output negative control
- full relevant command packages
- `go test ./... -count=1`
- `golangci-lint run ./...` (`0 issues`)
- test-style guard
- complete documentation guard/selftest suite
- Astro build and responsive audit (61 routes at two viewports)
- `npm audit --audit-level=low` (0 vulnerabilities)
- `git diff --check`

Refs #1235.
