### PR TITLE
fix(compat): match missing dir scheme error

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -52,11 +52,10 @@ type atlasVerb struct {
 	// Atlas flags. When nil, the generic applyAtlasProjectConfigToArgs is used.
 	projectConfig atlasProjectArgsApplier
 	// writesDir marks a verb that can CREATE the migration directory it was
-	// pointed at. It selects the scheme requirement in resolveAtlasMigrateSource
-	// (stokaro/ptah#1186): the community binary refuses a --dir naming no scheme
-	// on every verb, and the verbs that merely read one still accept it here,
-	// but a verb that writes turns that leniency into a directory materialised
-	// somewhere the operator did not name.
+	// pointed at. New uses this marker for its command-line scheme gate; diff
+	// owns the same gate separately, as do the read-only hash, validate, status
+	// and lint adapters. A directory named by atlas.hcl remains separate work in
+	// stokaro/ptah#1186.
 	writesDir bool
 }
 

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -159,9 +159,10 @@ func runAtlasMigrateDiff(
 	// creates nothing, measured on the pinned v1.3.0 on 2026-08-06. The flag's
 	// own default carries `file://`, so an omitted --dir passes.
 	//
-	// The read verbs still accept a scheme-less --dir, and so does a directory
-	// named by atlas.hcl on either writing verb; that half is stokaro/ptah#1186
-	// and is deliberately not closed here.
+	// Hash, validate, status and lint apply the same requirement to their
+	// command-line --dir. A directory named by atlas.hcl on either writing verb
+	// remains separate work in stokaro/ptah#1186 and is deliberately not closed
+	// here.
 	if err := atlasargs.RequireDirScheme(dirURLSpelled); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/atlas/migrate_hash_empty_dir_test.go
+++ b/cmd/atlas/migrate_hash_empty_dir_test.go
@@ -31,7 +31,7 @@ func TestMigrateHashRejectsExplicitEmptyDirectoryWithoutWritingSum(t *testing.T)
 	// stat and report `migrations directory : stat : no such file or directory`
 	// (stokaro/ptah#1186). What the test is really about is below: nothing is
 	// written either way.
-	c.Assert(err, qt.ErrorMatches, `missing scheme for dir url\. Did you mean "file://"\?`)
+	c.Assert(err, qt.ErrorMatches, `missing scheme for dir url\. Did you mean "file://"\? `)
 	_, statErr := os.Stat(filepath.Join(root, "atlas.sum"))
 	c.Assert(statErr, qt.ErrorIs, fs.ErrNotExist)
 }

--- a/cmd/atlas/migrate_write_dir_scheme_test.go
+++ b/cmd/atlas/migrate_write_dir_scheme_test.go
@@ -23,18 +23,16 @@ import (
 //	exit 1, nothing created
 //
 // Ptah accepted the bare path on every verb, which on the two verbs that create
-// a directory means materialising one somewhere the operator did not point at:
+// a directory means materializing one somewhere the operator did not point at:
 // `migrate new addcol --dir /tmp/nosuchxyz --dir-format goose` exited 0 and
-// wrote to /private/tmp/nosuchxyz. The read verbs still accept it; that half is
-// #1186 and is deliberately still open.
+// wrote to /private/tmp/nosuchxyz. That change first covered the writers; the
+// read consumers now require the scheme too and are covered below.
 //
 // The suggestion carries the URL's path component only — measured,
 // `--dir 'sub/dir?format=goose&x=1'` and `--dir 'sub/dir#frag'` both suggest
-// `"file://sub/dir"` there, while `--dir ./rel` suggests `"file://./rel"`. The
-// one measured byte Ptah does not reproduce is a trailing space: that binary
-// prints `…"file://mig"? ` where its own `checksum file not found` on the same
-// verb prints none, so the space is a slip in one format string rather than a
-// convention.
+// `"file://sub/dir"` there, while `--dir ./rel` suggests `"file://./rel"`.
+// The message terminates with one ASCII space before the line feed. In hex,
+// its final two bytes on stderr are `20 0a`.
 
 // atlasWriteVerbSpelling is one writing verb invoked with the --dir value
 // exactly as the caller spelled it. It is deliberately not
@@ -72,7 +70,7 @@ func atlasWriteVerbSpellings() []atlasWriteVerbSpelling {
 // atlasMissingSchemeError renders the community binary's message for a
 // directory URL naming no scheme.
 func atlasMissingSchemeError(path string) string {
-	return fmt.Sprintf("missing scheme for dir url. Did you mean %q?", "file://"+path)
+	return fmt.Sprintf("missing scheme for dir url. Did you mean %q? ", "file://"+path)
 }
 
 // TestCompatMigrateWrite_RefusesADirectoryNamingNoScheme is the headline test.
@@ -318,8 +316,9 @@ func TestCompatMigrateWrite_SpellingsTheCommunityBinaryAcceptsStillWrite(t *test
 //	status    binary 1, ptah 1, same line
 //
 // The control is below: the same directory named WITH the scheme still works on
-// every one of them, which is what separates "requires the scheme" from
-// "refuses this directory".
+// the two integrity verbs, which is what separates "requires the scheme" from
+// "refuses this directory". The tagged black-box integration contour covers
+// all six compatibility consumers and native bare-path controls.
 func TestCompatMigrateRead_RequiresTheSchemeToo(t *testing.T) {
 	verbs := []struct {
 		name string
@@ -343,7 +342,7 @@ func TestCompatMigrateRead_RequiresTheSchemeToo(t *testing.T) {
 
 			_, _, err := runCompat(verb.args(dir)...)
 
-			c.Assert(err, qt.ErrorMatches, `missing scheme for dir url\. Did you mean ".*"\?`)
+			c.Assert(err, qt.ErrorMatches, `missing scheme for dir url\. Did you mean ".*"\? `)
 		})
 	}
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1285,17 +1285,18 @@ A desired type names a domain when the desired schema declares one by that
 name, which is how every source Ptah reads carries it. A bare name with no
 declaration behind it stays an ordinary type name.
 
-## Output shape: seven cells from the #1235 register
+## Output shape: nine cells from the #1235 register
 
 [`stokaro/ptah#1235`](https://github.com/stokaro/ptah/issues/1235) registers 51
 places where `ptah-compat` and the pinned community binary v1.3.0 agree on the
-exit code and disagree on the bytes. Seven of them are closed here. Every row was
+exit code and disagree on the bytes. Nine of them are closed here. Every row was
 measured with each binary in its own directory, every exit code read from an
 unpiped invocation.
 
 | Finding | Command | Pinned binary | Ptah, before | Ptah, now |
 | --- | --- | --- | --- | --- |
 | 6.2 | `schema inspect --format '{{ json . }}'` over `a TEXT UNIQUE, b TEXT UNIQUE` plus `CREATE UNIQUE INDEX ux_t_c` | 3 indexes | 5 — each implicit autoindex listed twice | 3 |
+| 9.1–9.2 | `migrate validate --dir migrations`; the same on `migrate status` | The scheme hint ends with one ASCII space and a line feed (`20 0a`, 70 bytes) | The hint ended directly with a line feed (`3f 0a`, 69 bytes) | byte-identical |
 | 9.3 | `migrate apply` over an already-applied directory | `No migration files to execute\n` | the same plus a period | byte-identical |
 | 9.4 | `schema apply --auto-approve` against a synced database | `Schema is synced, no changes to be made\n` | the same plus a period | byte-identical |
 | 9.5 | `migrate validate` with `?format=bogus`; the same under `--dir-format bogus` and on `migrate hash` | Exit 1, empty stdout, stderr `Error: unknown dir format "bogus"\n` (34 bytes) | Exit 1 with a contextual semantic diagnostic that differed by verb and spelling | byte-identical on all four rows |
@@ -1342,6 +1343,13 @@ stderr.
 filesystem or database work. The invalid value stays verbatim, and the semantic
 resolver retains its detailed error in the unwrap chain. Native `ptah` and
 other Atlas-compatible errors keep their existing diagnostics.
+
+**9.1–9.2 change only the compatibility diagnostic.** The final two stderr
+bytes are `20 0a`: one ASCII space followed by the line feed. Hex makes the
+space visible without relying on Markdown trailing whitespace. The shared
+helper gives the same bytes to `hash`, `validate`, `status`, `lint`, `new` and
+`diff`; named schemes, refusal ordering, no-write behavior and native `ptah`
+commands keep their prior behavior.
 
 **9.13 changes only the compatibility error adapter.** Measured 2026-08-11
 with the file body `schema "main" {\n`, both binaries exited 1, wrote no stdout,

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -1517,20 +1517,23 @@ is rewritten, on a directory the gate refuses. A `--dir` naming a directory that
 does not exist yet is not a checksum error on either tool — both verbs create
 it, which is how the first migration of a project gets written.
 
-Because they create it, those same two verbs require `--dir` to name a scheme,
-which is what Atlas requires on every verb:
+The six shared scheme-hint consumers — `hash`, `validate`, `status`, `lint`,
+`new`, and `diff` — require their command-line `--dir` to name a scheme:
 
 ```bash
 ptah-compat migrate new add_users --dir migrations
 # Error: missing scheme for dir url. Did you mean "file://migrations"?
 ```
 
-Nothing is created. Ptah still accepts a bare path on the verbs that only read a
-directory, and on a directory named by `atlas.hcl` `migration.dir` — both remain
-looser than Atlas and are tracked in
-[#1186](https://github.com/stokaro/ptah/issues/1186). The requirement is a
-`PTAH_DIR` rule as much as a flag rule; `PTAH_MIGRATIONS_DIR`, which is the
-native `--migrations-dir` under its environment name, still takes a plain path.
+The stderr line ends with the bytes `20 0a`: one ASCII space followed by the
+line feed. Nothing is created. The requirement applies to `PTAH_DIR` as well as
+the flag.
+
+A directory named by `atlas.hcl` `migration.dir` still accepts a bare path and
+remains looser than Atlas, as tracked in
+[#1186](https://github.com/stokaro/ptah/issues/1186). `PTAH_MIGRATIONS_DIR`,
+which is the native `--migrations-dir` under its environment name, still takes a
+plain path.
 
 ### A migration name cannot contain a path separator
 

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -346,11 +346,12 @@ as it is on the other seven verbs that accept a `--dir` query — `apply`,
 `checkpoint`, `down`, `edit`, `rebase`, `rm` or `test`: those refuse a `--dir`
 query outright, as the shared rules above record.
 
-`--dir` must name a scheme on this verb and on `migrate diff`, as it must on
-every Atlas verb: `--dir migrations` is refused with
+`--dir` must name a scheme on `migrate new`, `diff`, `hash`, `validate`,
+`status`, and `lint`: `--dir migrations` is refused on those consumers with
 `missing scheme for dir url. Did you mean "file://migrations"?` and creates
-nothing. The same applies to its `PTAH_DIR` twin. The verbs that only read a
-directory still accept a bare path, as does `atlas.hcl` `migration.dir`
+nothing. The stderr line ends with the bytes `20 0a`: one ASCII space followed
+by the line feed. The same applies to its `PTAH_DIR` twin. A directory selected
+by `atlas.hcl` `migration.dir` still accepts a bare path
 ([#1186](https://github.com/stokaro/ptah/issues/1186)).
 
 Omitted entirely, `--dir` defaults to `file://migrations`, so

--- a/integration/migrate_dir_scheme_e2e_test.go
+++ b/integration/migrate_dir_scheme_e2e_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestMigrateDirectorySchemeDiagnosticsE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	repoRoot := e2eRepoRoot(t)
+	compatBinary := filepath.Join(t.TempDir(), "ptah-compat")
+	nativeBinary := filepath.Join(t.TempDir(), "ptah")
+	buildPtahCompat(c, ctx, repoRoot, compatBinary)
+	buildPtah(c, ctx, repoRoot, nativeBinary)
+
+	compatCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "compat hash",
+			args: []string{"migrate", "hash", "--dir", "migrations"},
+		},
+		{
+			name: "compat validate",
+			args: []string{"migrate", "validate", "--dir", "migrations"},
+		},
+		{
+			name: "compat status checks the directory before the database URL",
+			args: []string{"migrate", "status", "--dir", "migrations"},
+		},
+		{
+			name: "compat lint",
+			args: []string{
+				"migrate", "lint",
+				"--dir", "migrations",
+				"--dev-url", "sqlite://file?mode=memory&_fk=1",
+				"--latest", "1",
+			},
+		},
+		{
+			name: "compat new",
+			args: []string{"migrate", "new", "demo", "--dir", "migrations"},
+		},
+		{
+			name: "compat diff",
+			args: []string{"migrate", "diff", "demo", "--dir", "migrations"},
+		},
+	}
+
+	for _, test := range compatCases {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+
+			stdout, stderr, err := runCLIProcess(ctx, root, compatBinary, test.args...)
+
+			const wantStderr = "Error: missing scheme for dir url. Did you mean \"file://migrations\"? \n"
+			c.Assert(exitStatusOf(c, err), qt.Equals, 1)
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, wantStderr)
+			c.Assert(stderr, qt.HasLen, 70)
+			c.Assert(readDirectoryNames(c, root), qt.HasLen, 0)
+		})
+	}
+
+	c.Run("native validate and status retain bare paths", func(c *qt.C) {
+		root := c.TempDir()
+		migrationDir := filepath.Join(root, "migrations")
+		c.Assert(os.MkdirAll(migrationDir, 0o755), qt.IsNil)
+		c.Assert(os.WriteFile(
+			filepath.Join(migrationDir, "20240101000000_init.sql"),
+			[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+			0o600,
+		), qt.IsNil)
+
+		stdout, stderr, err := runCLIProcess(ctx, root, compatBinary,
+			"migrate", "hash", "--dir", "file://"+migrationDir,
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout, qt.Equals, "")
+		c.Assert(stderr, qt.Equals, "")
+
+		_, stderr, err = runCLIProcess(ctx, root, nativeBinary,
+			"migrations", "validate", "--dir", migrationDir, "--dir-format", "atlas",
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(stderr, qt.Equals, "")
+
+		_, stderr, err = runCLIProcess(ctx, root, nativeBinary,
+			"migrations", "status",
+			"--migrations-dir", migrationDir,
+			"--dir-format", "atlas",
+			"--db-url", "sqlite://"+filepath.Join(root, "status.db"),
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(stderr, qt.Equals, "")
+	})
+}
+
+func readDirectoryNames(c *qt.C, path string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(path)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}

--- a/internal/atlasargs/args.go
+++ b/internal/atlasargs/args.go
@@ -243,15 +243,13 @@ func LocalDirValue(value string) (string, error) {
 //	Error: missing scheme for dir url. Did you mean "file://mig"?
 //
 // and create nothing. [ParseLocalDir] deliberately keeps accepting the bare
-// path — the read verbs still take one and closing that half is
-// stokaro/ptah#1186 — so this is a separate call the writing verbs make before
-// they can create a directory the operator did not point at.
+// path, so compatibility commands own where the Atlas-facing scheme gate runs
+// while native and local-path adapters keep their own input contract.
 //
-// The one measured byte this does not reproduce is a trailing space: that
-// binary prints `…"file://mig"? \n`, where its own `checksum file not found`
-// on the same verb prints no trailing space. The space is a slip in one format
-// string rather than a convention, and reproducing it would be reproducing a
-// defect.
+// The format intentionally ends with one ASCII space. That makes the final two
+// stderr bytes `20 0a` after the compatibility command appends its line feed,
+// matching the pinned binary byte for byte. Native Ptah commands do not call
+// this compatibility-only diagnostic.
 //
 // The suggestion carries the URL's path component only. Measured on the same
 // day, `--dir 'sub/dir?format=goose&x=1'` and `--dir 'sub/dir#frag'` both
@@ -268,7 +266,7 @@ func RequireDirScheme(value string) error {
 	}
 	path, _, _ := strings.Cut(value, "?")
 	path, _, _ = strings.Cut(path, "#")
-	return fmt.Errorf("missing scheme for dir url. Did you mean %q?", "file://"+path)
+	return fmt.Errorf("missing scheme for dir url. Did you mean %q? ", "file://"+path)
 }
 
 // ParseLocalDir parses a local Atlas file:// migration directory URL while

--- a/internal/atlasargs/args_test.go
+++ b/internal/atlasargs/args_test.go
@@ -99,6 +99,62 @@ func TestLocalDirValue_FailurePathRejectsQuery(t *testing.T) {
 	c.Assert(got, qt.Equals, "")
 }
 
+func TestRequireDirScheme_HappyPathLeavesNamedSchemesToTheParser(t *testing.T) {
+	c := qt.New(t)
+	values := []string{
+		"file://migrations",
+		"atlas://repo/migrations",
+		"oci://registry.example/repository:tag",
+	}
+
+	for _, value := range values {
+		c.Run(value, func(c *qt.C) {
+			err := atlasargs.RequireDirScheme(value)
+
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestRequireDirScheme_FailurePathMatchesAtlasBytes(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "bare path",
+			value: "migrations",
+			want:  `missing scheme for dir url. Did you mean "file://migrations"? `,
+		},
+		{
+			name:  "query is omitted from the suggestion",
+			value: "migrations?format=goose",
+			want:  `missing scheme for dir url. Did you mean "file://migrations"? `,
+		},
+		{
+			name:  "fragment is omitted from the suggestion",
+			value: "migrations#frag",
+			want:  `missing scheme for dir url. Did you mean "file://migrations"? `,
+		},
+		{
+			name:  "empty value",
+			value: "",
+			want:  `missing scheme for dir url. Did you mean "file://"? `,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			err := atlasargs.RequireDirScheme(tt.value)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, tt.want)
+		})
+	}
+}
+
 func TestMap_HappyPathMigrateDownNativeFlags(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary

- match Atlas CE v1.3.0's missing-directory-scheme diagnostic byte-for-byte, including its final ASCII space before the newline
- pin the centralized helper and all six compatibility consumers: hash, validate, status, lint, new, and diff
- correct stale source and reader documentation that claimed read-only compatibility verbs still accepted bare command-line paths
- keep real-binary, filesystem, no-write, and native-path coverage in the tagged black-box integration contour

## Classification

COMPATIBILITY ADAPTER

This is an Atlas-compatible output-shape contract. It changes no semantic capability, migration behavior, or native Ptah surface.

## Contract and retained capabilities

For a bare command-line `--dir migrations`, all six compatibility consumers exit 1 with empty stdout, create no artifacts, and write exactly 70 stderr bytes. The final two bytes are `20 0a`: one ASCII space followed by the newline.

The centralized gate still lets named schemes proceed to the owning parser. Native `ptah` validate/status commands and `PTAH_MIGRATIONS_DIR` retain bare filesystem paths. Other compatibility commands that do not own this diagnostic also retain their existing bare-path behavior. The compatibility surface additionally retains the broader `atlas.hcl` `migration.dir` bare-path behavior tracked in #1186; this PR does not narrow either best-effort capability to CE behavior.

Refusal ordering is unchanged. In particular, `migrate status --dir migrations` reports the scheme diagnostic before a missing database URL.

## Test contour

Pure `RequireDirScheme` parsing and byte-shape tests remain beside `internal/atlasargs`. Real `ptah-compat`/`ptah` binaries, filesystem fingerprints, SQLite status control, all six compatibility consumers, and native bare-path controls run from `integration/migrate_dir_scheme_e2e_test.go` under `//go:build integration` and `package integration_test`.

## Documentation impact

Updated the compatibility/status source `docs/conformance.md`, the Atlas migration workflow page, and the Atlas command reference. Source comments in the command adapter and diff path now scope the command-line scheme requirement to the six consumers that enforce it. No page was added, moved, split, merged, or retired, so the content inventory is unchanged.

## Final base and head

- base: `72831bcf647d4bc979c18bcb2699a9cdfbe28128`
- head: `19dbaefc84ce703cc06721674f645a03e05d191b`
- remote commit: exactly one commit above the base, with ten changed files and no unrelated delta

## Verification on the final tree

- `go test -race ./internal/atlasargs ./cmd/atlas -count=1`
- `go test -race -tags integration ./integration -run '^TestMigrateDirectorySchemeDiagnosticsE2E$' -count=1`
- `go test -tags integration ./integration/... -run '^$' -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go tool qtlint ./...`
- `./scripts/check-test-style.sh`
- `golangci-lint run --fix ./...` and `golangci-lint run ./...` (`0 issues`)
- all three public API guards
- complete docs links, redirects, page-health, exit-code, style, versions, build, responsive, and audit suite
- final stale-claim sweep across source and documentation

This closes only issue #1235 cells 9.1-9.2; the issue remains open.