### PR TITLE
fix(compat): match unknown dir format errors

### DIFF
--- a/cmd/atlas/migrate_integrity.go
+++ b/cmd/atlas/migrate_integrity.go
@@ -58,6 +58,23 @@ type atlasMigrateSource struct {
 	projectArgs []string
 }
 
+// atlasMigrateIntegrityUnknownDirFormatDisplayError adapts the shared semantic
+// resolver's unknown-format error to the Atlas-compatible integrity surface.
+// Unwrap keeps the original command, spelling, and semantic context available
+// to callers that inspect the error chain.
+type atlasMigrateIntegrityUnknownDirFormatDisplayError struct {
+	value string
+	err   error
+}
+
+func (e atlasMigrateIntegrityUnknownDirFormatDisplayError) Error() string {
+	return fmt.Sprintf("unknown dir format %q", e.value)
+}
+
+func (e atlasMigrateIntegrityUnknownDirFormatDisplayError) Unwrap() error {
+	return e.err
+}
+
 // newAtlasMigrateIntegrityCommand wraps the table-driven adapter command for an
 // Atlas integrity verb with a converted-source-format path.
 //
@@ -93,6 +110,13 @@ func newAtlasMigrateIntegrityCommand(
 		}()
 		source, err := resolveAtlasMigrateSource(cmd, verb, args, cleanup)
 		if err != nil {
+			var unknownFormat *atlasmigrate.UnknownDirFormatError
+			if errors.As(err, &unknownFormat) {
+				return atlasMigrateIntegrityUnknownDirFormatDisplayError{
+					value: unknownFormat.Value,
+					err:   err,
+				}
+			}
 			return err
 		}
 		// Both verbs reaching this wrapper -- `migrate hash` and

--- a/cmd/atlas/migrate_integrity_formats_test.go
+++ b/cmd/atlas/migrate_integrity_formats_test.go
@@ -2,6 +2,7 @@ package atlas_test
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"go.5x5.cz/ptah/cmd/atlas"
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
 	"go.5x5.cz/ptah/cmd/internal/exitcode"
+	"go.5x5.cz/ptah/internal/atlasmigrate"
 	"go.5x5.cz/ptah/internal/migratesum"
 )
 
@@ -78,7 +80,25 @@ func runCompatExit(args ...string) (stdout, stderr string, err error) {
 	cmd.SetErr(&errOut)
 	cmd.SetArgs(args)
 	executed, execErr := cmd.ExecuteC()
-	return out.String(), errOut.String(), cmdutil.NormalizeCommandError(executed, execErr, 2)
+	normalizedErr := cmdutil.NormalizeCommandError(executed, execErr, 2)
+	return out.String(), errOut.String(), normalizedErr
+}
+
+func errorChainContainsText(err error, want string) bool {
+	if err == nil {
+		return false
+	}
+	if err.Error() == want {
+		return true
+	}
+	if multiErr, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, child := range multiErr.Unwrap() {
+			if errorChainContainsText(child, want) {
+				return true
+			}
+		}
+	}
+	return errorChainContainsText(errors.Unwrap(err), want)
 }
 
 func writeIntegrityFixture(c *qt.C) string {
@@ -507,32 +527,32 @@ func TestCompatMigrateSourceFormat_FailurePathUnknownFormat(t *testing.T) {
 		{
 			name: "unknown query value",
 			args: func(dir string) []string { return []string{"--dir", "file://" + dir + "?format=sqitch"} },
-			want: `atlas migrate hash --dir: unknown Atlas migration directory format "sqitch": .*`,
+			want: `unknown dir format "sqitch"`,
 		},
 		{
 			name: "unknown flag value",
 			args: func(dir string) []string { return []string{"--dir", "file://" + dir, "--dir-format", "sqitch"} },
-			want: `atlas migrate hash --dir-format: unknown Atlas migration directory format "sqitch": .*`,
+			want: `unknown dir format "sqitch"`,
 		},
 		{
 			name: "uppercase query value",
 			args: func(dir string) []string { return []string{"--dir", "file://" + dir + "?format=GOOSE"} },
-			want: `atlas migrate hash --dir: unknown Atlas migration directory format "GOOSE": .*`,
+			want: `unknown dir format "GOOSE"`,
 		},
 		{
 			name: "uppercase flag value",
 			args: func(dir string) []string { return []string{"--dir", "file://" + dir, "--dir-format", "GOOSE"} },
-			want: `atlas migrate hash --dir-format: unknown Atlas migration directory format "GOOSE": .*`,
+			want: `unknown dir format "GOOSE"`,
 		},
 		{
 			name: "uppercase atlas flag value",
 			args: func(dir string) []string { return []string{"--dir", "file://" + dir, "--dir-format", "ATLAS"} },
-			want: `atlas migrate hash --dir-format: unknown Atlas migration directory format "ATLAS": .*`,
+			want: `unknown dir format "ATLAS"`,
 		},
 		{
 			name: "padded flag value",
 			args: func(dir string) []string { return []string{"--dir", "file://" + dir, "--dir-format", " goose "} },
-			want: `atlas migrate hash --dir-format: unknown Atlas migration directory format " goose ": .*`,
+			want: `unknown dir format " goose "`,
 		},
 	}
 
@@ -548,6 +568,63 @@ func TestCompatMigrateSourceFormat_FailurePathUnknownFormat(t *testing.T) {
 			c.Assert(os.IsNotExist(statErr), qt.IsTrue)
 		})
 	}
+}
+
+func TestCompatMigrateIntegrityUnknownFormatPreservesSemanticErrorChain(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, stderr, err := runCompatExit(
+		"migrate", "validate",
+		"--dir", "file://migrations",
+		"--dir-format", " bogus ",
+	)
+	var unknownFormat *atlasmigrate.UnknownDirFormatError
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(err.Error(), qt.Equals, `unknown dir format " bogus "`)
+	c.Assert(stdout, qt.Equals, "")
+	c.Assert(stderr, qt.Equals, "Error: unknown dir format \" bogus \"\n")
+	c.Assert(err, qt.ErrorAs, &unknownFormat)
+	c.Assert(unknownFormat.Value, qt.Equals, " bogus ")
+	c.Assert(errorChainContainsText(err,
+		`atlas migrate validate --dir-format: unknown Atlas migration directory format " bogus ": expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate`),
+		qt.IsTrue)
+}
+
+func TestCompatMigrateIntegrityUnknownFormatAdapterLeavesOtherErrorsUnchanged(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, stderr, err := runCompatExit(
+		"migrate", "hash",
+		"--dir", "file://migrations?format=flyway;x=1",
+	)
+	const want = "atlas migrate hash --dir: parse migration directory URL query: invalid semicolon separator in query"
+	var unknownFormat *atlasmigrate.UnknownDirFormatError
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(err.Error(), qt.Equals, want)
+	c.Assert(stdout, qt.Equals, "")
+	c.Assert(stderr, qt.Equals, "Error: "+want+"\n")
+	c.Assert(err, qt.Not(qt.ErrorAs), &unknownFormat)
+}
+
+func TestCompatMigrateNewUnknownFormatKeepsVerboseDiagnostic(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, stderr, err := runCompatExit(
+		"migrate", "new", "demo",
+		"--dir", "file://migrations",
+		"--dir-format", "bogus",
+	)
+	const want = `atlas migrate new --dir-format: unknown Atlas migration directory format "bogus": expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate`
+	var unknownFormat *atlasmigrate.UnknownDirFormatError
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(err.Error(), qt.Equals, want)
+	c.Assert(stdout, qt.Equals, "")
+	c.Assert(stderr, qt.Equals, "Error: "+want+"\n")
+	c.Assert(err, qt.ErrorAs, &unknownFormat)
+	c.Assert(unknownFormat.Value, qt.Equals, "bogus")
 }
 
 // TestCompatMigrateSourceFormatQuery_HappyPath pins the two query-parsing rules
@@ -636,12 +713,12 @@ func TestCompatMigrateSourceFormat_FailurePathUnsupportedQuery(t *testing.T) {
 		{
 			name:  "unknown format value",
 			query: "?format=totally-bogus",
-			want:  `atlas migrate hash --dir: unknown Atlas migration directory format "totally-bogus": expected .*`,
+			want:  `unknown dir format "totally-bogus"`,
 		},
 		{
 			name:  "unknown format value beside an ignored key",
 			query: "?format=totally-bogus&other=1",
-			want:  `atlas migrate hash --dir: unknown Atlas migration directory format "totally-bogus": expected .*`,
+			want:  `unknown dir format "totally-bogus"`,
 		},
 	}
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1285,11 +1285,11 @@ A desired type names a domain when the desired schema declares one by that
 name, which is how every source Ptah reads carries it. A bare name with no
 declaration behind it stays an ordinary type name.
 
-## Output shape: five cells from the #1235 register
+## Output shape: six cells from the #1235 register
 
 [`stokaro/ptah#1235`](https://github.com/stokaro/ptah/issues/1235) registers 51
 places where `ptah-compat` and the pinned community binary v1.3.0 agree on the
-exit code and disagree on the bytes. Five of them are closed here. Every row was
+exit code and disagree on the bytes. Six of them are closed here. Every row was
 measured with each binary in its own directory, every exit code read from an
 unpiped invocation.
 
@@ -1298,6 +1298,7 @@ unpiped invocation.
 | 6.2 | `schema inspect --format '{{ json . }}'` over `a TEXT UNIQUE, b TEXT UNIQUE` plus `CREATE UNIQUE INDEX ux_t_c` | 3 indexes | 5 — each implicit autoindex listed twice | 3 |
 | 9.3 | `migrate apply` over an already-applied directory | `No migration files to execute\n` | the same plus a period | byte-identical |
 | 9.4 | `schema apply --auto-approve` against a synced database | `Schema is synced, no changes to be made\n` | the same plus a period | byte-identical |
+| 9.5 | `migrate validate` with `?format=bogus`; the same under `--dir-format bogus` and on `migrate hash` | Exit 1, empty stdout, stderr `Error: unknown dir format "bogus"\n` (34 bytes) | Exit 1 with a contextual semantic diagnostic that differed by verb and spelling | byte-identical on all four rows |
 | 9.6 | `migrate validate --dir file://migrations` with no directory; the same under `--dir-format goose` | Exit 1, empty stdout, stderr `Error: sql/migrate: stat migrations: no such file or directory\n` (63 bytes) | Exit 1, empty stdout, stderr `Error: migrations directory migrations: stat migrations: no such file or directory\n` (83 bytes) | byte-identical on both layouts |
 | 9.13 | `schema apply --to file://schema.hcl --dry-run` with an unclosed HCL block | HCL parser diagnostic without loader context | the same body prefixed by `load --to schema: parse HCL schema: ` | byte-identical |
 
@@ -1334,6 +1335,12 @@ files, and unrelated errors keep their prior diagnostics. Native
 stdout, and
 `error: migrations directory nope: stat nope: no such file or directory\n` on
 stderr.
+
+**9.5 changes only the shared integrity adapter.** Both format spellings on
+`migrate hash` and `migrate validate` now print the pinned diagnostic before
+filesystem or database work. The invalid value stays verbatim, and the semantic
+resolver retains its detailed error in the unwrap chain. Native `ptah` and
+other Atlas-compatible errors keep their existing diagnostics.
 
 **9.13 changes only the compatibility error adapter.** Measured 2026-08-11
 with the file body `schema "main" {\n`, both binaries exited 1, wrote no stdout,

--- a/integration/migrate_unknown_dir_format_e2e_test.go
+++ b/integration/migrate_unknown_dir_format_e2e_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestMigrateUnknownDirectoryFormatDiagnosticsE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	repoRoot := e2eRepoRoot(t)
+	compatBinary := filepath.Join(t.TempDir(), "ptah-compat")
+	nativeBinary := filepath.Join(t.TempDir(), "ptah")
+	buildPtahCompat(c, ctx, repoRoot, compatBinary)
+	buildPtah(c, ctx, repoRoot, nativeBinary)
+
+	compatCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "compat hash query",
+			args: []string{"migrate", "hash", "--dir", "file://migrations?format=bogus"},
+		},
+		{
+			name: "compat hash flag",
+			args: []string{"migrate", "hash", "--dir", "file://migrations", "--dir-format", "bogus"},
+		},
+		{
+			name: "compat validate query",
+			args: []string{"migrate", "validate", "--dir", "file://migrations?format=bogus"},
+		},
+		{
+			name: "compat validate flag",
+			args: []string{"migrate", "validate", "--dir", "file://migrations", "--dir-format", "bogus"},
+		},
+	}
+
+	for _, test := range compatCases {
+		c.Run(test.name, func(c *qt.C) {
+			stdout, stderr, err := runCLIProcess(ctx, c.TempDir(), compatBinary, test.args...)
+
+			c.Assert(exitStatusOf(c, err), qt.Equals, 1)
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, "Error: unknown dir format \"bogus\"\n")
+			c.Assert(stderr, qt.HasLen, 34)
+		})
+	}
+
+	c.Run("native validate keeps native diagnostic", func(c *qt.C) {
+		dir := c.TempDir()
+
+		stdout, stderr, err := runCLIProcess(ctx, dir, nativeBinary,
+			"migrations", "validate",
+			"--dir", dir,
+			"--dir-format", "bogus",
+		)
+
+		c.Assert(exitStatusOf(c, err), qt.Equals, 2)
+		c.Assert(stdout, qt.Equals, "")
+		c.Assert(stderr, qt.Equals,
+			"error: unknown migration directory format \"bogus\": expected auto, ptah, or atlas\n")
+	})
+}

--- a/internal/atlasmigrate/format.go
+++ b/internal/atlasmigrate/format.go
@@ -17,6 +17,21 @@ import (
 // [IgnoredDirQueryKeys] reports the complement of.
 const DirFormatQueryKey = "format"
 
+// UnknownDirFormatError reports a migration directory format the Atlas
+// semantic resolver does not recognize. Value is retained verbatim so a
+// compatibility adapter can reproduce the external surface's diagnostic
+// without parsing this error's semantic context.
+type UnknownDirFormatError struct {
+	Value string
+}
+
+func (e *UnknownDirFormatError) Error() string {
+	return fmt.Sprintf(
+		"unknown Atlas migration directory format %q: expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate",
+		e.Value,
+	)
+}
+
 // ResolveApplySourceForFormat returns the immutable filesystem the Atlas apply
 // migrator should read for an already-resolved directory format. The native
 // Atlas format preserves atlas.sum and down migrations. Every other supported
@@ -155,10 +170,7 @@ func parseApplyDirFormat(value string) (atlasmigrateimport.Format, error) {
 		atlasmigrateimport.FormatDBMate:
 		return atlasmigrateimport.Format(value), nil
 	default:
-		return "", fmt.Errorf(
-			"unknown Atlas migration directory format %q: expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate",
-			value,
-		)
+		return "", &UnknownDirFormatError{Value: value}
 	}
 }
 

--- a/internal/atlasmigrate/format_test.go
+++ b/internal/atlasmigrate/format_test.go
@@ -1,6 +1,7 @@
 package atlasmigrate_test
 
 import (
+	"errors"
 	"io/fs"
 	"net/url"
 	"os"
@@ -348,8 +349,13 @@ func TestResolveApplyDirFormat(t *testing.T) {
 
 	c.Run("unknown format reports the resolve error", func(c *qt.C) {
 		got, err := atlasmigrate.ResolveApplyDirFormat("sqitch", nil)
+		var unknownFormat *atlasmigrate.UnknownDirFormatError
 
-		c.Assert(err, qt.ErrorMatches, `unknown Atlas migration directory format "sqitch".*`)
+		c.Assert(err, qt.ErrorAs, &unknownFormat)
+		c.Assert(err.Error(), qt.Equals,
+			`unknown Atlas migration directory format "sqitch": expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate`)
+		c.Assert(unknownFormat.Value, qt.Equals, "sqitch")
+		c.Assert(errors.Unwrap(err), qt.IsNil)
 		c.Assert(string(got), qt.Equals, "")
 	})
 }


### PR DESCRIPTION
## Summary

- match Atlas CE v1.3.0's unknown migration-directory format diagnostic
- cover both `migrate hash` and `migrate validate`, under query and flag spellings
- preserve Ptah's detailed typed semantic error and complete contextual unwrap chain
- keep `migrate new`, native Ptah, valid formats, strictness, and precedence unchanged
- keep real-binary coverage in tagged black-box integration tests
- document issue #1235 cell 9.5 with exact byte evidence

## Classification

COMPATIBILITY ADAPTER

The semantic resolver still returns a detailed typed error with the invalid value preserved verbatim. Only the Atlas-compatible hash/validate integrity boundary maps that error to the external Atlas display contract.

## Exact contract

These four cases return exit 1, write no stdout, and write exactly 34 bytes to stderr:

- `migrate hash --dir 'file://migrations?format=bogus'`
- `migrate hash --dir file://migrations --dir-format bogus`
- `migrate validate --dir 'file://migrations?format=bogus'`
- `migrate validate --dir file://migrations --dir-format bogus`

```text
Error: unknown dir format "bogus"
```

A separate control proves `migrate new` remains outside this adapter, avoiding the neighboring cell 9.8 and PR #1400 scope.

## Test contour

Deterministic resolver, adapter, precedence, and unwrap-chain cases remain package unit tests. The four real-binary compatibility cases plus the native diagnostic control live under `integration/**`, use `//go:build integration`, and run from `package integration_test` with ambient `PTAH_*` variables removed.

## Final base and head

- base: `4810047d81e53cbe074dc9e12bec29381b158725`
- head: `74db5ea76d6f401dc750c492425347ec3fedcada`
- remote commit: exactly one commit above the base, with six changed files and no unrelated delta

## Verification on the final tree

- `go test -race ./cmd/atlas ./internal/atlasmigrate -count=1`
- `go test -race -tags integration ./integration -run '^TestMigrateUnknownDirectoryFormatDiagnosticsE2E$' -count=1`
- `go tool qtlint ./...`
- `./scripts/check-test-style.sh`
- `golangci-lint run ./...` (`0 issues`)
- `node docs/site/scripts/check-style.mjs`

Closes only issue #1235 cell 9.5; the issue remains open.