### PR TITLE
fix(compat): match missing validate directory error

### DIFF
--- a/cmd/atlas/migrate_integrity_formats_test.go
+++ b/cmd/atlas/migrate_integrity_formats_test.go
@@ -923,31 +923,3 @@ func TestCompatMigrateIntegritySemicolonQuery_FailurePath(t *testing.T) {
 		})
 	}
 }
-
-// TestCompatMigrateIntegrityConvertedDir_FailurePathMissingDirectory keeps the
-// missing-directory diagnostic identical on both layouts.
-func TestCompatMigrateIntegrityConvertedDir_FailurePathMissingDirectory(t *testing.T) {
-	c := qt.New(t)
-
-	tests := []struct {
-		name string
-		verb string
-	}{
-		{name: "hash", verb: "hash"},
-		{name: "validate", verb: "validate"},
-	}
-
-	for _, tt := range tests {
-		c.Run(tt.name, func(c *qt.C) {
-			missing := filepath.Join(c.TempDir(), "missing")
-
-			convertedOut, _, convertedErr := runCompatExit("migrate", tt.verb, "--dir", "file://"+missing+"?format=goose")
-			forwardedOut, _, forwardedErr := runCompatExit("migrate", tt.verb, "--dir", "file://"+missing)
-
-			c.Assert(convertedErr, qt.ErrorMatches, "migrations directory "+missing+": .*no such file or directory")
-			c.Assert(forwardedErr, qt.ErrorMatches, "migrations directory "+missing+": .*no such file or directory")
-			c.Assert(convertedOut, qt.Equals, forwardedOut)
-			c.Assert(exitcode.Code(convertedErr, 0), qt.Equals, 1)
-		})
-	}
-}

--- a/cmd/atlas/migrate_validate.go
+++ b/cmd/atlas/migrate_validate.go
@@ -59,7 +59,7 @@ func atlasMigrateValidateVerb() atlasVerb {
 // a checksum mismatch rather than as a conversion failure.
 func runAtlasMigrateValidate(cmd *cobra.Command, source atlasMigrateSource) error {
 	if err := cmdutil.StatDir(source.dir); err != nil {
-		return cmdutil.Fail(cmd, err)
+		return cmdutil.Fail(cmd, migratevalidate.AtlasDirectoryError(source.dir, err))
 	}
 	fsys := os.DirFS(source.dir)
 	names, err := atlasmigrateimport.SumFileNames(fsys, source.format)

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -156,7 +157,7 @@ func runAtlasValidate(cmd *cobra.Command, dir, dirFormatValue, devURL string) er
 		// and not a usage failure.
 		return FailAtlasChecksumUnreadableEntry(cmd, err)
 	case err != nil:
-		return cmdutil.Fail(cmd, err)
+		return cmdutil.Fail(cmd, AtlasDirectoryError(dir, err))
 	}
 
 	if !result.Integrity.OK() {
@@ -165,6 +166,37 @@ func runAtlasValidate(cmd *cobra.Command, dir, dirFormatValue, devURL string) er
 
 	return nil
 }
+
+// AtlasDirectoryError adapts cmdutil.StatDir's missing-directory diagnostic for
+// dir to the Atlas CE `sql/migrate` wording. Other failures keep their original
+// text, including permission errors, unrelated nested stat errors, and paths
+// that exist but are not directories.
+//
+// The display wrapper unwraps to the complete original error rather than only
+// the extracted [os.PathError], so callers retain every contextual layer for
+// errors.Is and errors.As while the compatibility surface prints Atlas's text.
+func AtlasDirectoryError(dir string, err error) error {
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) ||
+		pathErr.Op != "stat" ||
+		pathErr.Path != dir ||
+		!errors.Is(pathErr, fs.ErrNotExist) ||
+		err.Error() != "migrations directory "+dir+": "+pathErr.Error() {
+		return err
+	}
+	return atlasDirectoryDisplayError{
+		text: "sql/migrate: " + pathErr.Error(),
+		err:  err,
+	}
+}
+
+type atlasDirectoryDisplayError struct {
+	text string
+	err  error
+}
+
+func (e atlasDirectoryDisplayError) Error() string { return e.text }
+func (e atlasDirectoryDisplayError) Unwrap() error { return e.err }
 
 // DirectoryHoldsNoSQLFiles reports whether dir holds no `.sql` file at its top
 // level, which is the shape an integrity file has nothing to cover.

--- a/cmd/migratevalidate/migratevalidate_test.go
+++ b/cmd/migratevalidate/migratevalidate_test.go
@@ -3,6 +3,8 @@ package migratevalidate_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,6 +109,73 @@ func TestValidate_MissingDirectoryExitsTwo(t *testing.T) {
 	// The message surfaces the directory and the underlying stat error.
 	c.Assert(stderr, qt.Contains, "migrations directory")
 	c.Assert(err, qt.ErrorMatches, ".*does-not-exist.*")
+}
+
+func TestAtlasDirectoryError_MissingStatPreservesPathCause(t *testing.T) {
+	c := qt.New(t)
+	pathErr := &os.PathError{Op: "stat", Path: "nope", Err: fs.ErrNotExist}
+	original := fmt.Errorf("migrations directory nope: %w", pathErr)
+
+	got := migratevalidate.AtlasDirectoryError("nope", original)
+
+	c.Assert(got.Error(), qt.Equals, "sql/migrate: stat nope: file does not exist")
+	c.Assert(got, qt.ErrorIs, original)
+	c.Assert(got, qt.ErrorIs, fs.ErrNotExist)
+	var gotPathErr *os.PathError
+	c.Assert(got, qt.ErrorAs, &gotPathErr)
+	c.Assert(gotPathErr, qt.Equals, pathErr)
+}
+
+func TestAtlasDirectoryError_NonMatchingErrorsUnchanged(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		dir  string
+		err  error
+	}{
+		{
+			name: "regular file",
+			dir:  "migrations",
+			err:  errors.New("migrations directory migrations: not a directory"),
+		},
+		{
+			name: "stat permission denied",
+			dir:  "migrations",
+			err: fmt.Errorf("migrations directory migrations: %w", &os.PathError{
+				Op: "stat", Path: "migrations", Err: fs.ErrPermission,
+			}),
+		},
+		{
+			name: "missing open",
+			dir:  "migrations",
+			err: fmt.Errorf("open migrations directory: %w", &os.PathError{
+				Op: "open", Path: "migrations", Err: fs.ErrNotExist,
+			}),
+		},
+		{
+			name: "missing stat with unrelated context",
+			dir:  "migrations",
+			err: fmt.Errorf("read config: %w", &os.PathError{
+				Op: "stat", Path: "migrations", Err: fs.ErrNotExist,
+			}),
+		},
+		{
+			name: "missing stat for another directory",
+			dir:  "migrations",
+			err: fmt.Errorf("migrations directory other: %w", &os.PathError{
+				Op: "stat", Path: "other", Err: fs.ErrNotExist,
+			}),
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got := migratevalidate.AtlasDirectoryError(test.dir, test.err)
+
+			c.Assert(got, qt.Equals, test.err)
+		})
+	}
 }
 
 func TestValidate_PositionalArgExitsTwoWithMessage(t *testing.T) {

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1285,11 +1285,11 @@ A desired type names a domain when the desired schema declares one by that
 name, which is how every source Ptah reads carries it. A bare name with no
 declaration behind it stays an ordinary type name.
 
-## Output shape: four cells from the #1235 register
+## Output shape: five cells from the #1235 register
 
 [`stokaro/ptah#1235`](https://github.com/stokaro/ptah/issues/1235) registers 51
 places where `ptah-compat` and the pinned community binary v1.3.0 agree on the
-exit code and disagree on the bytes. Four of them are closed here. Every row was
+exit code and disagree on the bytes. Five of them are closed here. Every row was
 measured with each binary in its own directory, every exit code read from an
 unpiped invocation.
 
@@ -1298,6 +1298,7 @@ unpiped invocation.
 | 6.2 | `schema inspect --format '{{ json . }}'` over `a TEXT UNIQUE, b TEXT UNIQUE` plus `CREATE UNIQUE INDEX ux_t_c` | 3 indexes | 5 — each implicit autoindex listed twice | 3 |
 | 9.3 | `migrate apply` over an already-applied directory | `No migration files to execute\n` | the same plus a period | byte-identical |
 | 9.4 | `schema apply --auto-approve` against a synced database | `Schema is synced, no changes to be made\n` | the same plus a period | byte-identical |
+| 9.6 | `migrate validate --dir file://migrations` with no directory; the same under `--dir-format goose` | Exit 1, empty stdout, stderr `Error: sql/migrate: stat migrations: no such file or directory\n` (63 bytes) | Exit 1, empty stdout, stderr `Error: migrations directory migrations: stat migrations: no such file or directory\n` (83 bytes) | byte-identical on both layouts |
 | 9.13 | `schema apply --to file://schema.hcl --dry-run` with an unclosed HCL block | HCL parser diagnostic without loader context | the same body prefixed by `load --to schema: parse HCL schema: ` | byte-identical |
 
 **6.2 is not SQLite-specific, though the register is.** It reproduces on
@@ -1324,6 +1325,15 @@ connection's.
 `Schemas are synced, no changes to be made.`, does carry a period and already
 matched; only the `apply` spelling grew one. The native `ptah schema apply`
 sentence is untouched: no parity is owed on that surface.
+
+**9.6 changes only the compatibility diagnostic.** The adapter recognizes the
+command's own missing-directory `stat` error and changes its displayed text
+while preserving the complete original error chain. Permission errors, regular
+files, and unrelated errors keep their prior diagnostics. Native
+`ptah migrations validate --dir nope` also stays distinct: exit 2, empty
+stdout, and
+`error: migrations directory nope: stat nope: no such file or directory\n` on
+stderr.
 
 **9.13 changes only the compatibility error adapter.** Measured 2026-08-11
 with the file body `schema "main" {\n`, both binaries exited 1, wrote no stdout,

--- a/integration/migrate_validate_missing_dir_e2e_test.go
+++ b/integration/migrate_validate_missing_dir_e2e_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestMigrateValidateDirectoryDiagnosticsE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	repoRoot := e2eRepoRoot(t)
+	compatBinary := filepath.Join(t.TempDir(), "ptah-compat")
+	nativeBinary := filepath.Join(t.TempDir(), "ptah")
+	buildPtahCompat(c, ctx, repoRoot, compatBinary)
+	buildPtah(c, ctx, repoRoot, nativeBinary)
+
+	compatCases := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name:       "compat hash Atlas layout",
+			args:       []string{"migrate", "hash", "--dir", "file://migrations"},
+			wantStderr: "Error: migrations directory migrations: stat migrations: no such file or directory\n",
+		},
+		{
+			name:       "compat hash Goose layout",
+			args:       []string{"migrate", "hash", "--dir", "file://migrations?format=goose"},
+			wantStderr: "Error: migrations directory migrations: stat migrations: no such file or directory\n",
+		},
+		{
+			name:       "compat validate Atlas layout",
+			args:       []string{"migrate", "validate", "--dir", "file://migrations"},
+			wantStderr: "Error: sql/migrate: stat migrations: no such file or directory\n",
+		},
+		{
+			name: "compat validate Goose layout via flag",
+			args: []string{
+				"migrate", "validate", "--dir", "file://migrations", "--dir-format", "goose",
+			},
+			wantStderr: "Error: sql/migrate: stat migrations: no such file or directory\n",
+		},
+		{
+			name:       "compat validate Goose layout via URL",
+			args:       []string{"migrate", "validate", "--dir", "file://migrations?format=goose"},
+			wantStderr: "Error: sql/migrate: stat migrations: no such file or directory\n",
+		},
+	}
+
+	for _, test := range compatCases {
+		c.Run(test.name, func(c *qt.C) {
+			dir := c.TempDir()
+
+			stdout, stderr, err := runCLIProcess(ctx, dir, compatBinary, test.args...)
+
+			c.Assert(exitStatusOf(c, err), qt.Equals, 1)
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, test.wantStderr)
+		})
+	}
+
+	c.Run("compat regular file keeps prior diagnostic", func(c *qt.C) {
+		dir := c.TempDir()
+		c.Assert(os.WriteFile(filepath.Join(dir, "migration.sql"), []byte("SELECT 1;\n"), 0o600), qt.IsNil)
+
+		stdout, stderr, err := runCLIProcess(ctx, dir, compatBinary,
+			"migrate", "validate", "--dir", "file://migration.sql",
+		)
+
+		c.Assert(exitStatusOf(c, err), qt.Equals, 1)
+		c.Assert(stdout, qt.Equals, "")
+		c.Assert(stderr, qt.Equals,
+			"Error: migrations directory migration.sql: not a directory\n")
+	})
+
+	c.Run("native missing directory keeps native diagnostic", func(c *qt.C) {
+		dir := c.TempDir()
+
+		stdout, stderr, err := runCLIProcess(ctx, dir, nativeBinary,
+			"migrations", "validate", "--dir", "migrations",
+		)
+
+		c.Assert(exitStatusOf(c, err), qt.Equals, 2)
+		c.Assert(stdout, qt.Equals, "")
+		c.Assert(stderr, qt.Equals,
+			"error: migrations directory migrations: stat migrations: no such file or directory\n")
+	})
+}

--- a/integration/schema_apply_hcl_error_e2e_test.go
+++ b/integration/schema_apply_hcl_error_e2e_test.go
@@ -35,7 +35,7 @@ func TestSchemaApplyHCLDiagnosticsE2E(t *testing.T) {
 		schemaPath := filepath.Join(dir, "schema.hcl")
 		c.Assert(os.WriteFile(schemaPath, []byte("schema \"main\" {\n"), 0o600), qt.IsNil)
 
-		stdout, stderr, err := runSchemaApplyProcess(ctx, dir, compatBinary,
+		stdout, stderr, err := runCLIProcess(ctx, dir, compatBinary,
 			"schema", "apply",
 			"--url", "sqlite://"+filepath.Join(dir, "target.db"),
 			"--to", "file://"+schemaPath,
@@ -53,7 +53,7 @@ func TestSchemaApplyHCLDiagnosticsE2E(t *testing.T) {
 		dir := c.TempDir()
 		schemaPath := filepath.Join(dir, "missing.hcl")
 
-		stdout, stderr, err := runSchemaApplyProcess(ctx, dir, compatBinary,
+		stdout, stderr, err := runCLIProcess(ctx, dir, compatBinary,
 			"schema", "apply",
 			"--url", "sqlite://"+filepath.Join(dir, "target.db"),
 			"--to", "file://"+schemaPath,
@@ -72,7 +72,7 @@ func TestSchemaApplyHCLDiagnosticsE2E(t *testing.T) {
 		schemaPath := filepath.Join(dir, "schema.hcl")
 		c.Assert(os.WriteFile(schemaPath, []byte("schema \"main\" {\n"), 0o600), qt.IsNil)
 
-		stdout, stderr, err := runSchemaApplyProcess(ctx, dir, nativeBinary,
+		stdout, stderr, err := runCLIProcess(ctx, dir, nativeBinary,
 			"schema", "apply",
 			"--db-url", "sqlite://"+filepath.Join(dir, "target.db"),
 			"--to", "file://"+schemaPath,
@@ -88,7 +88,7 @@ func TestSchemaApplyHCLDiagnosticsE2E(t *testing.T) {
 	})
 }
 
-func runSchemaApplyProcess(
+func runCLIProcess(
 	ctx context.Context,
 	dir string,
 	binaryPath string,


### PR DESCRIPTION
## Summary

- match Atlas CE v1.3.0's missing-directory diagnostic for `ptah-compat migrate validate`
- apply the adapter to both Atlas and Goose directory layouts
- preserve native Ptah diagnostics and the complete original error chain
- keep real-binary/filesystem coverage in tagged black-box integration tests
- document issue #1235 cell 9.6 with exact byte evidence

## Classification

COMPATIBILITY ADAPTER

This changes only Atlas-compatible error rendering. The shared validation capability and native `ptah migrations validate` behavior remain unchanged.

## Exact contract

For an absent `file://migrations` directory, both Atlas and Goose compatibility paths now return exit 1, write no stdout, and write exactly:

```text
Error: sql/migrate: stat migrations: no such file or directory
```

The adapter is fail-closed: it requires the exact `cmdutil.StatDir` context, matching directory, `stat` operation, and `fs.ErrNotExist`. Permission failures, regular files, unrelated nested stat errors, open errors, and other-directory errors retain their original diagnostics. `errors.Is` and `errors.As` still traverse the complete original chain.

## Test contour

Deterministic adapter and error-chain cases remain package unit tests. Process and filesystem behavior for both `ptah-compat` and native `ptah` lives under `integration/**`, uses `//go:build integration`, and exercises exported process boundaries from `package integration_test`.

## Final base and head

- base: `c5d621c1220e97550122beb9c595208abd670dcf`
- head: `3e1e8b360bb3ad832869360d8f2d0d821330f423`
- remote commit: exactly one commit above the base, with seven changed files and no unrelated delta

## Verification on the final tree

- `go test -race ./cmd/atlas ./cmd/migratevalidate -count=1`
- `go test -race -tags integration ./integration -run '^TestMigrateValidateDirectoryDiagnosticsE2E$' -count=1`
- `go tool qtlint ./...`
- `./scripts/check-test-style.sh`
- `golangci-lint run ./...` (`0 issues`)
- `node docs/site/scripts/check-style.mjs`

Closes only issue #1235 cell 9.6; the issue remains open.