### PR TITLE
fix(compat): match migrate lint missing directory error

### DIFF
--- a/cmd/atlas/migrate_lint.go
+++ b/cmd/atlas/migrate_lint.go
@@ -234,7 +234,7 @@ func runAtlasMigrateLint(
 	}
 	source, err := project.captureLocal(localDir)
 	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate lint --dir: %w", err))
+		return cmdutil.Fail(cmd, atlasMigrateLintDirCaptureError(localDir.Path, localDir.AllowedRoot, err))
 	}
 	dir := source.Display
 	lintOptions := migrationlintreport.Options{

--- a/cmd/atlas/migrate_lint_error.go
+++ b/cmd/atlas/migrate_lint_error.go
@@ -1,0 +1,71 @@
+package atlas
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+type atlasMigrateLintMissingDirectoryError struct {
+	path    string
+	pathErr *os.PathError
+	cause   error
+}
+
+func (e *atlasMigrateLintMissingDirectoryError) Error() string {
+	return fmt.Sprintf("sql/migrate: stat %s: %v", e.path, e.pathErr.Err)
+}
+
+func (e *atlasMigrateLintMissingDirectoryError) Unwrap() error {
+	return e.cause
+}
+
+// atlasMigrateLintDirCaptureError adapts only the missing-directory error from
+// the rooted open performed by migrationsource.CaptureLocal. Its displayed
+// diagnostic matches the pinned Atlas binary while the complete prior error
+// chain remains available to errors.Is and errors.As.
+func atlasMigrateLintDirCaptureError(path, allowedRoot string, captureErr error) error {
+	prior := fmt.Errorf("atlas migrate lint --dir: %w", captureErr)
+	pathErr, ok := atlasMigrateLintMissingDirectoryPathError(captureErr)
+	if !ok || !atlasMigrateLintPathErrorMatches(path, allowedRoot, pathErr.Path) {
+		return prior
+	}
+	return &atlasMigrateLintMissingDirectoryError{
+		path:    filepath.Clean(pathErr.Path),
+		pathErr: pathErr,
+		cause:   prior,
+	}
+}
+
+func atlasMigrateLintMissingDirectoryPathError(err error) (*os.PathError, bool) {
+	direct, ok := err.(interface{ Unwrap() error })
+	if !ok {
+		return nil, false
+	}
+	pathErr, ok := direct.Unwrap().(*os.PathError)
+	if !ok || err.Error() != "open migrations directory: "+pathErr.Error() {
+		return nil, false
+	}
+	if pathErr.Op != "open" && pathErr.Op != "openat" {
+		return nil, false
+	}
+	if !errors.Is(pathErr.Err, fs.ErrNotExist) {
+		return nil, false
+	}
+	return pathErr, true
+}
+
+func atlasMigrateLintPathErrorMatches(path, allowedRoot, errorPath string) bool {
+	return atlasMigrateLintRootedCleanPath(path, allowedRoot) ==
+		atlasMigrateLintRootedCleanPath(errorPath, allowedRoot)
+}
+
+func atlasMigrateLintRootedCleanPath(path, allowedRoot string) string {
+	clean := filepath.Clean(path)
+	if allowedRoot != "" && !filepath.IsAbs(clean) {
+		return filepath.Clean(filepath.Join(allowedRoot, clean))
+	}
+	return clean
+}

--- a/cmd/atlas/migrate_lint_error_internal_test.go
+++ b/cmd/atlas/migrate_lint_error_internal_test.go
@@ -1,0 +1,163 @@
+package atlas
+
+// White-box testing required: this file verifies the narrow structural match
+// and unwrap chain of an unexported compatibility error adapter.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestAtlasMigrateLintDirCaptureError_AdaptsMissingOpen(t *testing.T) {
+	c := qt.New(t)
+	pathErr := &os.PathError{Op: "openat", Path: "missing", Err: syscall.ENOENT}
+	captureErr := fmt.Errorf("open migrations directory: %w", pathErr)
+
+	got := atlasMigrateLintDirCaptureError("nested/../missing", "", captureErr)
+
+	c.Assert(got.Error(), qt.Equals, "sql/migrate: stat missing: no such file or directory")
+	c.Assert(got, qt.ErrorIs, captureErr)
+	c.Assert(got, qt.ErrorIs, syscall.ENOENT)
+	var gotPathErr *os.PathError
+	c.Assert(got, qt.ErrorAs, &gotPathErr)
+	c.Assert(gotPathErr, qt.Equals, pathErr)
+	c.Assert(errors.Unwrap(got).Error(), qt.Equals,
+		"atlas migrate lint --dir: open migrations directory: openat missing: no such file or directory")
+}
+
+func TestAtlasMigrateLintDirCaptureError_RootedPathUsesObservedSpelling(t *testing.T) {
+	c := qt.New(t)
+	pathErr := &os.PathError{Op: "openat", Path: "missing", Err: syscall.ENOENT}
+	captureErr := fmt.Errorf("open migrations directory: %w", pathErr)
+
+	got := atlasMigrateLintDirCaptureError("/project/missing", "/project", captureErr)
+
+	c.Assert(got.Error(), qt.Equals, "sql/migrate: stat missing: no such file or directory")
+	c.Assert(got, qt.ErrorIs, captureErr)
+	var gotPathErr *os.PathError
+	c.Assert(got, qt.ErrorAs, &gotPathErr)
+	c.Assert(gotPathErr, qt.Equals, pathErr)
+}
+
+func TestAtlasMigrateLintDirCaptureError_PreservesNonmatchingErrors(t *testing.T) {
+	c := qt.New(t)
+	missingOpen := &os.PathError{Op: "openat", Path: "missing", Err: syscall.ENOENT}
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "regular file",
+			err: fmt.Errorf("open migrations directory: %w", &os.PathError{
+				Op: "openat", Path: "regular", Err: syscall.ENOTDIR,
+			}),
+		},
+		{
+			name: "permission",
+			err: fmt.Errorf("open migrations directory: %w", &os.PathError{
+				Op: "open", Path: "private", Err: syscall.EACCES,
+			}),
+		},
+		{
+			name: "outside root",
+			err:  errors.New(`invalid migrations directory: "/outside" is outside allowed root "/project"`),
+		},
+		{
+			name: "malformed URL",
+			err:  errors.New("decode migration directory URL path: invalid URL escape"),
+		},
+		{
+			name: "capture",
+			err:  fmt.Errorf("capture migrations directory: %w", missingOpen),
+		},
+		{
+			name: "close",
+			err: fmt.Errorf("close migrations directory: %w", &os.PathError{
+				Op: "close", Path: "missing", Err: syscall.ENOENT,
+			}),
+		},
+		{
+			name: "unrelated missing stat",
+			err: fmt.Errorf("open migrations directory: %w", &os.PathError{
+				Op: "stat", Path: "missing", Err: syscall.ENOENT,
+			}),
+		},
+		{
+			name: "different direct-open path",
+			err: fmt.Errorf("open migrations directory: %w", &os.PathError{
+				Op: "openat", Path: "other", Err: syscall.ENOENT,
+			}),
+		},
+		{
+			name: "additional wrapper",
+			err:  fmt.Errorf("prepare source: %w", fmt.Errorf("open migrations directory: %w", missingOpen)),
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got := atlasMigrateLintDirCaptureError("missing", "", test.err)
+
+			c.Assert(got.Error(), qt.Equals, "atlas migrate lint --dir: "+test.err.Error())
+			c.Assert(errors.Unwrap(got), qt.Equals, test.err)
+			c.Assert(got, qt.ErrorIs, test.err)
+		})
+	}
+}
+
+func TestAtlasMigrateLintPathErrorMatches_SymmetricRootedPaths(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		path        string
+		allowedRoot string
+		errorPath   string
+		want        bool
+	}{
+		{
+			name:        "both relative",
+			path:        "nested/../missing",
+			allowedRoot: "/project",
+			errorPath:   "missing",
+			want:        true,
+		},
+		{
+			name:        "requested absolute and error relative",
+			path:        "/project/missing",
+			allowedRoot: "/project",
+			errorPath:   "missing",
+			want:        true,
+		},
+		{
+			name:        "requested relative and error absolute",
+			path:        "missing",
+			allowedRoot: "/project",
+			errorPath:   "/project/missing",
+			want:        true,
+		},
+		{
+			name:        "different rooted path",
+			path:        "missing",
+			allowedRoot: "/project",
+			errorPath:   "/other/missing",
+			want:        false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(
+				atlasMigrateLintPathErrorMatches(test.path, test.allowedRoot, test.errorPath),
+				qt.Equals,
+				test.want,
+			)
+		})
+	}
+}

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1285,11 +1285,11 @@ A desired type names a domain when the desired schema declares one by that
 name, which is how every source Ptah reads carries it. A bare name with no
 declaration behind it stays an ordinary type name.
 
-## Output shape: six cells from the #1235 register
+## Output shape: seven cells from the #1235 register
 
 [`stokaro/ptah#1235`](https://github.com/stokaro/ptah/issues/1235) registers 51
 places where `ptah-compat` and the pinned community binary v1.3.0 agree on the
-exit code and disagree on the bytes. Six of them are closed here. Every row was
+exit code and disagree on the bytes. Seven of them are closed here. Every row was
 measured with each binary in its own directory, every exit code read from an
 unpiped invocation.
 
@@ -1300,6 +1300,7 @@ unpiped invocation.
 | 9.4 | `schema apply --auto-approve` against a synced database | `Schema is synced, no changes to be made\n` | the same plus a period | byte-identical |
 | 9.5 | `migrate validate` with `?format=bogus`; the same under `--dir-format bogus` and on `migrate hash` | Exit 1, empty stdout, stderr `Error: unknown dir format "bogus"\n` (34 bytes) | Exit 1 with a contextual semantic diagnostic that differed by verb and spelling | byte-identical on all four rows |
 | 9.6 | `migrate validate --dir file://migrations` with no directory; the same under `--dir-format goose` | Exit 1, empty stdout, stderr `Error: sql/migrate: stat migrations: no such file or directory\n` (63 bytes) | Exit 1, empty stdout, stderr `Error: migrations directory migrations: stat migrations: no such file or directory\n` (83 bytes) | byte-identical on both layouts |
+| 9.11 | `migrate lint --dir file://nope --dev-url <SQLite> --latest 1`; the same for the default directory, Goose, absolute and nested paths, and `atlas.hcl` | Exit 1, empty stdout, stderr `Error: sql/migrate: stat nope: no such file or directory\n` (57 bytes) | Exit 1, empty stdout, stderr `Error: atlas migrate lint --dir: open migrations directory: openat nope: no such file or directory\n` (99 bytes) | byte-identical across every measured source and layout |
 | 9.13 | `schema apply --to file://schema.hcl --dry-run` with an unclosed HCL block | HCL parser diagnostic without loader context | the same body prefixed by `load --to schema: parse HCL schema: ` | byte-identical |
 
 **6.2 is not SQLite-specific, though the register is.** It reproduces on

--- a/integration/migrate_lint_missing_dir_e2e_test.go
+++ b/integration/migrate_lint_missing_dir_e2e_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+type lintMissingDirectoryProcessCase struct {
+	name     string
+	setup    func(c *qt.C, root string)
+	args     func(root string) []string
+	wantPath func(root string) string
+}
+
+func TestMigrateLintMissingDirectoryDiagnosticsE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	repoRoot := e2eRepoRoot(t)
+	compatBinary := filepath.Join(t.TempDir(), "ptah-compat")
+	nativeBinary := filepath.Join(t.TempDir(), "ptah")
+	buildPtahCompat(c, ctx, repoRoot, compatBinary)
+	buildPtah(c, ctx, repoRoot, nativeBinary)
+
+	compatCases := []lintMissingDirectoryProcessCase{
+		{
+			name:  "compat explicit Atlas directory",
+			setup: leaveLintProjectEmpty,
+			args: func(_ string) []string {
+				return lintMissingDirectoryArgs("--dir", "file://nope")
+			},
+			wantPath: func(_ string) string { return "nope" },
+		},
+		{
+			name:  "compat default Atlas directory",
+			setup: leaveLintProjectEmpty,
+			args: func(_ string) []string {
+				return lintMissingDirectoryArgs()
+			},
+			wantPath: func(_ string) string { return "migrations" },
+		},
+		{
+			name:  "compat Goose query",
+			setup: leaveLintProjectEmpty,
+			args: func(_ string) []string {
+				return lintMissingDirectoryArgs("--dir", "file://nope?format=goose")
+			},
+			wantPath: func(_ string) string { return "nope" },
+		},
+		{
+			name:  "compat Goose flag",
+			setup: leaveLintProjectEmpty,
+			args: func(_ string) []string {
+				return lintMissingDirectoryArgs("--dir", "file://nope", "--dir-format", "goose")
+			},
+			wantPath: func(_ string) string { return "nope" },
+		},
+		{
+			name:  "compat absolute path",
+			setup: leaveLintProjectEmpty,
+			args: func(root string) []string {
+				return lintMissingDirectoryArgs("--dir", "file://"+filepath.Join(root, "nope"))
+			},
+			wantPath: func(root string) string { return filepath.Join(root, "nope") },
+		},
+		{
+			name:  "compat cleaned nested path",
+			setup: leaveLintProjectEmpty,
+			args: func(_ string) []string {
+				return lintMissingDirectoryArgs("--dir", "file://nested/../nope")
+			},
+			wantPath: func(_ string) string { return "nope" },
+		},
+		{
+			name:  "compat atlas.hcl migration directory",
+			setup: writeMissingLintProject,
+			args: func(_ string) []string {
+				return []string{"migrate", "lint", "--env", "local", "--latest", "1"}
+			},
+			wantPath: func(_ string) string { return "nope" },
+		},
+	}
+
+	for _, test := range compatCases {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			test.setup(c, root)
+
+			stdout, stderr, err := runCLIProcess(ctx, root, compatBinary, test.args(root)...)
+			wantStderr := "Error: sql/migrate: stat " + test.wantPath(root) + ": no such file or directory\n"
+
+			c.Assert(exitStatusOf(c, err), qt.Equals, 1)
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, wantStderr)
+			c.Assert(stderr, qt.HasLen, len(wantStderr))
+		})
+	}
+
+	c.Run("native missing directory keeps native diagnostic", func(c *qt.C) {
+		stdout, stderr, err := runCLIProcess(ctx, c.TempDir(), nativeBinary,
+			"migrations", "lint", "--dir", "nope",
+		)
+
+		c.Assert(exitStatusOf(c, err), qt.Equals, 2)
+		c.Assert(stdout, qt.Equals, "")
+		c.Assert(stderr, qt.Equals,
+			"error: migrations directory nope: stat nope: no such file or directory\n")
+	})
+}
+
+func lintMissingDirectoryArgs(extra ...string) []string {
+	args := []string{
+		"migrate", "lint",
+		"--dev-url", "sqlite://file?mode=memory&_fk=1",
+		"--latest", "1",
+	}
+	return append(args, extra...)
+}
+
+func leaveLintProjectEmpty(_ *qt.C, _ string) {}
+
+func writeMissingLintProject(c *qt.C, root string) {
+	c.Helper()
+	c.Assert(os.WriteFile(filepath.Join(root, "atlas.hcl"), []byte(`env "local" {
+  dev = "sqlite://file?mode=memory&_fk=1"
+  migration {
+    dir = "file://nested/../nope"
+  }
+}
+`), 0o600), qt.IsNil)
+}


### PR DESCRIPTION
## Summary

- adapt only `ptah-compat migrate lint` missing-directory diagnostics at the existing rooted capture boundary
- match Atlas CE v1.3.0's `sql/migrate: stat ...` display for Atlas and foreign directory layouts without adding a `stat` preflight
- preserve the complete original error chain and leave native Ptah and every nonmatching capture error unchanged
- keep all process/filesystem coverage in tagged black-box integration tests
- document issue #1235 cell 9.11 with exact byte evidence

## Classification

COMPATIBILITY ADAPTER

This change exists solely to reproduce the Atlas CLI's observable error contract. The underlying rooted filesystem capture remains Ptah's safer implementation.

## Contract and safety

The adapter recognizes only a direct `open migrations directory` wrapper over an `*os.PathError` whose operation is `open` or `openat`, whose cause is `ENOENT`, and whose requested and observed paths identify the same directory after normalization through the allowed root. It displays the cleaned observed path, so relative `atlas.hcl` paths remain relative while absolute CLI paths remain absolute.

It does not call `os.Stat`, loosen root confinement, rewrite permission or regular-file failures, or adapt malformed URLs, unrelated paths, extra wrapper layers, capture failures, or close failures. `errors.Is`, `errors.As`, and the original `*os.PathError` identity remain available through `Unwrap`.

## Evidence

The pinned Atlas CE v1.3.0 differential is byte-identical for seven cases: explicit/default Atlas directories, Goose query/flag formats, absolute and cleaned nested CLI paths, and a relative `atlas.hcl` directory. The common relative result is exit 1, empty stdout, and exactly:

```text
Error: sql/migrate: stat nope: no such file or directory
```

Native `ptah migrations lint` retains its existing exit code and actionable diagnostic.

## Test contour

The narrow structural matcher and unwrap-chain controls remain deterministic package unit tests; their white-box placement is documented because the adapter is intentionally unexported. All compat/native real-binary, filesystem, config-file, and SQLite-dev-URL scenarios live under `integration/**`, use `//go:build integration`, and run from `package integration_test`.

## Final base and head

- base: `2c5e65683c7953138eeb1314fa25c5dd72739223`
- head: `67a26b64be796cbe0a980a2888a429531d5bafd2`
- remote commit: exactly one commit above the base, with five changed files and no unrelated delta

## Verification on the final tree

- `go test ./... -count=1` outside the sandbox so existing `httptest` listeners and testdata scratch writes are permitted
- `go test -race ./cmd/atlas -count=1`
- `go test -race -tags integration ./integration -run '^TestMigrateLintMissingDirectoryDiagnosticsE2E$' -count=1`
- `go tool qtlint ./...`
- `./scripts/check-test-style.sh`
- `golangci-lint run ./...` (`0 issues`)
- `node docs/site/scripts/check-style.mjs`

This closes only issue #1235 cell 9.11; the issue remains open.