### PR TITLE
fix(schema): preserve rendered SQL terminators

### DIFF
--- a/cmd/atlas/schema_inspect_output_test.go
+++ b/cmd/atlas/schema_inspect_output_test.go
@@ -25,6 +25,27 @@ func runSchemaInspectOutput(c *qt.C, dbPath string, extra ...string) (string, er
 	return out.String(), err
 }
 
+func TestSchemaInspectExplicitSQLTemplateWritesExactTerminatedStatement(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "inspect-sql.db")
+	createSQLiteSchemaCleanTable(c, dbPath, "users")
+
+	out, err := runSchemaInspectOutput(c, dbPath, "--format", `{{ sql . }}`)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Equals, "CREATE TABLE \"users\" (\n  \"id\" INTEGER PRIMARY KEY\n);\n")
+}
+
+func TestSchemaInspectExplicitSQLTemplateWritesNoBytesForEmptyDatabase(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "empty.db")
+
+	out, err := runSchemaInspectOutput(c, dbPath, "--format", `{{ sql . }}`)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Equals, "")
+}
+
 // TestSchemaInspectOutputWritesTheFile pins where the rendered schema goes.
 //
 // Reverted, every row fails with `unknown flag: --output` (or `-o`).

--- a/cmd/schema/inspect_test.go
+++ b/cmd/schema/inspect_test.go
@@ -25,8 +25,20 @@ func TestSchemaInspectLiveDatabaseWritesSQL(t *testing.T) {
 	)
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
-	c.Assert(out, qt.Contains, `CREATE TABLE "users"`)
-	c.Assert(out, qt.Not(qt.Contains), "Database:")
+	c.Assert(out, qt.Equals, "CREATE TABLE \"users\" (\n  \"id\" INTEGER PRIMARY KEY\n);\n")
+}
+
+func TestSchemaInspectEmptyLiveDatabaseWritesEmptySQL(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "empty.db")
+
+	out, err := runSchema("", "inspect",
+		"--db-url", "sqlite://"+dbPath,
+		"--format", "sql",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Equals, "")
 }
 
 func TestSchemaInspectSchemaFileNormalizedOnDevDatabase(t *testing.T) {

--- a/docs/site/src/content/docs/atlas/conformance.md
+++ b/docs/site/src/content/docs/atlas/conformance.md
@@ -28,6 +28,26 @@ results. They do not, by themselves, prove every Atlas OSS command, flag,
 dialect feature, and output mode. Use the comparison gap register for product
 and coverage gaps that are outside the current measured corpus.
 
+### SQL inspect statement terminators
+
+Finding 4.6 in
+[`stokaro/ptah#1235`](https://github.com/stokaro/ptah/issues/1235) was measured
+on August 7, 2026, against the pinned Atlas CE v1.3.0 binary:
+
+| Result | Empty SQLite database | Populated SQLite database |
+| --- | --- | --- |
+| Atlas CE v1.3.0 | 0 bytes | no semicolon-only lines |
+| Ptah before | `;\n` | a semicolon-only line after every statement |
+| Ptah now | 0 bytes | no semicolon-only lines |
+
+The shared report serializer now keeps each renderer-produced statement
+verbatim instead of adding another terminator. An indent argument still
+prefixes every line of nonempty SQL, while empty SQL stays empty. Exact tests
+cover `ptah schema inspect --format sql`, the Atlas-compatible
+`ptah-compat schema inspect --format '{{ sql . }}'`, and HCL and JSON controls.
+This closes only finding 4.6; the issue's comment, indentation, view, and object
+ordering findings remain separate.
+
 ## How to read green and red checks
 
 The conformance repository separates regression budgets from full parity:

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -324,8 +324,8 @@ func (r *SchemaInspectReport) MarshalSQL(indent ...string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("render SQL: %w", err)
 	}
-	sql := strings.Join(statements, ";\n") + ";\n"
-	if len(indent) == 0 || indent[0] == "" {
+	sql := strings.Join(statements, "")
+	if sql == "" || len(indent) == 0 || indent[0] == "" {
 		return sql, nil
 	}
 	return indent[0] + strings.ReplaceAll(sql, "\n", "\n"+indent[0]), nil

--- a/internal/atlasreport/schema_inspect_sql_terminators_test.go
+++ b/internal/atlasreport/schema_inspect_sql_terminators_test.go
@@ -1,0 +1,103 @@
+package atlasreport_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+	"go.5x5.cz/ptah/internal/atlasreport"
+)
+
+func TestRenderSchemaInspect_EmptySQLReturnsNoBytesAndKeepsOtherFormats(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{name: "SQL", format: `{{ sql . }}`, want: ""},
+		{name: "indented SQL", format: `{{ sql . "  " }}`, want: ""},
+		{
+			name:   "HCL control",
+			format: `{{ hcl . }}`,
+			want:   atlashclrender.GeneratedCodeMarker + "\n\nschema \"main\" {\n}\n\n",
+		},
+		{
+			name:   "JSON control",
+			format: `{{ json . }}`,
+			want:   `{"schemas":[{"name":"main"}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			output, err := atlasreport.RenderSchemaInspect(test.format, emptySQLiteInspectReport(false))
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(output.Text, qt.Equals, test.want)
+		})
+	}
+}
+
+func TestRenderSchemaInspect_SQLKeepsRenderedTerminatorsAndIndentation(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{
+			name:   "unindented",
+			format: `{{ sql . }}`,
+			want: "CREATE TABLE \"users\" (\n" +
+				"  \"id\" INTEGER NOT NULL PRIMARY KEY,\n" +
+				"  \"email\" TEXT\n" +
+				");\n" +
+				"CREATE INDEX IF NOT EXISTS \"idx_users_email\" ON \"users\" (\"email\");\n",
+		},
+		{
+			name:   "every line stays indented",
+			format: `{{ sql . "  " }}`,
+			want: "  CREATE TABLE \"users\" (\n" +
+				"    \"id\" INTEGER NOT NULL PRIMARY KEY,\n" +
+				"    \"email\" TEXT\n" +
+				"  );\n" +
+				"  CREATE INDEX IF NOT EXISTS \"idx_users_email\" ON \"users\" (\"email\");\n" +
+				"  ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			output, err := atlasreport.RenderSchemaInspect(test.format, sqlTerminatorInspectReport())
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(output.Text, qt.Equals, test.want)
+		})
+	}
+}
+
+func sqlTerminatorInspectReport() *atlasreport.SchemaInspectReport {
+	return atlasreport.NewSchemaInspectReport(
+		&goschema.Database{
+			Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+			Fields: []goschema.Field{
+				{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+				{StructName: "User", Name: "email", Type: "TEXT", Nullable: true},
+			},
+			Indexes: []goschema.Index{{
+				Name: "idx_users_email", TableName: "users", Fields: []string{"email"},
+			}},
+		},
+		&types.DBSchema{},
+		types.DBInfo{Dialect: platform.SQLite, Schema: "main"},
+		nil,
+		atlasreport.SchemaInspectReportOptions{DescribeSchemas: true},
+	)
+}


### PR DESCRIPTION
## Summary

This closes issue #1235 cell 4.6 by preserving the SQL statements produced by the shared renderer instead of appending another terminator in the schema-inspection report layer.

- empty SQL inspection now emits exactly zero bytes, including with an indent argument;
- populated inspection keeps the renderer-provided terminator for each statement and no longer inserts semicolon-only lines;
- the existing nonempty indentation behavior remains byte-for-byte unchanged;
- native `ptah schema inspect --format sql` and Atlas-compatible `ptah-compat schema inspect --format &#39;{{ sql . }}&#39;` use the same shared behavior;
- HCL and JSON output are unchanged.

Related to #1235. This closes only cell 4.6; cells 4.1, 4.5, 4.7, 4.8, and 6.6 remain separate.

## Classification

GENERAL CAPABILITY

The behavior lives in `internal/atlasreport`, below both command adapters. Native Ptah and the compatibility surface already consume that serializer, so no separate native exposure is required.

## Verification

- exact-byte tests in `internal/atlasreport`, `cmd/schema`, and `cmd/atlas`
- `go test -race ./internal/atlasreport ./cmd/schema ./cmd/atlas -count=1`
- `go test ./core/renderer -count=1`
- full `go test ./... -count=1`
- targeted `go vet` and `golangci-lint`
- test-style guard
- all public API guards
- complete documentation guards, site build, and responsive checks
- `npm audit --audit-level=low`: 0 vulnerabilities
- `git diff --check`

Independent review: clean.

## Sequencing

PR #1401 has landed. This branch is rebased directly onto the current `master`, and the diff remains limited to the five cell-4.6 files.