### PR TITLE
fix(import): require exact Goose no-transaction marker

### DIFF
--- a/docs/migrations-import.md
+++ b/docs/migrations-import.md
@@ -32,7 +32,7 @@ The source tool is auto-detected; pass `--from` to be explicit or to disambiguat
 | Tool | Status | Notes |
 | --- | --- | --- |
 | golang-migrate | **Supported** | `<version>_<name>.up.sql` / `.down.sql`; integer or timestamp versions. |
-| Goose | **Supported** | Single-file `<version>_<name>.sql` split by `-- +goose Up` / `-- +goose Down` (SQL only; `StatementBegin/End` directives are stripped, `NO TRANSACTION` becomes `-- +ptah no_transaction` on both output directions, and Go-based migrations are rejected). |
+| Goose | **Supported** | Single-file `<version>_<name>.sql` split by `-- +goose Up` / `-- +goose Down` (SQL only; `StatementBegin/End` directives are stripped, the exact line `-- +goose NO TRANSACTION` becomes `-- +ptah no_transaction` on both output directions, and Go-based migrations are rejected). |
 | Flyway | **Supported** | Versioned `V<version>__<desc>.sql` (dotted versions such as `V2.1` are supported), undo `U<version>__<desc>.sql` (paired to its versioned migration by version and imported as the down), and repeatable `R__<desc>.sql` (imported as a one-time migration ordered after the versioned ones). |
 | Liquibase | **Supported** (formatted SQL) | Formatted-SQL changelogs (a `.sql` file beginning with `--liquibase formatted sql`): each `--changeset <author>:<id>` becomes a migration, and its `--rollback` lines become the down. XML, YAML, and JSON changelogs are detected and rejected with a message — they are a follow-up. |
 

--- a/docs/site/src/content/docs/versioned/import.md
+++ b/docs/site/src/content/docs/versioned/import.md
@@ -93,7 +93,7 @@ assert it explicitly (`golang-migrate`, `goose`, `flyway`, `liquibase`,
 | Tool | Notes |
 | --- | --- |
 | golang-migrate | `NNN_name.up.sql` / `.down.sql` pairs. |
-| Goose | Annotated single files (`-- +goose Up` / `-- +goose Down`); a whole-file `-- +goose NO TRANSACTION` becomes `-- +ptah no_transaction` on both imported directions. |
+| Goose | Annotated single files (`-- +goose Up` / `-- +goose Down`); the exact whole-file line `-- +goose NO TRANSACTION` becomes `-- +ptah no_transaction` on both imported directions. |
 | Flyway | Including dotted versions, undo `U__` scripts, and repeatable `R__` scripts. |
 | Liquibase | Formatted-SQL changelogs (`--changeset` / `--rollback`); XML, YAML, and JSON changelogs are rejected with a message. |
 | dbmate | Annotated single files (`-- migrate:up` / `-- migrate:down`); directive options such as `transaction:false` are dropped from the SQL. |

--- a/migration/importer/goose.go
+++ b/migration/importer/goose.go
@@ -173,15 +173,26 @@ const (
 	gooseStatementEndMarker   = "statement_end"
 	gooseNoTxMarker           = "notx"
 	gooseOtherMarker          = "other"
+	gooseNoTxDirective        = "-- +goose NO TRANSACTION"
 )
 
 // gooseMarker classifies a line as a goose annotation: the up/down section
 // markers, the StatementBegin/End and NO TRANSACTION directives (not SQL), or ""
 // for an ordinary SQL line.
 func gooseMarker(line string) string {
+	if strings.TrimSuffix(line, "\r") == gooseNoTxDirective {
+		return gooseNoTxMarker
+	}
+
 	trimmed := strings.TrimSpace(line)
 	directive, ok := strings.CutPrefix(trimmed, "-- +goose")
 	if !ok {
+		return ""
+	}
+	// Goose recognizes NO TRANSACTION only in the exact spelling above. Keep
+	// whitespace- or case-normalized lookalikes in the SQL body instead of
+	// silently changing the migration's transaction mode.
+	if strings.EqualFold(strings.Join(strings.Fields(directive), " "), "no transaction") {
 		return ""
 	}
 	switch strings.ToLower(strings.TrimSpace(directive)) {
@@ -193,8 +204,6 @@ func gooseMarker(line string) string {
 		return gooseStatementBeginMarker
 	case "statementend":
 		return gooseStatementEndMarker
-	case "no transaction":
-		return gooseNoTxMarker
 	default:
 		return gooseOtherMarker
 	}

--- a/migration/importer/goose_test.go
+++ b/migration/importer/goose_test.go
@@ -116,7 +116,7 @@ func TestGooseParseStatementBlockConsumesNoTransaction(t *testing.T) {
 -- +goose StatementBegin
 CREATE FUNCTION f() RETURNS int AS $$
 BEGIN
-  -- +goose NO TRANSACTION
+-- +goose NO TRANSACTION
   -- +goose NO TRANSACTION extra
   -- +goose Down
   RETURN 1;
@@ -153,6 +153,67 @@ $$ LANGUAGE plpgsql;`
 	down, err := os.ReadFile(filepath.Join(out, "0000000001_fn.down.sql"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(down), qt.Equals, "-- +ptah no_transaction\nDROP FUNCTION f();")
+}
+
+func TestGooseParseNoTransactionRequiresExactMarker(t *testing.T) {
+	tests := []struct {
+		name          string
+		marker        string
+		noTransaction bool
+		wantSQL       string
+	}{
+		{
+			name:          "exact",
+			marker:        "-- +goose NO TRANSACTION",
+			noTransaction: true,
+			wantSQL:       "SELECT 0;\nSELECT 1;",
+		},
+		{
+			name:          "exact CRLF line",
+			marker:        "-- +goose NO TRANSACTION\r",
+			noTransaction: true,
+			wantSQL:       "SELECT 0;\nSELECT 1;",
+		},
+		{
+			name:    "lowercase",
+			marker:  "-- +goose no transaction",
+			wantSQL: "SELECT 0;\n-- +goose no transaction\nSELECT 1;",
+		},
+		{
+			name:    "space after prefix",
+			marker:  "-- +goose  NO TRANSACTION",
+			wantSQL: "SELECT 0;\n-- +goose  NO TRANSACTION\nSELECT 1;",
+		},
+		{
+			name:    "space between words",
+			marker:  "-- +goose NO  TRANSACTION",
+			wantSQL: "SELECT 0;\n-- +goose NO  TRANSACTION\nSELECT 1;",
+		},
+		{
+			name:    "leading space",
+			marker:  " -- +goose NO TRANSACTION",
+			wantSQL: "SELECT 0;\n -- +goose NO TRANSACTION\nSELECT 1;",
+		},
+		{
+			name:    "trailing space",
+			marker:  "-- +goose NO TRANSACTION ",
+			wantSQL: "SELECT 0;\n-- +goose NO TRANSACTION \nSELECT 1;",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			parser, err := importer.ParserByName("goose")
+			c.Assert(err, qt.IsNil)
+
+			sql := "-- +goose Up\nSELECT 0;\n" + tt.marker + "\nSELECT 1;\n"
+			migrations, err := parser.Parse(fstest.MapFS{"1_marker.sql": {Data: []byte(sql)}})
+			c.Assert(err, qt.IsNil)
+			c.Assert(migrations, qt.HasLen, 1)
+			c.Assert(migrations[0].NoTransaction, qt.Equals, tt.noTransaction)
+			c.Assert(migrations[0].UpSQL, qt.Equals, tt.wantSQL)
+		})
+	}
 }
 
 func TestGooseParseErrors(t *testing.T) {


### PR DESCRIPTION
Follow-up to the actionable Codex review finding on #1402.

GENERAL CAPABILITY

## Summary

- recognize `-- +goose NO TRANSACTION` as whole-migration metadata only when the directive line is exact
- keep case- and whitespace-normalized lookalikes in the imported SQL instead of silently disabling transaction execution
- retain exact directive recognition for CRLF source files and inside `StatementBegin` blocks
- document the exact-line contract on both native migration-import pages

The semantic implementation remains in `migration/importer`, the shared Ptah migration-import package used by the native `ptah migrations import` surface. This is not Atlas-specific CLI machinery and adds no compatibility-only API.

## Verification

- `go test -race ./migration/importer ./cmd/migrationsimport -count=1`
- `go tool qtlint ./migration/importer`
- `go vet ./migration/importer`
- `go tool teststyle -baseline .teststyle-baseline.json -root .`
- `golangci-lint run ./migration/importer`
- complete documentation checks: links, redirects, core-doc links, page health, exit codes, style self-test/style, versions self-test, site build, responsive self-test/check, and `npm audit --audit-level=low`

## Documentation impact

Checked the native migration-import reference and workflow documentation plus all Goose `NO TRANSACTION` mentions. Updated:

- `docs/migrations-import.md`
- `docs/site/src/content/docs/versioned/import.md`

No page was added, moved, split, merged, or retired, so `docs/site/CONTENT_INVENTORY.md` does not change.